### PR TITLE
Adds [%tw syntax for use with tailwind-ppx

### DIFF
--- a/src/lsp/util/getClassNameAtPosition.ts
+++ b/src/lsp/util/getClassNameAtPosition.ts
@@ -12,7 +12,7 @@ export function getClassNameAtPosition(
   }
   const text1: string = document.getText(range1)
 
-  if (!/\bclass(Name)?=['"][^'"]*$/.test(text1)) return null
+  if (!/\bclass(Name)?=(?:\[%tw )?['"][^'"]*$/.test(text1)) return null
 
   const range2: Range = {
     start: { line: Math.max(position.line - 5, 0), character: 0 },
@@ -21,7 +21,7 @@ export function getClassNameAtPosition(
   const text2: string = document.getText(range2)
 
   let str: string = text1 + text2.substr(text1.length).match(/^([^"' ]*)/)[0]
-  let matches: RegExpMatchArray = str.match(/\bclass(Name)?=["']([^"']+)$/)
+  let matches: RegExpMatchArray = str.match(/\bclass(Name)?=(?:\[%tw )?["']([^"']+)$/)
 
   if (!matches) return null
 


### PR DESCRIPTION
Adds the [%tw syntax for use with [tailwind-ppx](https://github.com/dylanirlbeck/tailwind-ppx).

Although I added the regex (and it's apparently right, based on regex tests) I'm not able to test the extension locally, as it seems that my changes don't have any effect.

I tried using `npm run package` and installing the VSIX file, does anyone have any idea on what could be happening or can build the extension and test it?