### PR TITLE
Add hyperscript support, enable 'key: value' style js code

### DIFF
--- a/src/lsp/providers/completionProvider.ts
+++ b/src/lsp/providers/completionProvider.ts
@@ -130,7 +130,7 @@ function provideClassAttributeCompletions(
     end: position,
   })
 
-  const match = findLast(/(?:\b|:)class(?:Name)?=['"`{]/gi, str)
+  const match = findLast(/(?:\b|:)class(?:Name)?(=|(: ?))['"`{]/gi, str)
 
   if (match === null) {
     return null

--- a/src/lsp/util/find.ts
+++ b/src/lsp/util/find.ts
@@ -135,7 +135,7 @@ export function findClassListsInHtmlRange(
   range?: Range
 ): DocumentClassList[] {
   const text = doc.getText(range)
-  const matches = findAll(/(?:\b|:)class(?:Name)?=['"`{]/g, text)
+  const matches = findAll(/(?:\b|:)class(?:Name)?(=|(: ?))['"`{]/g, text)
   const result: DocumentClassList[] = []
 
   matches.forEach((match) => {


### PR DESCRIPTION
This is a simple regex update to enable autocomplete support for hyperscript.  Previously only `class="foo"` or `className="foo"`, would activate the autocomplete, with this PR `class:"foo"`, `class: "foo"`, `className:"foo"` and `className: "foo"` also activate autocomplete.