### PR TITLE
Change class regex to match elm source

### DIFF
--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -5,6 +5,7 @@ export const DEFAULT_LANGUAGES = [
   'django-html',
   'edge',
   'ejs',
+  'elm',
   'erb',
   'gohtml',
   'GoHTML',

--- a/src/lsp/providers/completionProvider.ts
+++ b/src/lsp/providers/completionProvider.ts
@@ -130,7 +130,7 @@ function provideClassAttributeCompletions(
     end: position,
   })
 
-  const match = findLast(/(?:\b|:)class(?:Name)?=['"`{]/gi, str)
+  const match = findLast(/(?:\b|:)class(?:Name)?(=|\s+)['"`{]/gi, str)
 
   if (match === null) {
     return null

--- a/src/lsp/util/find.ts
+++ b/src/lsp/util/find.ts
@@ -135,7 +135,7 @@ export function findClassListsInHtmlRange(
   range?: Range
 ): DocumentClassList[] {
   const text = doc.getText(range)
-  const matches = findAll(/(?:\b|:)class(?:Name)?=['"`{]/g, text)
+  const matches = findAll(/(?:\b|:)class(?:Name)?(=|\s+)['"`{]/g, text)
   const result: DocumentClassList[] = []
 
   matches.forEach((match) => {

--- a/src/lsp/util/html.ts
+++ b/src/lsp/util/html.ts
@@ -7,6 +7,7 @@ export const HTML_LANGUAGES = [
   'django-html',
   'edge',
   'ejs',
+  'elm',
   'erb',
   'gohtml',
   'GoHTML',


### PR DESCRIPTION
Just a small modification to the regex for use with elm source `class` method.