### PR TITLE
add '-' to triggerCharacters

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -92,6 +92,8 @@ const TRIGGER_CHARACTERS = [
   '!',
   // JIT opacity modifiers
   '/',
+  // class name including '-'
+  '-',
 ] as const
 
 const colorNames = Object.keys(namedColors)


### PR DESCRIPTION
Hi, thx for the great project! I hope we can add `-` to the completion trigger characters, it seems not a problem in vscode, but when I use it in [emacs with lsp-mode](https://github.com/merrickluo/lsp-tailwindcss), it can't trigger completion when type `-`, seems like it's been treated as a word separator. I can workaround by adding that in elisp code, but I'm hoping we can just add it to the server if there is no big trouble.