### PR TITLE
Make output chanel name more human-friendly

### DIFF
--- a/packages/tailwindcss-intellisense/src/extension.ts
+++ b/packages/tailwindcss-intellisense/src/extension.ts
@@ -79,7 +79,7 @@ function getUserLanguages(folder?: WorkspaceFolder): Record<string, string> {
 
 export function activate(context: ExtensionContext) {
   let module = context.asAbsolutePath(path.join('dist', 'server', 'index.js'))
-  let outputChannel: OutputChannel = Window.createOutputChannel(CLIENT_ID)
+  let outputChannel: OutputChannel = Window.createOutputChannel(CLIENT_NAME)
 
   // TODO: check if the actual language MAPPING changed
   // not just the language IDs


### PR DESCRIPTION
According to the documentation, the channel name is: "Human-readable string which will be used to represent the channel in the UI". So it shouldn't break anything.

Change: `tailwindcss-intellisense` -> `Tailwind CSS IntelliSense`

![Screen Shot 2021-02-09 at 14 17 11](https://user-images.githubusercontent.com/6411116/107369659-566bf180-6ae2-11eb-9b55-6de8c8bea5d8.png)

Links: 
[VS Code API Documentation](https://code.visualstudio.com/api/references/vscode-api#window) / FUNCTIONS / createOutputChannel