### PR TITLE
Fix build due to invalid default `Settings`

### DIFF
--- a/packages/tailwindcss-intellisense/src/lsp/server.ts
+++ b/packages/tailwindcss-intellisense/src/lsp/server.ts
@@ -56,6 +56,7 @@ const defaultSettings: Settings = {
   includeLanguages: {},
   experimental: {
     classRegex: [],
+    showPixelValues: false,
   },
   showPixelEquivalents: true,
   rootFontSize: 16,

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -45,6 +45,7 @@ export type Settings = {
   }
   experimental: {
     classRegex: string[]
+    showPixelValues: boolean
   }
 }
 


### PR DESCRIPTION
As mentioned in #274, a file was preventing an errror-less build because an experimental setting was missing. I supplied a default value for the field. 

However, upon fixing it I found that the underlying type `Settings` had been compiled with some previous version of the type that failed to includes the following properties:

1. `showPixelEquivalents`
2. `rootFontSize`

The file that declares the type, `state.ts`, was already updated to hold those properties, so I re-built the language server. This fixed the two fields above, but the experimental setting was gone this time. To fix the final error, I added that field to the original type definition in `state.ts`.

Likely to completely fix this, you would need to re-release the language server and update the extension's version.