### PR TITLE
fix crash on not passing "userLanguages" option

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -156,7 +156,9 @@ async function createProjectService(
     editor: {
       connection,
       globalSettings: params.initializationOptions.configuration as Settings,
-      userLanguages: params.initializationOptions.userLanguages,
+      userLanguages: params.initializationOptions.userLanguages
+        ? params.initializationOptions.userLanguages
+        : {},
       // TODO
       capabilities: {
         configuration: true,


### PR DESCRIPTION
Since the server can be used by various clients and there is no
guarantee that the "userLanguages" are provided, handle that
case gracefully and don't crash.