### PR TITLE
Avoid `invalidConfigPath` for function values

### DIFF
--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidConfigPathDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidConfigPathDiagnostics.ts
@@ -90,10 +90,11 @@ function validateConfigPath(
       typeof value === 'number' ||
       value instanceof String ||
       value instanceof Number ||
-      Array.isArray(value)
+      Array.isArray(value) ||
+      typeof value === 'function'
     )
   ) {
-    let reason = `'${pathToString(path)}' was found but does not resolve to a string.`
+    let reason = `'${pathToString(path)}' was found but does not resolve to a string, number, array or function.`
 
     if (isObject(value)) {
       let validKeys = Object.keys(value).filter(


### PR DESCRIPTION
Pass `validateConfigPath` if a type of value equals to `function`. The purpose of this PR is to avoid unwanted warnings when we define theme values as functions in tailwind.config.js, which, for example, are required to define theme colors with opacity enabled. https://github.com/tailwindlabs/tailwindcss/discussions/2206#discussioncomment-60081