### PR TITLE
feature: add showColorEquivalents

### DIFF
--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -1157,7 +1157,7 @@ function stringifyDecls(
           let hex = ''
           const color = showColorEquivalents ? getColorsInString(value)[0] : undefined
           if(color instanceof TinyColor) {
-            hex = color.toString() || ''
+            hex = color.toString('hex') || ''
           }
           return `${prop}: ${value}${px ? `/* ${px} */` : ''}${hex ? `/* ${hex} */` : ''};`
         })

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -1156,8 +1156,8 @@ function stringifyDecls(
           const px = showPixelEquivalents ? remToPx(value, rootFontSize) : undefined
           let hex = ''
           const color = showColorEquivalents ? getColorsInString(value)[0] : undefined
-          if(color instanceof TinyColor) {
-            hex = color.toString('hex') || ''
+          if(color) {
+            hex = culori.formatHex(color) || ''
           }
           return `${prop}: ${value}${px ? `/* ${px} */` : ''}${hex ? `/* ${hex} */` : ''};`
         })

--- a/packages/tailwindcss-language-service/src/hoverProvider.ts
+++ b/packages/tailwindcss-language-service/src/hoverProvider.ts
@@ -111,6 +111,7 @@ async function provideClassNameHover(
     {
       tabSize: dlv(settings, 'editor.tabSize', 2),
       showPixelEquivalents: dlv(settings, 'tailwindCSS.showPixelEquivalents', true),
+      showColorEquivalents: dlv(settings, 'tailwindCSS.showColorEquivalents', true),
       rootFontSize: dlv(settings, 'tailwindCSS.rootFontSize', 16),
     }
   )

--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -48,7 +48,7 @@ const colorRegex = new RegExp(
   'gi'
 )
 
-function getColorsInString(str: string): (culori.Color | KeywordColor)[] {
+export function getColorsInString(str: string): (culori.Color | KeywordColor)[] {
   if (/(?:box|drop)-shadow/.test(str)) return []
 
   return Array.from(str.matchAll(colorRegex), (match) => {

--- a/packages/tailwindcss-language-service/src/util/jit.ts
+++ b/packages/tailwindcss-language-service/src/util/jit.ts
@@ -55,7 +55,7 @@ export async function stringifyRoot(state: State, root: Root, uri?: string): Pro
     clone.walkDecls((decl) => {
       const color = getColorsInString(decl.value)[0]
       if(color && color instanceof TinyColor) {
-        decl.value = `${decl.value}/* ${color.toString()} */`
+        decl.value = `${decl.value}/* ${color.toString('hex')} */`
       }
     })
   }
@@ -85,7 +85,7 @@ export async function stringifyDecls(state: State, rule: Rule, uri?: string): Pr
     let hex = ''
     const color = showColorEquivalents ? getColorsInString(value)[0] : undefined
     if(color instanceof TinyColor) {
-      hex = color.toString() || ''
+      hex = color.toString('hex') || ''
     }
     result.push(`${prop}: ${value}${px ? `/* ${px} */` : ''}${hex ? `/* ${hex} */` : ''};`)
   })

--- a/packages/tailwindcss-language-service/src/util/jit.ts
+++ b/packages/tailwindcss-language-service/src/util/jit.ts
@@ -3,7 +3,7 @@ import type { Container, Document, Root, Rule } from 'postcss'
 import dlv from 'dlv'
 import { remToPx } from './remToPx'
 import {getColorsInString} from './color'
-import { TinyColor } from '@ctrl/tinycolor'
+import * as culori from 'culori'
 
 export function bigSign(bigIntValue) {
   // @ts-ignore
@@ -54,8 +54,8 @@ export async function stringifyRoot(state: State, root: Root, uri?: string): Pro
   if(showColorEquivalents) {
     clone.walkDecls((decl) => {
       const color = getColorsInString(decl.value)[0]
-      if(color && color instanceof TinyColor) {
-        decl.value = `${decl.value}/* ${color.toString('hex')} */`
+      if(color) {
+        decl.value = `${decl.value}/* ${culori.formatHex(color)} */`
       }
     })
   }
@@ -84,8 +84,8 @@ export async function stringifyDecls(state: State, rule: Rule, uri?: string): Pr
     let px = showPixelEquivalents ? remToPx(value, rootFontSize) : undefined
     let hex = ''
     const color = showColorEquivalents ? getColorsInString(value)[0] : undefined
-    if(color instanceof TinyColor) {
-      hex = color.toString('hex') || ''
+    if(color) {
+      hex = culori.formatHex(color) || ''
     }
     result.push(`${prop}: ${value}${px ? `/* ${px} */` : ''}${hex ? `/* ${hex} */` : ''};`)
   })

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -42,6 +42,7 @@ export type Settings = {
     classAttributes: string[]
     validate: boolean
     showPixelEquivalents: boolean
+    showColorEquivalents: boolean
     rootFontSize: number
     colorDecorators: boolean
     lint: {

--- a/packages/tailwindcss-language-service/src/util/stringify.ts
+++ b/packages/tailwindcss-language-service/src/util/stringify.ts
@@ -74,7 +74,7 @@ export function stringifyCss(
         let hex = ''
         if(color) {
           hex = color.map(c => {
-            return c instanceof TinyColor ? c.toString() : c
+            return c instanceof TinyColor ? c.toString('hex') : c
           }).join(' ')
         }
         return `${indentStr + indent}${curr}: ${val}${px ? `/* ${px} */` : ''}${hex ? `/* ${hex} */` : ''};`

--- a/packages/tailwindcss-language-service/src/util/stringify.ts
+++ b/packages/tailwindcss-language-service/src/util/stringify.ts
@@ -5,6 +5,8 @@ import { ensureArray } from './array'
 import { remToPx } from './remToPx'
 import stringifyObject from 'stringify-object'
 import isObject from './isObject'
+import { getColorsInString } from './color'
+import { TinyColor } from '@ctrl/tinycolor'
 
 export function stringifyConfigValue(x: any): string {
   if (isObject(x)) return `${Object.keys(x).length} values`
@@ -27,10 +29,12 @@ export function stringifyCss(
   {
     tabSize = 2,
     showPixelEquivalents = false,
+    showColorEquivalents = false,
     rootFontSize = 16,
   }: Partial<{
     tabSize: number
     showPixelEquivalents: boolean
+    showColorEquivalents: boolean
     rootFontSize: number
   }> = {}
 ): string {
@@ -66,7 +70,14 @@ export function stringifyCss(
     const propStr = ensureArray(obj[curr])
       .map((val) => {
         const px = showPixelEquivalents ? remToPx(val, rootFontSize) : undefined
-        return `${indentStr + indent}${curr}: ${val}${px ? `/* ${px} */` : ''};`
+        let color = showColorEquivalents ? getColorsInString(val) : undefined
+        let hex = ''
+        if(color) {
+          hex = color.map(c => {
+            return c instanceof TinyColor ? c.toString() : c
+          }).join(' ')
+        }
+        return `${indentStr + indent}${curr}: ${val}${px ? `/* ${px} */` : ''}${hex ? `/* ${hex} */` : ''};`
       })
       .join('\n')
     return `${acc}${i === 0 ? '' : '\n'}${propStr}`

--- a/packages/tailwindcss-language-service/src/util/stringify.ts
+++ b/packages/tailwindcss-language-service/src/util/stringify.ts
@@ -6,7 +6,7 @@ import { remToPx } from './remToPx'
 import stringifyObject from 'stringify-object'
 import isObject from './isObject'
 import { getColorsInString } from './color'
-import { TinyColor } from '@ctrl/tinycolor'
+import * as culori from 'culori'
 
 export function stringifyConfigValue(x: any): string {
   if (isObject(x)) return `${Object.keys(x).length} values`
@@ -74,7 +74,7 @@ export function stringifyCss(
         let hex = ''
         if(color) {
           hex = color.map(c => {
-            return c instanceof TinyColor ? c.toString('hex') : c
+            return c ? culori.formatHex(c) : c
           }).join(' ')
         }
         return `${indentStr + indent}${curr}: ${val}${px ? `/* ${px} */` : ''}${hex ? `/* ${hex} */` : ''};`

--- a/packages/vscode-tailwindcss/README.md
+++ b/packages/vscode-tailwindcss/README.md
@@ -80,6 +80,10 @@ Controls whether the editor should render inline color decorators for Tailwind C
 
 Show `px` equivalents for `rem` CSS values in completions and hovers. **Default: `true`**
 
+### `tailwindCSS.showColorEquivalents`
+
+Show hex format for color values in completions and hovers. **Default: `true`**
+
 ### `tailwindCSS.rootFontSize`
 
 Root font size in pixels. Used to convert `rem` CSS values to their `px` equivalents. See [`tailwindCSS.showPixelEquivalents`](#tailwindcssshowpixelequivalents). **Default: `16`**

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -229,6 +229,11 @@
           "default": true,
           "markdownDescription": "Show `px` equivalents for `rem` CSS values."
         },
+        "tailwindCSS.showColorEquivalents": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show hex format for color values."
+        },
         "tailwindCSS.rootFontSize": {
           "type": "number",
           "default": 16,


### PR DESCRIPTION
Hex format color is widely common use, but the tailwindcss-intellisense was just linting the rgba format color. The UI design often offers hex color, so it's tedious to give it a check to our color preset. With `showColorEquivalents` , the completion and hover tips will show the hex color as well. 