### PR TITLE
fix/regex-with-colon

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -174,7 +174,7 @@ async function findCustomClassLists(
 
 export function matchClassAttributes(text: string, attributes: string[]): RegExpMatchArray[] {
   const attrs = attributes.filter((x) => typeof x === 'string').flatMap((a) => [a, `\\[${a}\\]`])
-  const re = /(?:\s|:|\()(ATTRS)\s*=\s*['"`{]/
+  const re = /(?:\s|:|\()(ATTRS)\s*[=:]\s*['"`{]/
   return findAll(new RegExp(re.source.replace('ATTRS', attrs.join('|')), 'gi'), text)
 }
 


### PR DESCRIPTION
Allow IntelliSense to suggest classes with Styled Components by allowing the use of ":"-symbol. e.g. className: "ABC"

Fixes the issue #456