### PR TITLE
Prevent errors in not semicolon languages

### DIFF
--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -27,7 +27,7 @@ export function getInvalidTailwindDirectiveDiagnostics(
     ranges.push(...boundaries.css)
   }
 
-  const notSemicolonLanguages = ["sass"]
+  const notSemicolonLanguages = ["sass", "sugarss", "stylus"]
   let regex: RegExp
   if (
     notSemicolonLanguages.includes(doc.languageId) ||

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -27,11 +27,22 @@ export function getInvalidTailwindDirectiveDiagnostics(
     ranges.push(...boundaries.css)
   }
 
+  const notSemicolonLanguages = ["sass"]
+  let regex: RegExp
+  if (
+    notSemicolonLanguages.includes(doc.languageId) ||
+    (state.editor && notSemicolonLanguages.includes(state.editor.userLanguages[doc.languageId]))
+  ) {
+    regex = /(?:\s|^)@tailwind\s+(?<value>[^\n]+)/g
+  } else {
+    regex = /(?:\s|^)@tailwind\s+(?<value>[^;]+)/g
+  }
+  
   let hasVariantsDirective = state.jit && semver.gte(state.version, '2.1.99')
 
   ranges.forEach((range) => {
     let text = document.getText(range)
-    let matches = findAll(/(?:\s|^)@tailwind\s+(?<value>[^;]+)/g, text)
+    let matches = findAll(regex, text)
 
     let valid = [
       'utilities',

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -27,7 +27,7 @@ export function getInvalidTailwindDirectiveDiagnostics(
     ranges.push(...boundaries.css)
   }
 
-  const notSemicolonLanguages = ["sass", "sugarss", "stylus"]
+  let notSemicolonLanguages = ['sass', 'sugarss', 'stylus']
   let regex: RegExp
   if (
     notSemicolonLanguages.includes(doc.languageId) ||
@@ -37,7 +37,7 @@ export function getInvalidTailwindDirectiveDiagnostics(
   } else {
     regex = /(?:\s|^)@tailwind\s+(?<value>[^;]+)/g
   }
-  
+
   let hasVariantsDirective = state.jit && semver.gte(state.version, '2.1.99')
 
   ranges.forEach((range) => {

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -30,8 +30,9 @@ export function getInvalidTailwindDirectiveDiagnostics(
   let notSemicolonLanguages = ['sass', 'sugarss', 'stylus']
   let regex: RegExp
   if (
-    notSemicolonLanguages.includes(doc.languageId) ||
-    (state.editor && notSemicolonLanguages.includes(state.editor.userLanguages[doc.languageId]))
+    notSemicolonLanguages.includes(document.languageId) ||
+    (state.editor &&
+      notSemicolonLanguages.includes(state.editor.userLanguages[document.languageId]))
   ) {
     regex = /(?:\s|^)@tailwind\s+(?<value>[^\n]+)/g
   } else {


### PR DESCRIPTION
## Related

Resolves #460

## Comments

Prevent unwanted error messages related to the tailwind directive in languages that don't require semicolons at the end of lines.

Support added for:
- sass
- sugarss
- stylus

List taken from: https://github.com/tailwindlabs/tailwindcss-intellisense/blob/master/packages/tailwindcss-language-service/src/util/languages.ts#L34
