### PR TITLE
Allow autocompletion when using +=

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -174,7 +174,7 @@ async function findCustomClassLists(
 
 export function matchClassAttributes(text: string, attributes: string[]): RegExpMatchArray[] {
   const attrs = attributes.filter((x) => typeof x === 'string').flatMap((a) => [a, `\\[${a}\\]`])
-  const re = /(?:\s|:|\()(ATTRS)\s*=\s*['"`{]/
+  const re = /(?:\s|:|\()(ATTRS)\s*\+?=\s*['"`{]/
   return findAll(new RegExp(re.source.replace('ATTRS', attrs.join('|')), 'gi'), text)
 }
 


### PR DESCRIPTION
This allows to use the autocompletion when concatinating strings using
+=.

This allows to use autocompletion when e.g. writing conditional styling
this way:

```js
var className = "text-red-50";
if (shouldBeRounded){
    className += "rounded";
}
```
