### PR TITLE
Consider `.ts` file extensions on enhanced resolver

### DIFF
--- a/packages/tailwindcss-language-server/src/util/resolveFrom.ts
+++ b/packages/tailwindcss-language-server/src/util/resolveFrom.ts
@@ -5,9 +5,9 @@ function createResolver(options: Partial<ResolveOptions> = {}): Resolver {
   return ResolverFactory.createResolver({
     fileSystem: new CachedInputFileSystem(fs, 4000),
     useSyncFileSystemCalls: true,
-    // cachePredicate: () => false,
     conditionNames: ['node', 'require'],
-    ...options,
+    extensions: ['.js', '.ts', '.json', '.node'],
+    ...options
   })
 }
 


### PR DESCRIPTION
Hey, I've been using TypeScript to write my `tailwind.config.ts` file and ran into an issue when resolving imports. Using imports like `import { foo } from './foo'` where `foo` is some TypeScript file will cause an exception. Thrown here:

https://github.com/tailwindlabs/tailwindcss-intellisense/blob/85cf5edccbcf801052d3bedf68e09165796993de/packages/tailwindcss-language-server/src/util/resolveFrom.ts#L22

![tailwind-extension-error](https://user-images.githubusercontent.com/56021306/152141222-ae67f4fa-19f6-4559-890b-e35b77080499.png)

I have a small reproduction to play around with, which uses [esbuild-register](https://github.com/egoist/esbuild-register) to load the config file:
https://github.com/JensDll/tailwindcss-config-reproduction

The problem seems to be that [enhanced-resolve](https://github.com/webpack/enhanced-resolve) does not consider `.ts` file extensions per default. Additionally, TypeScript does not allow you to specify them explicitly at the moment. Related discussion: 
- https://github.com/microsoft/TypeScript/issues/37582

This pull request will add `.ts` to the enhanced resolver's `extensions` option. The reproduction should no longer throw an error.