### PR TITLE
Improve conflict diagnostics

### DIFF
--- a/packages/tailwindcss-language-service/src/diagnostics/getCssConflictDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getCssConflictDiagnostics.ts
@@ -20,7 +20,9 @@ export async function getCssConflictDiagnostics(
   const classLists = await findClassListsInDocument(state, document)
 
   classLists.forEach((classList) => {
-    const classNames = getClassNamesInClassList(classList)
+    const classNames = Array.isArray(classList)
+      ? classList.flatMap(getClassNamesInClassList)
+      : getClassNamesInClassList(classList)
 
     classNames.forEach((className, index) => {
       if (state.jit) {

--- a/packages/tailwindcss-language-service/src/diagnostics/getRecommendedVariantOrderDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getRecommendedVariantOrderDiagnostics.ts
@@ -22,7 +22,7 @@ export async function getRecommendedVariantOrderDiagnostics(
   let diagnostics: RecommendedVariantOrderDiagnostic[] = []
   const classLists = await findClassListsInDocument(state, document)
 
-  classLists.forEach((classList) => {
+  classLists.flat().forEach((classList) => {
     const classNames = getClassNamesInClassList(classList)
     classNames.forEach((className) => {
       let { rules } = jit.generateRules(state, [className.className])

--- a/packages/tailwindcss-language-service/src/documentColorProvider.ts
+++ b/packages/tailwindcss-language-service/src/documentColorProvider.ts
@@ -20,7 +20,7 @@ export async function getDocumentColors(
   if (settings.tailwindCSS.colorDecorators === false) return colors
 
   let classLists = await findClassListsInDocument(state, document)
-  classLists.forEach((classList) => {
+  classLists.flat().forEach((classList) => {
     let classNames = getClassNamesInClassList(classList)
     classNames.forEach((className) => {
       let color = getColor(state, className.className)


### PR DESCRIPTION
Fixes #434

This PR improves CSS conflict diagnostics, allowing it to catch conflicts that are separated by expressions, e.g.

```jsx
<div className={`uppercase ${something} lowercase`} />
```

```html
<div class="uppercase {{ something }} lowercase"></div>
```