### PR TITLE
Optimize language service build

### DIFF
--- a/packages/tailwindcss-language-service/.browserslistrc
+++ b/packages/tailwindcss-language-service/.browserslistrc
@@ -1,0 +1,4 @@
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Safari versions
+node 12


### PR DESCRIPTION
`tsdx` uses `.browserslistrc` to determine how to transpile the source code. By default it supports very old environments.

By specifying relatively modern targets, the bundle size has been reduced with ~40%. This also significantly increases performance and readability of the output, because babel’s regenerator runtime isn’t used anymore.

The output target can’t be set to something too new, because `tsdx` uses an older version of terser which isn’t compatible with all new syntax (e.g. optional chaining).

Before this PR:

```sh
$ du -sh dist/*.js
4.0K	dist/index.js
192K	dist/tailwindcss-language-service.cjs.development.js
80K	dist/tailwindcss-language-service.cjs.production.min.js
192K	dist/tailwindcss-language-service.esm.js
```

After this PR:

```sh
$ du -sh dist/*.js
4.0K	dist/index.js
116K	dist/tailwindcss-language-service.cjs.development.js
56K	dist/tailwindcss-language-service.cjs.production.min.js
116K	dist/tailwindcss-language-service.esm.js
```