### PR TITLE
Convert dlv require statements to imports

### DIFF
--- a/packages/tailwindcss-language-service/src/codeActions/provideInvalidApplyCodeActions.ts
+++ b/packages/tailwindcss-language-service/src/codeActions/provideInvalidApplyCodeActions.ts
@@ -7,7 +7,7 @@ import { getClassNameMeta } from '../util/getClassNameMeta'
 import { getClassNameParts } from '../util/getClassNameAtPosition'
 import { validateApply } from '../util/validateApply'
 import { isWithinRange } from '../util/isWithinRange'
-const dlv = require('dlv')
+import dlv from 'dlv'
 import type { Root, Source } from 'postcss'
 import { absoluteRange } from '../util/absoluteRange'
 import { removeRangesFromString } from '../util/removeRangesFromString'

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -9,7 +9,7 @@ import type {
   Position,
   CompletionContext,
 } from 'vscode-languageserver'
-const dlv = require('dlv')
+import dlv from 'dlv'
 import removeMeta from './util/removeMeta'
 import { getColor, getColorFromValue } from './util/color'
 import { isHtmlContext } from './util/html'

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidConfigPathDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidConfigPathDiagnostics.ts
@@ -9,7 +9,7 @@ import isObject from '../util/isObject'
 import { closest } from '../util/closest'
 import { absoluteRange } from '../util/absoluteRange'
 import { combinations } from '../util/combinations'
-const dlv = require('dlv')
+import dlv from 'dlv'
 
 function pathToString(path: string | string[]): string {
   if (typeof path === 'string') return path

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidScreenDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidScreenDiagnostics.ts
@@ -6,7 +6,7 @@ import { getLanguageBoundaries } from '../util/getLanguageBoundaries'
 import { findAll, indexToPosition } from '../util/find'
 import { closest } from '../util/closest'
 import { absoluteRange } from '../util/absoluteRange'
-const dlv = require('dlv')
+import dlv from 'dlv'
 
 export function getInvalidScreenDiagnostics(
   state: State,

--- a/packages/tailwindcss-language-service/src/hoverProvider.ts
+++ b/packages/tailwindcss-language-service/src/hoverProvider.ts
@@ -1,7 +1,7 @@
 import { State } from './util/state'
 import type { Hover, TextDocument, Position } from 'vscode-languageserver'
 import { stringifyCss, stringifyConfigValue } from './util/stringify'
-const dlv = require('dlv')
+import dlv from 'dlv'
 import { isCssContext } from './util/css'
 import { findClassNameAtPosition } from './util/find'
 import { validateApply } from './util/validateApply'

--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -1,4 +1,4 @@
-const dlv = require('dlv')
+import dlv from 'dlv'
 import { State } from './state'
 import removeMeta from './removeMeta'
 import { ensureArray, dedupe, flatten } from './array'

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -9,7 +9,7 @@ import { flatten } from './array'
 import { getClassAttributeLexer, getComputedClassAttributeLexer } from './lexers'
 import { getLanguageBoundaries } from './getLanguageBoundaries'
 import { resolveRange } from './resolveRange'
-const dlv = require('dlv')
+import dlv from 'dlv'
 import { createMultiRegexp } from './createMultiRegexp'
 
 export function findAll(re: RegExp, str: string): RegExpMatchArray[] {

--- a/packages/tailwindcss-language-service/src/util/flagEnabled.ts
+++ b/packages/tailwindcss-language-service/src/util/flagEnabled.ts
@@ -1,5 +1,5 @@
 import { State } from './state'
-const dlv = require('dlv')
+import dlv from 'dlv'
 
 export function flagEnabled(state: State, flag: string) {
   if (state.featureFlags.future.includes(flag)) {

--- a/packages/tailwindcss-language-service/src/util/getClassNameAtPosition.ts
+++ b/packages/tailwindcss-language-service/src/util/getClassNameAtPosition.ts
@@ -1,6 +1,6 @@
 import { State } from './state'
 import { combinations } from './combinations'
-const dlv = require('dlv')
+import dlv from 'dlv'
 
 export function getClassNameParts(state: State, className: string): string[] {
   let separator = state.separator

--- a/packages/tailwindcss-language-service/src/util/getClassNameDecls.ts
+++ b/packages/tailwindcss-language-service/src/util/getClassNameDecls.ts
@@ -1,7 +1,7 @@
 import { State } from './state'
 import { getClassNameParts } from './getClassNameAtPosition'
 import removeMeta from './removeMeta'
-const dlv = require('dlv')
+import dlv from 'dlv'
 
 export function getClassNameDecls(
   state: State,

--- a/packages/tailwindcss-language-service/src/util/getClassNameMeta.ts
+++ b/packages/tailwindcss-language-service/src/util/getClassNameMeta.ts
@@ -1,6 +1,6 @@
 import { State, ClassNameMeta } from './state'
 import { getClassNameParts } from './getClassNameAtPosition'
-const dlv = require('dlv')
+import dlv from 'dlv'
 
 export function getClassNameMeta(
   state: State,

--- a/packages/tailwindcss-language-service/src/util/stringify.ts
+++ b/packages/tailwindcss-language-service/src/util/stringify.ts
@@ -1,5 +1,5 @@
 import removeMeta from './removeMeta'
-const dlv = require('dlv')
+import dlv from 'dlv'
 import escapeClassName from 'css.escape'
 import { ensureArray } from './array'
 import { remToPx } from './remToPx'


### PR DESCRIPTION
It was already imported in one place, that appears to work fine.

Using `require` results in invalid ESM output, because `require` is not defined in ES modules.