### PR TITLE
Define TypeScript compiler target

### DIFF
--- a/packages/tailwindcss-language-service/package-lock.json
+++ b/packages/tailwindcss-language-service/package-lock.json
@@ -23,6 +23,7 @@
         "semver": "7.3.2",
         "sift-string": "0.0.2",
         "stringify-object": "3.3.0",
+        "tmp-cache": "1.1.0",
         "vscode-emmet-helper-bundled": "0.0.1",
         "vscode-languageclient": "7.0.0",
         "vscode-languageserver": "7.0.0",
@@ -11525,6 +11526,14 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tmp-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tmp-cache/-/tmp-cache-1.1.0.tgz",
+      "integrity": "sha512-j040fkL/x+XAZQ9K3bKGEPwgYhOZNBQLa3NXEADUiuno9C+3N2JJA4bVPDREixp604G3/vTXWA3DIPpA9lu1RQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -21537,6 +21546,11 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "tmp-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tmp-cache/-/tmp-cache-1.1.0.tgz",
+      "integrity": "sha512-j040fkL/x+XAZQ9K3bKGEPwgYhOZNBQLa3NXEADUiuno9C+3N2JJA4bVPDREixp604G3/vTXWA3DIPpA9lu1RQ=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/packages/tailwindcss-language-service/tsconfig.json
+++ b/packages/tailwindcss-language-service/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "lib": ["ES2020"],
+    "target": "ES2020",
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
TypeScript was complaining about some syntax features, this solves it. It doesn’t affect the output, as `tsdx` ignores the `target` property.