### PR TITLE
fix: guard against optional client capabilities

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -1563,10 +1563,10 @@ class DocumentService {
 function supportsDynamicRegistration(connection: Connection, params: InitializeParams): boolean {
   return (
     connection.onInitialized &&
-    params.capabilities.textDocument.hover.dynamicRegistration &&
-    params.capabilities.textDocument.colorProvider.dynamicRegistration &&
-    params.capabilities.textDocument.codeAction.dynamicRegistration &&
-    params.capabilities.textDocument.completion.dynamicRegistration
+    params.capabilities.textDocument.hover?.dynamicRegistration &&
+    params.capabilities.textDocument.colorProvider?.dynamicRegistration &&
+    params.capabilities.textDocument.codeAction?.dynamicRegistration &&
+    params.capabilities.textDocument.completion?.dynamicRegistration
   )
 }
 


### PR DESCRIPTION
for lsp client like lsp-mode for emacs which doesn't have colorProvider, server is failing to start, and according to the specification, the capabilities here is all optional, so we should guard the nil situation.