### PR TITLE
Handle the `DEFAULT` case for `matchVariant`

### DIFF
--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -216,7 +216,7 @@ export function completionsFromClassList(
                 .filter((value) => !existingVariants.includes(`${variant.name}-${value}`))
                 .map((value) =>
                   variantItem({
-                    label: `${variant.name}${variant.hasDash ? '-' : ''}${value}${sep}`,
+                    label: value === 'DEFAULT'? `${variant.name}${sep}` : `${variant.name}${variant.hasDash ? '-' : ''}${value}${sep}`,
                     detail: variant.selectors({ value }).join(', '),
                   })
                 )
@@ -845,7 +845,7 @@ function provideVariantsDirectiveCompletions(
 
   let possibleVariants = state.variants.flatMap((variant) => {
     if (variant.values.length) {
-      return variant.values.map((value) => `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
+      return variant.values.map((value) => value === 'DEFAULT'? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
     }
     return [variant.name]
   })

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -216,7 +216,10 @@ export function completionsFromClassList(
                 .filter((value) => !existingVariants.includes(`${variant.name}-${value}`))
                 .map((value) =>
                   variantItem({
-                    label: value === 'DEFAULT'? `${variant.name}${sep}` : `${variant.name}${variant.hasDash ? '-' : ''}${value}${sep}`,
+                    label:
+                      value === 'DEFAULT'
+                        ? `${variant.name}${sep}`
+                        : `${variant.name}${variant.hasDash ? '-' : ''}${value}${sep}`,
                     detail: variant.selectors({ value }).join(', '),
                   })
                 )
@@ -845,7 +848,9 @@ function provideVariantsDirectiveCompletions(
 
   let possibleVariants = state.variants.flatMap((variant) => {
     if (variant.values.length) {
-      return variant.values.map((value) => value === 'DEFAULT'? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
+      return variant.values.map((value) =>
+        value === 'DEFAULT' ? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`
+      )
     }
     return [variant.name]
   })

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidVariantDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidVariantDiagnostics.ts
@@ -34,7 +34,7 @@ export function getInvalidVariantDiagnostics(
 
   let possibleVariants = state.variants.flatMap((variant) => {
     if (variant.values.length) {
-      return variant.values.map((value) => `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
+      return variant.values.map((value) => value === 'DEFAULT'? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
     }
     return [variant.name]
   })

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidVariantDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidVariantDiagnostics.ts
@@ -34,7 +34,9 @@ export function getInvalidVariantDiagnostics(
 
   let possibleVariants = state.variants.flatMap((variant) => {
     if (variant.values.length) {
-      return variant.values.map((value) => value === 'DEFAULT'? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
+      return variant.values.map((value) =>
+        value === 'DEFAULT' ? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`
+      )
     }
     return [variant.name]
   })

--- a/packages/tailwindcss-language-service/src/util/getVariantsFromClassName.ts
+++ b/packages/tailwindcss-language-service/src/util/getVariantsFromClassName.ts
@@ -7,7 +7,9 @@ export function getVariantsFromClassName(
 ): { variants: string[]; offset: number } {
   let allVariants = state.variants.flatMap((variant) => {
     if (variant.values.length) {
-      return variant.values.map((value) => value === 'DEFAULT'? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
+      return variant.values.map((value) =>
+        value === 'DEFAULT' ? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`
+      )
     }
     return [variant.name]
   })

--- a/packages/tailwindcss-language-service/src/util/getVariantsFromClassName.ts
+++ b/packages/tailwindcss-language-service/src/util/getVariantsFromClassName.ts
@@ -7,7 +7,7 @@ export function getVariantsFromClassName(
 ): { variants: string[]; offset: number } {
   let allVariants = state.variants.flatMap((variant) => {
     if (variant.values.length) {
-      return variant.values.map((value) => `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
+      return variant.values.map((value) => value === 'DEFAULT'? variant.name : `${variant.name}${variant.hasDash ? '-' : ''}${value}`)
     }
     return [variant.name]
   })


### PR DESCRIPTION
This PR handles the `DEFAULT` value for `matchVariant`.

It should show you `foo:` instead of `foo-DEFAULT:` in completions.

---

@bradlc, I'm not 100% sure how to test this so going to leave this open until whenever you have time
to look at it.

