### PR TITLE
Fixed error when initializationOptions is undefined

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -381,7 +381,7 @@ async function createProjectService(
     editor: {
       connection,
       folder,
-      userLanguages: params.initializationOptions.userLanguages
+      userLanguages: params.initializationOptions?.userLanguages
         ? params.initializationOptions.userLanguages
         : {},
       // TODO


### PR DESCRIPTION
This PR fixes an issue where the language server crashes if the `initalizationOptions` property is not defined. The `initializationOptions` property is optional according to the [language server protocol specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize), so the server shouldn't rely on it being an object.

This also fixes https://github.com/helix-editor/helix/issues/2213. Helix does not send the `initializationOptions` by default and so the language server was crashing.