### PR TITLE
Fix client not starting (#608)

### DIFF
--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -196,6 +196,16 @@ export async function activate(context: ExtensionContext) {
   //   )
   // )
 
+  Workspace.findFiles(`**/${CONFIG_GLOB}`).then(uris => {
+    uris.forEach(uri => {
+      let folder = Workspace.getWorkspaceFolder(uri)
+      if (!folder || isExcluded(uri.fsPath, folder)) {
+        return
+      }
+      bootWorkspaceClient(folder)
+    })
+  })
+  
   let configWatcher = Workspace.createFileSystemWatcher(`**/${CONFIG_GLOB}`, false, true, true)
 
   configWatcher.onDidCreate((uri) => {

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -196,15 +196,6 @@ export async function activate(context: ExtensionContext) {
   //   )
   // )
 
-  Workspace.findFiles(`**/${CONFIG_GLOB}`).then(uris => {
-    uris.forEach(uri => {
-      let folder = Workspace.getWorkspaceFolder(uri)
-      if (!folder || isExcluded(uri.fsPath, folder)) {
-        return
-      }
-      bootWorkspaceClient(folder)
-    })
-  })
   
   let configWatcher = Workspace.createFileSystemWatcher(`**/${CONFIG_GLOB}`, false, true, true)
 
@@ -654,7 +645,7 @@ export async function activate(context: ExtensionContext) {
 
     let [configFile] = await Workspace.findFiles(
       new RelativePattern(folder, `**/${CONFIG_GLOB}`),
-      `{${getExcludePatterns(folder).join(',')}}`,
+      `${getExcludePatterns(folder).join(',')}`, 
       1
     )
 


### PR DESCRIPTION
Fixes #608 where the extension client (sometimes?) doesn't start after restarting VSCode.
`Workspace.createFileSystemWatcher` doesn't seem to create events for already existing files when starting VSCode so an initial scan for config files is necessary.