### PR TITLE
Fix method called before initialize

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -2249,7 +2249,7 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
     }
   }
 
-  tw.init()
+  await tw.init()
 
   return {
     capabilities: {


### PR DESCRIPTION
wait for init in onInitialize before sending response to the client, so that client won't try to do request before the lsp handlers are registered.

otherwise client will got errors like `Unhandled method textDocument/codeAction`