### PR TITLE
Add htmldjango (vim filetype) to languages

### DIFF
--- a/packages/tailwindcss-language-service/src/util/languages.ts
+++ b/packages/tailwindcss-language-service/src/util/languages.ts
@@ -17,6 +17,7 @@ export const htmlLanguages = [
   'HTML (Eex)',
   'HTML (EEx)',
   'html-eex',
+  'htmldjango',
   'jade',
   'leaf',
   'liquid',


### PR DESCRIPTION
# Description

Short version - 

Vim and Neovim use filetypes to handle different files. For syntax, highlighting, and more. 
Vim uses the filetype `htmldjango` for django templates.
The tailwindcss-language-server does not recognise `htmldjango` as a file language and so vim and neovim suffer as a result.

I would like to add `htmldjango` as a language upstream so individual configurations for lsp in the Vim world don't need to consider this issue.

Issue was raised in [`neovim/nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/issues/2488) repo. I think adding this line would be the most effective way to solve the issue.

I've built and tested this with neovim and it works.
