### PR TITLE
Fix InvalidTailwindDirective in notSemicolonLanguages with CRLF file endings

### DIFF
--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -35,7 +35,7 @@ export function getInvalidTailwindDirectiveDiagnostics(
     (state.editor &&
       notSemicolonLanguages.includes(state.editor.userLanguages[document.languageId]))
   ) {
-    regex = /(?:\s|^)@tailwind\s+(?<value>[^(\r)?\n]+)/g
+    regex = /(?:\s|^)@tailwind\s+(?<value>[^\r\n]+)/g
   } else {
     regex = /(?:\s|^)@tailwind\s+(?<value>[^;]+)/g
   }

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -35,7 +35,7 @@ export function getInvalidTailwindDirectiveDiagnostics(
     (state.editor &&
       notSemicolonLanguages.includes(state.editor.userLanguages[document.languageId]))
   ) {
-    regex = /(?:\s|^)@tailwind\s+(?<value>[^\n]+)/g
+    regex = /(?:\s|^)@tailwind\s+(?<value>[^(\r)?\n]+)/g
   } else {
     regex = /(?:\s|^)@tailwind\s+(?<value>[^;]+)/g
   }


### PR DESCRIPTION
Just adds `(\r)?` to the find tailwind directive regex so that it recognizes `\r\n` as the end of line, this was the error that i got:
```
'utilities
' is not a valid value. Did you mean 'utilities'?(invalidTailwindDirective)
```

### steps to reproduce 

1. go into any tailwind app
2. create `app.sass`
3. paste `@tailwind utilities`
4. change file endings to CRLF
5. now you should see the warning