### PR TITLE
Support TS/ESM Tailwind config files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"debounce": "1.2.0",
 				"deepmerge": "4.2.2",
 				"detect-indent": "6.0.0",
-				"detective": "5.2.0",
+				"detective-typescript": "9.0.0",
 				"dlv": "1.1.3",
 				"dset": "3.1.2",
 				"enhanced-resolve-301": "0.0.1",
@@ -4964,6 +4964,18 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "5.55.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
+			"integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "2.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
@@ -4988,6 +5000,30 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.55.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
+			"integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.55.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@zkochan/cmd-shim": {
@@ -5422,6 +5458,14 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ast-module-types": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
+			"integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ==",
+			"engines": {
+				"node": ">=6.0"
 			}
 		},
 		"node_modules/ast-types-flow": {
@@ -7716,20 +7760,113 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/detective": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
-			"integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+		"node_modules/detective-typescript": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-9.0.0.tgz",
+			"integrity": "sha512-lR78AugfUSBojwlSRZBeEqQ1l8LI7rbxOl1qTUnGLcjZQDjZmrZCb7R46rK8U8B5WzFvJrxa7fEBA8FoD/n5fA==",
 			"dependencies": {
-				"acorn-node": "^1.6.1",
-				"defined": "^1.0.0",
-				"minimist": "^1.1.1"
-			},
-			"bin": {
-				"detective": "bin/detective.js"
+				"@typescript-eslint/typescript-estree": "^5.13.0",
+				"ast-module-types": "^3.0.0",
+				"node-source-walk": "^5.0.0",
+				"typescript": "^4.5.5"
 			},
 			"engines": {
-				"node": ">=0.8.0"
+				"node": "^12.20.0 || ^14.14.0 || >=16.0.0"
+			}
+		},
+		"node_modules/detective-typescript/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.55.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
+			"integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.55.0",
+				"@typescript-eslint/visitor-keys": "5.55.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/detective-typescript/node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/detective-typescript/node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/detective-typescript/node_modules/fast-glob": {
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/detective-typescript/node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/detective-typescript/node_modules/ignore": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/detective-typescript/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/dezalgo": {
@@ -15415,6 +15552,17 @@
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
 			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+		},
+		"node_modules/node-source-walk": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
+			"integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+			"dependencies": {
+				"@babel/parser": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/nopt": {
 			"version": "4.0.3",
@@ -25580,6 +25728,11 @@
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
+		"@typescript-eslint/types": {
+			"version": "5.55.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
+			"integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug=="
+		},
 		"@typescript-eslint/typescript-estree": {
 			"version": "2.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
@@ -25592,6 +25745,22 @@
 				"lodash": "^4.17.15",
 				"semver": "^7.3.2",
 				"tsutils": "^3.17.1"
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "5.55.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
+			"integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
+			"requires": {
+				"@typescript-eslint/types": "5.55.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+				}
 			}
 		},
 		"@zkochan/cmd-shim": {
@@ -25926,6 +26095,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"ast-module-types": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
+			"integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="
 		},
 		"ast-types-flow": {
 			"version": "0.0.7",
@@ -27696,14 +27870,79 @@
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
 		},
-		"detective": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
-			"integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+		"detective-typescript": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-9.0.0.tgz",
+			"integrity": "sha512-lR78AugfUSBojwlSRZBeEqQ1l8LI7rbxOl1qTUnGLcjZQDjZmrZCb7R46rK8U8B5WzFvJrxa7fEBA8FoD/n5fA==",
 			"requires": {
-				"acorn-node": "^1.6.1",
-				"defined": "^1.0.0",
-				"minimist": "^1.1.1"
+				"@typescript-eslint/typescript-estree": "^5.13.0",
+				"ast-module-types": "^3.0.0",
+				"node-source-walk": "^5.0.0",
+				"typescript": "^4.5.5"
+			},
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": {
+					"version": "5.55.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
+					"integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
+					"requires": {
+						"@typescript-eslint/types": "5.55.0",
+						"@typescript-eslint/visitor-keys": "5.55.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"semver": "^7.3.7",
+						"tsutils": "^3.21.0"
+					}
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.12",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+					"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
+					}
+				},
+				"globby": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.2.9",
+						"ignore": "^5.2.0",
+						"merge2": "^1.4.1",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.2.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+				}
 			}
 		},
 		"dezalgo": {
@@ -33689,6 +33928,14 @@
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
 			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+		},
+		"node-source-walk": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
+			"integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+			"requires": {
+				"@babel/parser": "^7.0.0"
+			}
 		},
 		"nopt": {
 			"version": "4.0.3",

--- a/packages/tailwindcss-language-server/package.json
+++ b/packages/tailwindcss-language-server/package.json
@@ -46,7 +46,7 @@
     "culori": "0.20.1",
     "debounce": "1.2.0",
     "deepmerge": "4.2.2",
-    "detective": "5.2.0",
+    "detective-typescript": "9.0.0",
     "dlv": "1.1.3",
     "dset": "3.1.2",
     "enhanced-resolve-301": "0.0.1",

--- a/packages/tailwindcss-language-server/src/lib/constants.ts
+++ b/packages/tailwindcss-language-server/src/lib/constants.ts
@@ -1,3 +1,4 @@
-export const CONFIG_GLOB = '{tailwind,tailwind.config,tailwind.*.config,tailwind.config.*}.{js,cjs}'
+export const CONFIG_GLOB =
+  '{tailwind,tailwind.config,tailwind.*.config,tailwind.config.*}.{js,cjs,ts,mjs}'
 export const PACKAGE_LOCK_GLOB = '{package-lock.json,yarn.lock,pnpm-lock.yaml}'
 export const CSS_GLOB = '*.{css,scss,sass,less,pcss}'

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -105,6 +105,7 @@ export interface State {
     postcss?: { version: string; module: Postcss }
     postcssSelectorParser?: { module: any }
     resolveConfig?: { module: any }
+    loadConfig?: { module: any }
     jit?: {
       generateRules: { module: any }
       createContext: { module: any }


### PR DESCRIPTION
This PR adds support for TypeScript and ESM Tailwind config files when using a version of `tailwindcss` that supports these (currently `tailwindcss@insiders`, since https://github.com/tailwindlabs/tailwindcss/pull/10785)