### PR TITLE
Remove language service dependency on TextDocuments

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -412,7 +412,6 @@ async function createProjectService(
         diagnosticRelatedInformation: true,
         itemDefaults,
       },
-      documents: documentService.documents,
       getConfiguration,
       getDocumentSymbols: (uri: string) => {
         return connection.sendRequest('@/tailwindCSS/getDocumentSymbols', { uri })
@@ -1171,7 +1170,7 @@ async function createProjectService(
         if (!document) return null
         let settings = await state.editor.getConfiguration(document.uri)
         if (!settings.tailwindCSS.codeActions) return null
-        return doCodeActions(state, params)
+        return doCodeActions(state, params, document)
       }, null)
     },
     onDocumentLinks(params: DocumentLinkParams): DocumentLink[] {

--- a/packages/tailwindcss-language-service/src/codeActions/provideInvalidApplyCodeActions.ts
+++ b/packages/tailwindcss-language-service/src/codeActions/provideInvalidApplyCodeActions.ts
@@ -18,13 +18,13 @@ import { dset } from 'dset'
 import selectorParser from 'postcss-selector-parser'
 import { flatten } from '../util/array'
 import { getTextWithoutComments } from '../util/doc'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 export async function provideInvalidApplyCodeActions(
   state: State,
-  params: CodeActionParams,
+  document: TextDocument,
   diagnostic: InvalidApplyDiagnostic
 ): Promise<CodeAction[]> {
-  let document = state.editor.documents.get(params.textDocument.uri)
   if (!document) return []
   let documentText = getTextWithoutComments(document, 'css')
   let cssRange: Range
@@ -144,7 +144,7 @@ export async function provideInvalidApplyCodeActions(
       diagnostics: [diagnostic],
       edit: {
         changes: {
-          [params.textDocument.uri]: changes,
+          [document.uri]: changes,
         },
       },
     },

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -20,7 +20,6 @@ export type ClassNames = {
 export type EditorState = {
   connection: Connection
   folder: string
-  documents: TextDocuments<TextDocument>
   userLanguages: Record<string, string>
   capabilities: {
     configuration: boolean


### PR DESCRIPTION
The code actions API depends on `TextDocuments`. This is specific to the language server. This makes it hard to use without a language server.

The use of `TextDocuments` has been removed. Instead, the resolved text document is passed down.

This makes a lot simpler for me to implement https://github.com/remcohaszing/monaco-tailwindcss/issues/78 downstream.