### PR TITLE
Don't read CSS file when it was deleted

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -1845,7 +1845,7 @@ class TW {
         let isCssFile = minimatch(normalizedFilename, `**/${CSS_GLOB}`, {
           dot: true,
         })
-        if (isCssFile) {
+        if (isCssFile && change.type !== FileChangeType.Deleted) {
           let configPath = await getConfigFileFromCssFile(change.file)
           if (
             cssFileConfigMap.has(normalizedFilename) &&


### PR DESCRIPTION
In Neovim when using the Tailwind language server, deleting a CSS file results in the following error:

```
[ERROR][2023-04-21 21:06:00] ...lsp/handlers.lua:535    "Unhandled exception: ENOENT: no such file or directory, open '/my/file/path/hi.css'\nError: ENOENT: no such file or directory, open '/my/file/path/hi.css'"
```

This is happening due to the LSP attempting to read from the now deleted CSS file during file watch changes. I updated the code that was reading from the CSS files to first ensure that it wasn't a `Deleted` change event.