### PR TITLE
Support @apply string in JavaScript

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -282,7 +282,7 @@ async function getConfiguration(uri?: string) {
         includeLanguages: {},
         files: { exclude: ['**/.git/**', '**/node_modules/**', '**/.hg/**', '**/.svn/**'] },
         experimental: {
-          classRegex: [],
+          classRegex: ["['\"`]@apply\\s+(.*)['\"`]"],
           configFile: null,
         },
       },

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -275,7 +275,10 @@
         },
         "tailwindCSS.experimental.classRegex": {
           "type": "array",
-          "scope": "language-overridable"
+          "scope": "language-overridable",
+          "default": [
+            "['\"`]@apply\\s+(.*)['\"`]"
+          ]
         },
         "tailwindCSS.experimental.configFile": {
           "type": [


### PR DESCRIPTION
This PR is based on https://github.com/tailwindlabs/tailwindcss/discussions/11095.

This change makes the `classRegex` setting have a default that picks up strings starting with `@apply`.