### PR TITLE
Improved performance

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -14,12 +14,18 @@ import { getTextWithoutComments } from './doc'
 import { isSemicolonlessCssLanguage } from './languages'
 
 export function findAll(re: RegExp, str: string): RegExpMatchArray[] {
-  let match: RegExpMatchArray
-  let matches: RegExpMatchArray[] = []
+  let match: RegExpMatchArray;
+
+  const count = (str.match(re) || []).length;
+  let matches: RegExpMatchArray[] = new Array(count);
+  let i = 0;
+
   while ((match = re.exec(str)) !== null) {
-    matches.push({ ...match })
+    matches[i] = match;
+    i++;
   }
-  return matches
+
+  return matches;
 }
 
 export function findLast(re: RegExp, str: string): RegExpMatchArray {


### PR DESCRIPTION
Improved performance by avoid resizing matches array. This seems to provide a quite healthy performance improvement across the board. 

I did some performance tracking with `node:perf_hooks`
![image](https://github.com/tailwindlabs/tailwindcss-intellisense/assets/10583205/ee888d54-3c0d-49ef-a75b-630110f8c220)

The first block is without my modifications, just tracking the performance. The second is with my changes. I tested it by modifying the className with exactly the same values. With my changes it seems that around 100-150~ms are sliced off on many calls.
