### PR TITLE
Avoid getting settings twice when doing completions

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -79,7 +79,7 @@ import { getColor } from 'tailwindcss-language-service/src/util/color'
 import * as culori from 'culori'
 import namedColors from 'color-name'
 import tailwindPlugins from './lib/plugins'
-import isExcluded from './util/isExcluded'
+import isExcluded, { isExcludedOnComplete } from './util/isExcluded'
 import { getFileFsPath, normalizeFileNameToFsPath } from './util/uri'
 import { equal } from 'tailwindcss-language-service/src/util/array'
 import preflight from 'tailwindcss/lib/css/preflight.css'
@@ -1169,7 +1169,7 @@ async function createProjectService(
         if (!document) return null
         let settings = await state.editor.getConfiguration(document.uri)
         if (!settings.tailwindCSS.suggestions) return null
-        if (await isExcluded(state, document)) return null
+        if (await isExcludedOnComplete(state, document, settings)) return null
         return doComplete(state, document, params.position, params.context)
       }, null)
     },

--- a/packages/tailwindcss-language-server/src/util/isExcluded.ts
+++ b/packages/tailwindcss-language-server/src/util/isExcluded.ts
@@ -1,6 +1,6 @@
 import minimatch from 'minimatch'
 import * as path from 'path'
-import { State } from 'tailwindcss-language-service/src/util/state'
+import { Settings, State } from 'tailwindcss-language-service/src/util/state'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { getFileFsPath } from './uri'
 
@@ -11,6 +11,21 @@ export default async function isExcluded(
 ): Promise<boolean> {
   let settings = await state.editor.getConfiguration(document.uri)
 
+  for (let pattern of settings.tailwindCSS.files.exclude) {
+    if (minimatch(file, path.join(state.editor.folder, pattern))) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export async function isExcludedOnComplete(
+  state: State,
+  document: TextDocument,
+  settings: Settings,
+  file: string = getFileFsPath(document.uri)
+): Promise<boolean> {
   for (let pattern of settings.tailwindCSS.files.exclude) {
     if (minimatch(file, path.join(state.editor.folder, pattern))) {
       return true


### PR DESCRIPTION
In this code block, settings is fetched and then fetched again inside isExcluded inn a seperate call.

**server.ts**
```typescript
    async onCompletion(params: CompletionParams): Promise<CompletionList> {
      return withFallback(async () => {
        if (!state.enabled) return null
        let document = documentService.getDocument(params.textDocument.uri)
        if (!document) return null
        let settings = await state.editor.getConfiguration(document.uri)
        if (!settings.tailwindCSS.suggestions) return null
        if (await isExcluded(state, document)) return null
        return doComplete(state, document, params.position, params.context)
      }, null)
    },
```

**isExcluded.ts**
```typescript
export default async function isExcluded(
  state: State,
  document: TextDocument,
  file: string = getFileFsPath(document.uri)
): Promise<boolean> {
 // Here the exact same settings are fetched again
  let settings = await state.editor.getConfiguration(document.uri)

  for (let pattern of settings.tailwindCSS.files.exclude) {
    if (minimatch(file, path.join(state.editor.folder, pattern))) {
      return true
    }
  }

  return false
}
```
---
### Here it is with my changes

**server.ts**
```typescript
async onCompletion(params: CompletionParams): Promise<CompletionList> {
      return withFallback(async () => {
        if (!state.enabled) return null
        let document = documentService.getDocument(params.textDocument.uri)
        if (!document) return null
        let settings = await state.editor.getConfiguration(document.uri)
        if (!settings.tailwindCSS.suggestions) return null
        if (await isExcludedOnComplete(state, document, settings)) return null
        return doComplete(state, document, params.position, params.context)
      }, null)
    },
```
    
**isExluded.ts**
```typescript
export async function isExcludedOnComplete(
  state: State,
  document: TextDocument,
  settings: Settings,
  file: string = getFileFsPath(document.uri)
): Promise<boolean> {
  for (let pattern of settings.tailwindCSS.files.exclude) {
    if (minimatch(file, path.join(state.editor.folder, pattern))) {
      return true
    }
  }

  return false
}
```

Doing this halves the hits to the cache 2 -> 1, which has quite a big impact since the document settings cache is quite large. 

From some preliminary benchmarking it takes about 100ms to get a settings object after it's cached. So eliminating a 100ms call is quite valuable. 