### PR TITLE
Fix IntelliSense following closing script/style tag containing whitespace

### DIFF
--- a/packages/tailwindcss-language-service/src/util/getLanguageBoundaries.ts
+++ b/packages/tailwindcss-language-service/src/util/getLanguageBoundaries.ts
@@ -77,11 +77,11 @@ let states = {
     ...text,
   },
   style: {
-    cssBlockEnd: { match: '</style>', pop: 1 },
+    cssBlockEnd: { match: /<\/style\s*>/, pop: 1 },
     ...text,
   },
   script: {
-    jsBlockEnd: { match: '</script>', pop: 1 },
+    jsBlockEnd: { match: /<\/script\s*>/, pop: 1 },
     ...text,
   },
 }


### PR DESCRIPTION
Fixes #800

This PR updates the pattern for closing `script` and `style` tags, so that IntelliSense continues to function following a closing tag containing whitespace, such as `</script >`:

```html
<script></script >
<template>
  <span class="intellisense will work here now"></span>
</template>
```