### PR TITLE
Fix `classRegex` hovers in unknown contexts

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -296,10 +296,10 @@ export async function findClassListsInRange(
   mode?: 'html' | 'css' | 'jsx',
   includeCustom: boolean = true
 ): Promise<DocumentClassList[]> {
-  let classLists: DocumentClassList[]
+  let classLists: DocumentClassList[] = []
   if (mode === 'css') {
     classLists = findClassListsInCssRange(state, doc, range)
-  } else {
+  } else if (mode === 'html' || mode === 'jsx') {
     classLists = await findClassListsInHtmlRange(state, doc, mode, range)
   }
   return dedupeByRange([
@@ -449,6 +449,8 @@ export async function findClassNameAtPosition(
     classNames = await findClassNamesInRange(state, doc, searchRange, 'html')
   } else if (isJsxContext(state, doc, position)) {
     classNames = await findClassNamesInRange(state, doc, searchRange, 'jsx')
+  } else {
+    classNames = await findClassNamesInRange(state, doc, searchRange)
   }
 
   if (classNames.length === 0) {


### PR DESCRIPTION
Fixes #822

Previously `findClassNameAtPosition` would only return results if the position was in a known CSS, HTML, or JSX context. Now, `experimental.classRegex` configurations are always checked regardless of the position in the file.