### PR TITLE
Expand `classRegex` search range

### DIFF
--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -499,8 +499,8 @@ async function provideCustomClassNameCompletions(
   const positionOffset = document.offsetAt(position)
 
   const searchRange: Range = {
-    start: document.positionAt(Math.max(0, positionOffset - 1000)),
-    end: document.positionAt(positionOffset + 1000),
+    start: document.positionAt(0),
+    end: document.positionAt(positionOffset + 2000),
   }
 
   let str = document.getText(searchRange)

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -135,7 +135,7 @@ async function findCustomClassLists(
 
   if (!Array.isArray(regexes) || regexes.length === 0) return []
 
-  const text = doc.getText(range)
+  const text = doc.getText(range ? { ...range, start: doc.positionAt(0) } : undefined)
   const result: DocumentClassList[] = []
 
   for (let i = 0; i < regexes.length; i++) {


### PR DESCRIPTION
Fixes #832
Fixes #837

This PR expands the `classRegex` search range so that longer matches can be found (#837). Additionally the search range now always starts at the very beginning of the document, so that patterns match as expected. An example of why this matters is a simple string pattern: `'[^']*'`. Consider the following document:

```
'' + 'hello world'
```

If we start searching from the beginning the matches would be: `'', 'hello world'`, but if we start from the second character the only match would be: `' + '`