### PR TITLE
Add support for styled-jsx / CSS in JS syntax

### DIFF
--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -83,6 +83,8 @@
           "source.css",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       },
@@ -90,14 +92,18 @@
         "scopeName": "tailwindcss.at-rules.scss.injection",
         "path": "./syntaxes/at-rules.scss.tmLanguage.json",
         "injectTo": [
-          "source.css.scss"
+          "source.css.scss",
+          "source.tsx",
+          "source.jsx"
         ]
       },
       {
         "scopeName": "tailwindcss.at-rules.postcss.injection",
         "path": "./syntaxes/at-rules.postcss.tmLanguage.json",
         "injectTo": [
-          "source.css.postcss"
+          "source.css.postcss",
+          "source.tsx",
+          "source.jsx"
         ]
       },
       {
@@ -108,6 +114,8 @@
           "source.css.postcss",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       },
@@ -119,6 +127,8 @@
           "source.css.postcss",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       },
@@ -130,6 +140,8 @@
           "source.css.postcss",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       }


### PR DESCRIPTION
This branch adds support for CSS in JS libraries like [styled-jsx](https://github.com/vercel/styled-jsx) with _partial_ support for others like [styled-components](https://styled-components.com/) (in particular the "css backtick" syntax only).

This plugin had basic _intellisense_ support for the `<style jsx>` syntax, but lacked support for the css / css.resolve / css.global backtick syntax that is used by styled-jsx. Furthermore, because of the way `<style jsx>` blocks function syntactically (they are actually JS strings, not CSS blocks), this plugin's package.json incorrectly specifies the grammar scopes necessary to trigger the syntax highlighting rules on the style blocks. This PR fixes both of these issues that affect compatibility with styled-jsx and the like.

Below is a before/after screenshot pair of how this feature works alongside embedded CSS using both the css backtick syntax as well as the `<style jsx>` tags with both highlighting and intellisense functioning as expected. Note that this feature still depends on the user installing [blanu.vscode-styled-jsx](https://marketplace.visualstudio.com/items?itemName=blanu.vscode-styled-jsx) (or the styled-components variant) to provide the actual base CSS syntax highlighting for those styled blocks. If you do test this, please make sure you've installed that plugin.

#### Before

![image](https://github.com/tailwindlabs/tailwindcss-intellisense/assets/686/6107382c-0242-442a-80af-29080cb90c94)

#### After

![image](https://github.com/tailwindlabs/tailwindcss-intellisense/assets/686/1496537e-08ef-4f64-b025-d57d11032cd7)

Since I'm a first time contributor, I'm unsure what, if any, tests might be needed, but do let me know if I should add any.