### PR TITLE
feat: add glimmer langs

### DIFF
--- a/packages/tailwindcss-language-service/src/util/languages.ts
+++ b/packages/tailwindcss-language-service/src/util/languages.ts
@@ -54,6 +54,8 @@ export const jsLanguages = [
   'rescript',
   'typescript',
   'typescriptreact',
+  'glimmer-js',
+  'glimmer-ts',
 ]
 
 export const specialLanguages = ['vue', 'svelte']


### PR DESCRIPTION
Adds support for `.gjs` and `.gts` file formats. Glimmer `<template>` tag components are the new format which power Ember.js. References:

- RFC: https://rfcs.emberjs.com/id/0779-first-class-component-templates
- Component implementation: https://github.com/ember-template-imports/ember-template-imports

Local test:

<img width="796" alt="image" src="https://github.com/tailwindlabs/tailwindcss-intellisense/assets/10243652/ed68047d-aa78-4da0-a5f1-664f20e746f8">
