### PR TITLE
Enable Sort Selection on a remote host

### DIFF
--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.x (Pre-Release)
 
-- Nothing yet
+- Enable Sort Selection on a remote host (#878)
 
 ## 0.10.2
 

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -64,7 +64,7 @@
       {
         "command": "tailwindCSS.sortSelection",
         "title": "Tailwind CSS: Sort Selection",
-        "enablement": "editorHasSelection && resourceScheme == file && tailwindCSS.activeTextEditorSupportsClassSorting"
+        "enablement": "editorHasSelection && (resourceScheme == file || resourceScheme == vscode-remote) && tailwindCSS.activeTextEditorSupportsClassSorting"
       }
     ],
     "grammars": [


### PR DESCRIPTION
If you were in a VSCode remote workspace (for instance, over SSH) the Sort Selection command was not available. This fixes that.

Fixes #877