### PR TITLE
Simplify hovers

### DIFF
--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -251,7 +251,7 @@ async function getConfiguration(uri?: string) {
         classAttributes: ['class', 'className', 'ngClass'],
         codeActions: true,
         hovers: true,
-        simplifyHovers: false,
+        simplifyHovers: true,
         suggestions: true,
         validate: true,
         colorDecorators: true,

--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -251,6 +251,7 @@ async function getConfiguration(uri?: string) {
         classAttributes: ['class', 'className', 'ngClass'],
         codeActions: true,
         hovers: true,
+        simplifyHovers: false,
         suggestions: true,
         validate: true,
         colorDecorators: true,

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -114,7 +114,7 @@ withFixture('basic', (c) => {
       detail: 'text-transform: uppercase;',
       documentation: {
         kind: 'markdown',
-        value: '```css\n.uppercase {\n  text-transform: uppercase;\n}\n```',
+        value: '```css\n& {\n  text-transform: uppercase;\n}\n```',
       },
     })
   })

--- a/packages/tailwindcss-language-server/tests/env/multi-config-content.test.js
+++ b/packages/tailwindcss-language-server/tests/env/multi-config-content.test.js
@@ -13,7 +13,7 @@ withFixture('multi-config-content', (c) => {
       contents: {
         language: 'css',
         value:
-          '.bg-foo {\n  --tw-bg-opacity: 1;\n  background-color: rgb(255 0 0 / var(--tw-bg-opacity));\n}',
+          '& {\n  --tw-bg-opacity: 1;\n  background-color: rgb(255 0 0 / var(--tw-bg-opacity));\n}',
       },
       range: { start: { line: 0, character: 12 }, end: { line: 0, character: 18 } },
     })
@@ -30,7 +30,7 @@ withFixture('multi-config-content', (c) => {
       contents: {
         language: 'css',
         value:
-          '.bg-foo {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 255 / var(--tw-bg-opacity));\n}',
+          '& {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 255 / var(--tw-bg-opacity));\n}',
       },
       range: { start: { line: 0, character: 12 }, end: { line: 0, character: 18 } },
     })

--- a/packages/tailwindcss-language-server/tests/env/multi-config.test.js
+++ b/packages/tailwindcss-language-server/tests/env/multi-config.test.js
@@ -13,7 +13,7 @@ withFixture('multi-config', (c) => {
       contents: {
         language: 'css',
         value:
-          '.bg-foo {\n  --tw-bg-opacity: 1;\n  background-color: rgb(255 0 0 / var(--tw-bg-opacity));\n}',
+          '& {\n  --tw-bg-opacity: 1;\n  background-color: rgb(255 0 0 / var(--tw-bg-opacity));\n}',
       },
       range: { start: { line: 0, character: 12 }, end: { line: 0, character: 18 } },
     })
@@ -30,7 +30,7 @@ withFixture('multi-config', (c) => {
       contents: {
         language: 'css',
         value:
-          '.bg-foo {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 255 / var(--tw-bg-opacity));\n}',
+          '& {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 255 / var(--tw-bg-opacity));\n}',
       },
       range: { start: { line: 0, character: 12 }, end: { line: 0, character: 18 } },
     })

--- a/packages/tailwindcss-language-server/tests/hover/hover.test.js
+++ b/packages/tailwindcss-language-server/tests/hover/hover.test.js
@@ -36,7 +36,7 @@ withFixture('basic', (c) => {
     text: '<div class="bg-red-500">',
     position: { line: 0, character: 13 },
     expected:
-      '.bg-red-500 {\n' +
+      '& {\n' +
       '  --tw-bg-opacity: 1;\n' +
       '  background-color: rgb(239 68 68 / var(--tw-bg-opacity));\n' +
       '}',
@@ -49,7 +49,7 @@ withFixture('basic', (c) => {
   testHover('arbitrary value', {
     text: '<div class="p-[3px]">',
     position: { line: 0, character: 13 },
-    expected: '.p-\\[3px\\] {\n' + '  padding: 3px;\n' + '}',
+    expected: '& {\n' + '  padding: 3px;\n' + '}',
     expectedRange: {
       start: { line: 0, character: 12 },
       end: { line: 0, character: 19 },
@@ -59,7 +59,7 @@ withFixture('basic', (c) => {
   testHover('arbitrary value with theme function', {
     text: '<div class="p-[theme(spacing.4)]">',
     position: { line: 0, character: 13 },
-    expected: '.p-\\[theme\\(spacing\\.4\\)\\] {\n' + '  padding: 1rem/* 16px */;\n' + '}',
+    expected: '& {\n' + '  padding: 1rem/* 16px */;\n' + '}',
     expectedRange: {
       start: { line: 0, character: 12 },
       end: { line: 0, character: 32 },
@@ -69,21 +69,21 @@ withFixture('basic', (c) => {
   testHover('arbitrary property', {
     text: '<div class="[text-wrap:balance]">',
     position: { line: 0, character: 13 },
-    expected: '.\\[text-wrap\\:balance\\] {\n' + '  text-wrap: balance;\n' + '}',
+    expected: '& {\n' + '  text-wrap: balance;\n' + '}',
     expectedRange: {
       start: { line: 0, character: 12 },
       end: { line: 0, character: 31 },
     },
   })
 
-  testHover('simplified hovers', {
+  testHover('disable simplified hovers', {
     text: '<div class="[[data-important]_&]:bg-purple-300">',
     position: { line: 0, character: 13 },
     settings: {
-      tailwindCSS: { simplifyHovers: true },
+      tailwindCSS: { simplifyHovers: false },
     },
     expected:
-      '[data-important] & {\n' +
+      '[data-important] .\\[\\[data-important\\]_\\&\\]\\:bg-purple-300 {\n' +
       '  --tw-bg-opacity: 1;\n' +
       '  background-color: rgb(216 180 254 / var(--tw-bg-opacity));\n' +
       '}',

--- a/packages/tailwindcss-language-server/tests/hover/hover.test.js
+++ b/packages/tailwindcss-language-server/tests/hover/hover.test.js
@@ -75,4 +75,21 @@ withFixture('basic', (c) => {
       end: { line: 0, character: 31 },
     },
   })
+
+  testHover('simplified hovers', {
+    text: '<div class="[[data-important]_&]:bg-purple-300">',
+    position: { line: 0, character: 13 },
+    settings: {
+      tailwindCSS: { simplifyHovers: true },
+    },
+    expected:
+      '[data-important] & {\n' +
+      '  --tw-bg-opacity: 1;\n' +
+      '  background-color: rgb(216 180 254 / var(--tw-bg-opacity));\n' +
+      '}',
+    expectedRange: {
+      start: { line: 0, character: 12 },
+      end: { line: 0, character: 46 },
+    },
+  })
 })

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -1416,7 +1416,7 @@ export async function resolveCompletionItem(
     if (!item.documentation) {
       item.documentation = {
         kind: 'markdown' as typeof MarkupKind.Markdown,
-        value: ['```css', await jit.stringifyRoot(state, root), '```'].join('\n'),
+        value: ['```css', await jit.stringifyRoot(state, root, className), '```'].join('\n'),
       }
     }
     return item

--- a/packages/tailwindcss-language-service/src/hoverProvider.ts
+++ b/packages/tailwindcss-language-service/src/hoverProvider.ts
@@ -1,5 +1,5 @@
 import { State } from './util/state'
-import type { Hover,  Position } from 'vscode-languageserver'
+import type { Hover, Position } from 'vscode-languageserver'
 import { stringifyCss, stringifyConfigValue } from './util/stringify'
 import dlv from 'dlv'
 import { isCssContext } from './util/css'
@@ -71,7 +71,7 @@ async function provideClassNameHover(
     return {
       contents: {
         language: 'css',
-        value: await jit.stringifyRoot(state, root, document.uri),
+        value: await jit.stringifyRoot(state, root, className.className, document.uri),
       },
       range: className.range,
     }

--- a/packages/tailwindcss-language-service/src/util/jit.ts
+++ b/packages/tailwindcss-language-service/src/util/jit.ts
@@ -1,5 +1,6 @@
 import { State } from './state'
 import type { Container, Document, Root, Rule, Node, AtRule } from 'postcss'
+import escapeClassName from 'css.escape'
 import { addPixelEquivalentsToCss, addPixelEquivalentsToValue } from './pixelEquivalents'
 
 export function bigSign(bigIntValue) {
@@ -33,13 +34,26 @@ export function generateRules(
   }
 }
 
-export async function stringifyRoot(state: State, root: Root, uri?: string): Promise<string> {
+export async function stringifyRoot(
+  state: State,
+  root: Root,
+  className: string,
+  uri?: string
+): Promise<string> {
   let settings = await state.editor.getConfiguration(uri)
   let clone = root.clone()
 
   clone.walkAtRules('defaults', (node) => {
     node.remove()
   })
+
+  if (settings.tailwindCSS.simplifyHovers) {
+    clone.walkRules((rule) => {
+      rule.selectors = rule.selectors.map((selector) => {
+        return selector.replace(`.${escapeClassName(className)}`, '&')
+      })
+    })
+  }
 
   let css = clone.toString()
 

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -46,6 +46,7 @@ export type TailwindCssSettings = {
   classAttributes: string[]
   suggestions: boolean
   hovers: boolean
+  simplifyHovers: boolean
   codeActions: boolean
   validate: boolean
   showPixelEquivalents: boolean

--- a/packages/tailwindcss-language-service/src/util/stringify.ts
+++ b/packages/tailwindcss-language-service/src/util/stringify.ts
@@ -49,7 +49,7 @@ export function stringifyCss(className: string, obj: any, settings: Settings): s
       .join('\n')
     return `${acc}${i === 0 ? '' : '\n'}${propStr}`
   }, '')
-  css += `${indentStr}${augmentClassName(className, obj)} {\n${decls}\n${indentStr}}`
+  css += `${indentStr}${augmentClassName(className, obj, settings)} {\n${decls}\n${indentStr}}`
 
   for (let i = context.length - 1; i >= 0; i--) {
     css += `${indent.repeat(i)}\n}`
@@ -62,8 +62,9 @@ export function stringifyCss(className: string, obj: any, settings: Settings): s
   return css
 }
 
-function augmentClassName(className: string, obj: any): string {
+function augmentClassName(className: string, obj: any, settings: Settings): string {
+  const classSelector = settings.tailwindCSS.simplifyHovers ? '&' : `.${escapeClassName(className)}`
   const pseudo = obj.__pseudo.join('')
   const scope = obj.__scope ? `${obj.__scope} ` : ''
-  return `${scope}.${escapeClassName(className)}${pseudo}`
+  return `${scope}${classSelector}${pseudo}`
 }

--- a/packages/vscode-tailwindcss/README.md
+++ b/packages/vscode-tailwindcss/README.md
@@ -110,7 +110,7 @@ Enable hovers. **Default: `true`**
 
 ### `tailwindCSS.simplifyHovers`
 
-Simplify hovers to use the CSS nesting selector (`&`) in place of the class name. **Default: `false`**
+Simplify hovers to use the CSS nesting selector (`&`) in place of the class name. **Default: `true`**
 
 ### `tailwindCSS.suggestions`
 

--- a/packages/vscode-tailwindcss/README.md
+++ b/packages/vscode-tailwindcss/README.md
@@ -108,6 +108,10 @@ Root font size in pixels. Used to convert `rem` CSS values to their `px` equival
 
 Enable hovers. **Default: `true`**
 
+### `tailwindCSS.simplifyHovers`
+
+Simplify hovers to use the CSS nesting selector (`&`) in place of the class name. **Default: `false`**
+
 ### `tailwindCSS.suggestions`
 
 Enable autocomplete suggestions. **Default: `true`**

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -195,6 +195,12 @@
           "markdownDescription": "Enable hovers.",
           "scope": "language-overridable"
         },
+        "tailwindCSS.simplifyHovers": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Simplify hovers to use the CSS nesting selector (`&`) in place of the class name.",
+          "scope": "language-overridable"
+        },
         "tailwindCSS.codeActions": {
           "type": "boolean",
           "default": true,

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -197,7 +197,7 @@
         },
         "tailwindCSS.simplifyHovers": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Simplify hovers to use the CSS nesting selector (`&`) in place of the class name.",
           "scope": "language-overridable"
         },


### PR DESCRIPTION
Enables hovers to replace the class name with a simple `&` to better help understand what the selector is doing.

Sometimes it is necessary to write code that gets as complex as `[&[aria-selected=true]:has(+_:not([aria-selected=true]))::before]:border-purple-500`. I often reach to hover over the class to make sure it is doing what I intended. Unfortunately the current implementation's hover puts out this code:

```css
.\[\&\[aria-selected\=true\]\:has\(\+_\:not\(\[aria-selected\=true\]\)\)\:\:before\]\:border-purple-500[aria-selected=true]:has(+ :not([aria-selected=true]))::before {
  --tw-border-opacity: 1;
  border-color: rgb(168 85 247 / var(--tw-border-opacity));
}
```

I would not blame you if you had no idea what this selector was doing, and the noise gets amplified by the word wrapping that VS code does. It takes quite a lot of time to precisely figure out which part of this selector is relevant. With my changes the hover would instead show the following:

```css
&[aria-selected=true]:has(+ :not([aria-selected=true]))::before {
  --tw-border-opacity: 1;
  border-color: rgb(168 85 247 / var(--tw-border-opacity));
}
```

I've opted to make this default behaviour as I believe this is the better experience to provide by default.
