### PR TITLE
Show color decorators in split editors

### DIFF
--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.x (Pre-Release)
 
 - Enable Sort Selection on a remote host (#878)
+- Show color decorators in split editors (#888)
 
 ## 0.10.2
 

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -613,9 +613,14 @@ export async function activate(context: ExtensionContext) {
             })
           }
 
-          Window.visibleTextEditors
-            .find((editor) => editor.document === document)
-            ?.setDecorations(
+          let editors = Window.visibleTextEditors.filter(
+            (editor) => editor.document === document
+          )
+
+          // Make sure we show document colors for all visible editors
+          // Not just the first one for a given document
+          editors.forEach((editor) => {
+            editor.setDecorations(
               colorDecorationType,
               nonEditableColors.map(({ range, color }) => ({
                 range,
@@ -628,6 +633,7 @@ export async function activate(context: ExtensionContext) {
                 },
               }))
             )
+          })
 
           return editableColors
         },


### PR DESCRIPTION
When the same document was open in multiple editors we'd only show color decorators in one of them. This PR fixes this by applying the colors to all visible editors for a given document.

Fixes #885