### PR TITLE
Support Astro's `class:list` attribute by default

### DIFF
--- a/packages/tailwindcss-language-server/src/config.ts
+++ b/packages/tailwindcss-language-server/src/config.ts
@@ -13,7 +13,7 @@ function getDefaultSettings(): Settings {
     editor: { tabSize: 2 },
     tailwindCSS: {
       emmetCompletions: false,
-      classAttributes: ['class', 'className', 'ngClass'],
+      classAttributes: ['class', 'className', 'ngClass', 'class:list'],
       codeActions: true,
       hovers: true,
       suggestions: true,

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.x (Pre-Release)
 
 - Fix crash when class regex matches an empty string (#897)
+- Support Astro's `class:list` attribute by default (#890)
 
 ## 0.10.5
 

--- a/packages/vscode-tailwindcss/README.md
+++ b/packages/vscode-tailwindcss/README.md
@@ -88,7 +88,7 @@ Enable completions when using [Emmet](https://emmet.io/)-style syntax, for examp
 
 ### `tailwindCSS.classAttributes`
 
-The HTML attributes for which to provide class completions, hover previews, linting etc. **Default: `class`, `className`, `ngClass`**
+The HTML attributes for which to provide class completions, hover previews, linting etc. **Default: `class`, `className`, `ngClass`, `class:list`**
 
 ### `tailwindCSS.colorDecorators`
 

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -179,7 +179,8 @@
           "default": [
             "class",
             "className",
-            "ngClass"
+            "ngClass",
+            "class:list"
           ],
           "markdownDescription": "The HTML attributes for which to provide class completions, hover previews, linting etc."
         },


### PR DESCRIPTION
In Astro, `class:list={...}` takes an array of class values.

```astro
<!-- This -->
<span class:list={[ 'hello goodbye', { world: true }, [ 'friend' ] ]} />
<!-- Becomes -->
<span class="hello goodbye world friend"></span>
```

https://docs.astro.build/en/reference/directives-reference/#classlist

Including `class:list` in the default `tailwindCSS.classAttributes` should make it more useful!