### PR TITLE
fix: bump `enhanced-resolve` for upstream fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2164,10 +2164,10 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/enhanced-resolve-301": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve-301/-/enhanced-resolve-301-0.0.1.tgz",
-      "integrity": "sha512-g/f3kXka2n15qdlm6ROmbKTumvXmZIbQraY/fNYFrUeMN4slbDWNsCswvpn6LhObdFXAaM/X/ATHUvRWk8+UVg==",
+    "node_modules/enhanced-resolve": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7278,7 +7278,7 @@
         "deepmerge": "4.2.2",
         "dlv": "1.1.3",
         "dset": "3.1.2",
-        "enhanced-resolve-301": "0.0.1",
+        "enhanced-resolve": "^5.15.0",
         "esbuild": "^0.19.5",
         "fast-glob": "3.2.4",
         "find-up": "5.0.0",

--- a/packages/tailwindcss-language-server/ThirdPartyNotices.txt
+++ b/packages/tailwindcss-language-server/ThirdPartyNotices.txt
@@ -614,7 +614,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-enhanced-resolve-301@0.0.1
+enhanced-resolve@5.15.0
 
 Copyright JS Foundation and other contributors
 

--- a/packages/tailwindcss-language-server/package.json
+++ b/packages/tailwindcss-language-server/package.json
@@ -51,7 +51,7 @@
     "deepmerge": "4.2.2",
     "dlv": "1.1.3",
     "dset": "3.1.2",
-    "enhanced-resolve-301": "0.0.1",
+    "enhanced-resolve": "^5.15.0",
     "esbuild": "^0.19.5",
     "fast-glob": "3.2.4",
     "find-up": "5.0.0",

--- a/packages/tailwindcss-language-server/src/util/resolveFrom.ts
+++ b/packages/tailwindcss-language-server/src/util/resolveFrom.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs'
-import { CachedInputFileSystem, ResolverFactory, Resolver, ResolveOptions } from 'enhanced-resolve-301'
+import { CachedInputFileSystem, ResolverFactory, Resolver, ResolveOptions } from 'enhanced-resolve'
 import { equal } from 'tailwindcss-language-service/src/util/array'
 
 let pnpApi: any


### PR DESCRIPTION
EDIT: Sorry, I just noticed https://github.com/webpack/enhanced-resolve/pull/301 still hasn't been merged. In that case there would be a need to rebase enhanced-resolve-301 instead of this.

This pulls in https://github.com/webpack/enhanced-resolve/pull/353.

Otherwise, the following is broken (https://github.com/webpack/enhanced-resolve/issues/352):
```javascript
module.exports = require('@acme/ui/tailwind.config.cjs')
```

where `@acme/ui` has:
```json
"exports": {
  "./*.cjs": "./*.cjs",
},
```

and requires the following workaround
```json
"exports": {
  "./tailwind.config.cjs": "./tailwind.config.cjs",
  "./*.cjs": "./*.cjs",
},
```

Bumping the package fixes this. The `tailwindcss-language-server` code has a comment referencing https://github.com/webpack/enhanced-resolve/issues/282, but that's been fixed upstream so I'm not sure if it's still a blocker for this.