### PR TITLE
Add support for `<script type=“text/babel”>`

### DIFF
--- a/packages/tailwindcss-language-service/src/util/getLanguageBoundaries.ts
+++ b/packages/tailwindcss-language-service/src/util/getLanguageBoundaries.ts
@@ -10,7 +10,7 @@ import { getTextWithoutComments } from './doc'
 import { isCssLanguage } from './css'
 
 export type LanguageBoundary = {
-  type: 'html' | 'js' | 'css' | (string & {});
+  type: 'html' | 'js' | 'jsx' | 'css' | (string & {});
   range: Range
   lang?: string
 }
@@ -22,6 +22,11 @@ let htmlScriptTypes = [
   'text/x-template',
   // https://github.com/tailwindlabs/tailwindcss-intellisense/issues/722
   'text/x-handlebars-template',
+]
+
+let jsxScriptTypes = [
+  // https://github.com/tailwindlabs/tailwindcss-intellisense/issues/906
+  'text/babel',
 ]
 
 let text = { text: { match: /[^]/, lineBreaks: true } }
@@ -190,6 +195,8 @@ export function getLanguageBoundaries(
           boundaries[boundaries.length - 1].type = token.text
         } else if (token.type === 'type' && htmlScriptTypes.includes(token.text)) {
           boundaries[boundaries.length - 1].type = 'html'
+        } else if (token.type === 'type' && jsxScriptTypes.includes(token.text)) {
+          boundaries[boundaries.length - 1].type = 'jsx'
         }
       }
       offset += token.text.length

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix crash when class regex matches an empty string (#897)
 - Support Astro's `class:list` attribute by default (#890)
 - Fix hovers and CSS conflict detection in Vue `<style lang="sass">` blocks (#930)
+- Add support for `<script type="text/babel">` (#932)
 
 ## 0.10.5
 


### PR DESCRIPTION
Requires #930 
Fixes #906

Now in an HTML file (or any HTML "context") a `<script type="text/babel">` block will be treated as containing JSX and can show completions, hovers, etc… rather than just being a block of text that intellisense doesn't know about.