### PR TITLE
Handle `style` exports condition when processing `@import`s

### DIFF
--- a/packages/tailwindcss-language-server/src/project-locator.test.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.test.ts
@@ -81,5 +81,6 @@ testFixture('v4/multi-config', [
 testFixture('v4/workspaces', [
   { config: 'packages/admin/app.css' },
   // { config: 'packages/shared/ui.css' }, // Should this be included?
+  // { config: 'packages/style-export/lib.css' }, // Should this be included?
   { config: 'packages/web/app.css' },
 ])

--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -9,14 +9,13 @@ import { CONFIG_GLOB, CSS_GLOB } from './lib/constants'
 import { readCssFile } from './util/css'
 import { Graph } from './graph'
 import type { Message } from 'postcss'
-import postcss from 'postcss'
-import postcssImport from 'postcss-import'
 import { type DocumentSelector, DocumentSelectorPriority } from './projects'
 import { CacheMap } from './cache-map'
 import { getPackageRoot } from './util/get-package-root'
 import resolveFrom from './util/resolveFrom'
 import { type Feature, supportedFeatures } from '@tailwindcss/language-service/src/features'
 import { pathToFileURL } from 'node:url'
+import { resolveCssImports } from './resolve-css-imports'
 
 export interface ProjectConfig {
   /** The folder that contains the project */
@@ -483,7 +482,6 @@ type ConfigEntry = {
   content: ContentItem[]
 }
 
-let resolveImports = postcss([postcssImport()])
 class FileEntry {
   content: string | null
   deps: Message[] = []
@@ -504,7 +502,7 @@ class FileEntry {
 
   async resolveImports() {
     try {
-      let result = await resolveImports.process(this.content, { from: this.path })
+      let result = await resolveCssImports().process(this.content, { from: this.path })
       this.deps = result.messages.filter((msg) => msg.type === 'dependency')
 
       // Replace the file content with the processed CSS

--- a/packages/tailwindcss-language-server/src/projects.ts
+++ b/packages/tailwindcss-language-server/src/projects.ts
@@ -755,6 +755,7 @@ export async function createProjectService(
         originalConfig = { theme: {} }
       } catch {
         // TODO: Fall back to built-in v4 stuff
+        // TODO: Log errors? It might get noisy as people are editing their CSS though
         enabled = false
         state.enabled = false
         return

--- a/packages/tailwindcss-language-server/src/resolve-css-imports.ts
+++ b/packages/tailwindcss-language-server/src/resolve-css-imports.ts
@@ -4,6 +4,7 @@ import { createResolver } from './util/resolve'
 
 const resolver = createResolver({
   extensions: ['.css'],
+  mainFields: ['style'],
   conditionNames: ['style'],
 })
 

--- a/packages/tailwindcss-language-server/src/resolve-css-imports.ts
+++ b/packages/tailwindcss-language-server/src/resolve-css-imports.ts
@@ -1,7 +1,22 @@
 import postcss from 'postcss'
 import postcssImport from 'postcss-import'
+import { createResolver } from './util/resolve'
 
-const resolveImports = postcss([postcssImport()])
+const resolver = createResolver({
+  extensions: ['.css'],
+  conditionNames: ['style'],
+})
+
+const resolveImports = postcss([
+  postcssImport({
+    resolve(id, basedir) {
+      let paths = resolver.resolveSync({}, basedir, id)
+      return paths
+        ? paths
+        : id
+    },
+  }),
+])
 
 export function resolveCssImports() {
   return resolveImports

--- a/packages/tailwindcss-language-server/src/resolve-css-imports.ts
+++ b/packages/tailwindcss-language-server/src/resolve-css-imports.ts
@@ -1,0 +1,8 @@
+import postcss from 'postcss'
+import postcssImport from 'postcss-import'
+
+const resolveImports = postcss([postcssImport()])
+
+export function resolveCssImports() {
+  return resolveImports
+}

--- a/packages/tailwindcss-language-server/src/util/resolve.ts
+++ b/packages/tailwindcss-language-server/src/util/resolve.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs'
+import {
+  CachedInputFileSystem,
+  ResolverFactory,
+  Resolver,
+  ResolveOptions,
+} from 'enhanced-resolve-301'
+
+export function createResolver(options: Partial<ResolveOptions> = {}): Resolver {
+  return ResolverFactory.createResolver({
+    fileSystem: new CachedInputFileSystem(fs, 4000),
+    useSyncFileSystemCalls: true,
+    conditionNames: ['node', 'require'],
+    ...options,
+  })
+}

--- a/packages/tailwindcss-language-server/src/util/resolveFrom.ts
+++ b/packages/tailwindcss-language-server/src/util/resolveFrom.ts
@@ -1,32 +1,18 @@
-import * as fs from 'fs'
-import {
-  CachedInputFileSystem,
-  ResolverFactory,
-  Resolver,
-  ResolveOptions,
-} from 'enhanced-resolve-301'
 import { equal } from '@tailwindcss/language-service/src/util/array'
+import { createResolver } from './resolve'
 
 let pnpApi: any
 let extensions = Object.keys(require.extensions)
 
-function createResolver(options: Partial<ResolveOptions> = {}): Resolver {
-  return ResolverFactory.createResolver({
-    fileSystem: new CachedInputFileSystem(fs, 4000),
-    useSyncFileSystemCalls: true,
-    // cachePredicate: () => false,
-    conditionNames: ['node', 'require'],
-    extensions,
-    pnpApi,
-    ...options,
-  })
+function recreateResolver() {
+  return createResolver({ extensions, pnpApi })
 }
 
-let resolver = createResolver()
+let resolver = recreateResolver()
 
 export function setPnpApi(newPnpApi: any): void {
   pnpApi = newPnpApi
-  resolver = createResolver()
+  resolver = recreateResolver()
 }
 
 export default function resolveFrom(from?: string, id?: string): string {
@@ -35,7 +21,7 @@ export default function resolveFrom(from?: string, id?: string): string {
   let newExtensions = Object.keys(require.extensions)
   if (!equal(newExtensions, extensions)) {
     extensions = newExtensions
-    resolver = createResolver()
+    resolver = recreateResolver()
   }
 
   let result = resolver.resolveSync({}, from, id)

--- a/packages/tailwindcss-language-server/src/util/v4/design-system.ts
+++ b/packages/tailwindcss-language-server/src/util/v4/design-system.ts
@@ -1,9 +1,7 @@
 import type { DesignSystem } from '@tailwindcss/language-service/src/util/v4'
 
 import postcss from 'postcss'
-import postcssImport from 'postcss-import'
-
-const resolveImports = postcss([postcssImport()])
+import { resolveCssImports } from '../../resolve-css-imports'
 
 const HAS_V4_IMPORT = /@import\s*(?:'tailwindcss'|"tailwindcss")/
 const HAS_V4_THEME = /@theme\s*\{/
@@ -36,7 +34,7 @@ export async function loadDesignSystem(
   // Step 2: Use postcss to resolve `@import` rules in the CSS file
   // TODO: What if someone is actively editing their config and introduces a syntax error?
   // We don't want to necessarily throw away the knowledge that we have a v4 project.
-  let resolved = await resolveImports.process(css, { from: filepath })
+  let resolved = await resolveCssImports().process(css, { from: filepath })
 
   // Step 3: Take the resolved CSS and pass it to v4's `loadDesignSystem`
   let design = tailwindcss.__unstable__loadDesignSystem(resolved.css) as DesignSystem

--- a/packages/tailwindcss-language-server/tests/common.ts
+++ b/packages/tailwindcss-language-server/tests/common.ts
@@ -201,6 +201,8 @@ async function init(fixture: string): Promise<FixtureContext> {
         },
       } as DidOpenTextDocumentParams)
 
+      // If opening a document stalls then it's probably because this promise is not being resolved
+      // This can happen if a document is not covered by one of the selectors because of it's URI
       await initPromise
 
       return {

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -553,3 +553,26 @@ withFixture('v4/basic', (c) => {
     })
   })
 })
+
+withFixture('v4/workspaces', (c) => {
+  let completion = buildCompletion(c)
+
+  test('@import resolution supports exports.style', async ({ expect }) => {
+    let result = await completion({
+      dir: 'packages/web',
+      lang: 'html',
+      text: '<div class=""></div>',
+      position: { line: 0, character: 12 },
+    })
+
+    let item = result.items.find((item) => item.label === 'bg-beet')
+
+    let resolved = await c.sendRequest('completionItem/resolve', item)
+
+    expect(resolved).toEqual({
+      ...item,
+      detail: 'background-color: #8e3b46;',
+      documentation: '#8e3b46',
+    })
+  })
+})

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -568,6 +568,7 @@ withFixture('v4/workspaces', (c) => {
     let items = [
       result.items.find((item) => item.label === 'bg-beet'),
       result.items.find((item) => item.label === 'bg-orangepeel'),
+      result.items.find((item) => item.label === 'bg-style-main'),
     ]
 
     let resolved = await Promise.all(items.map((item) => c.sendRequest('completionItem/resolve', item)))
@@ -582,6 +583,12 @@ withFixture('v4/workspaces', (c) => {
       ...items[1],
       detail: 'background-color: #ff9f00;',
       documentation: '#ff9f00',
+    })
+
+    expect(resolved[2]).toEqual({
+      ...items[2],
+      detail: 'background-color: #8e3b46;',
+      documentation: '#8e3b46',
     })
   })
 })

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -10,8 +10,9 @@ function buildCompletion(c) {
       triggerKind: 1,
     },
     settings,
+    dir = '',
   }) {
-    let textDocument = await c.openDocument({ text, lang, settings })
+    let textDocument = await c.openDocument({ text, lang, settings, dir })
 
     return c.sendRequest('textDocument/completion', {
       textDocument,

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -565,14 +565,24 @@ withFixture('v4/workspaces', (c) => {
       position: { line: 0, character: 12 },
     })
 
-    let item = result.items.find((item) => item.label === 'bg-beet')
+    let item1 = result.items.find((item) => item.label === 'bg-beet')
 
-    let resolved = await c.sendRequest('completionItem/resolve', item)
+    let resolved1 = await c.sendRequest('completionItem/resolve', item1)
 
-    expect(resolved).toEqual({
-      ...item,
+    expect(resolved1).toEqual({
+      ...item1,
       detail: 'background-color: #8e3b46;',
       documentation: '#8e3b46',
+    })
+
+    let item2 = result.items.find((item) => item.label === 'bg-orangepeel')
+
+    let resolved2 = await c.sendRequest('completionItem/resolve', item2)
+
+    expect(resolved2).toEqual({
+      ...item2,
+      detail: 'background-color: #ff9f00;',
+      documentation: '#ff9f00',
     })
   })
 })

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -565,22 +565,21 @@ withFixture('v4/workspaces', (c) => {
       position: { line: 0, character: 12 },
     })
 
-    let item1 = result.items.find((item) => item.label === 'bg-beet')
+    let items = [
+      result.items.find((item) => item.label === 'bg-beet'),
+      result.items.find((item) => item.label === 'bg-orangepeel'),
+    ]
 
-    let resolved1 = await c.sendRequest('completionItem/resolve', item1)
+    let resolved = await Promise.all(items.map((item) => c.sendRequest('completionItem/resolve', item)))
 
-    expect(resolved1).toEqual({
-      ...item1,
+    expect(resolved[0]).toEqual({
+      ...items[0],
       detail: 'background-color: #8e3b46;',
       documentation: '#8e3b46',
     })
 
-    let item2 = result.items.find((item) => item.label === 'bg-orangepeel')
-
-    let resolved2 = await c.sendRequest('completionItem/resolve', item2)
-
-    expect(resolved2).toEqual({
-      ...item2,
+    expect(resolved[1]).toEqual({
+      ...items[1],
       detail: 'background-color: #ff9f00;',
       documentation: '#ff9f00',
     })

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
@@ -19,6 +19,10 @@
       "resolved": "packages/shared",
       "link": true
     },
+    "node_modules/@private/style-export": {
+      "resolved": "packages/style-export",
+      "link": true
+    },
     "node_modules/@private/web": {
       "resolved": "packages/web",
       "link": true
@@ -33,6 +37,9 @@
     },
     "packages/shared": {
       "name": "@private/shared"
+    },
+    "packages/style-export": {
+      "name": "@private/style-export"
     },
     "packages/web": {
       "name": "@private/web"

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
@@ -23,6 +23,10 @@
       "resolved": "packages/style-export",
       "link": true
     },
+    "node_modules/@private/style-main-field": {
+      "resolved": "packages/style-main-field",
+      "link": true
+    },
     "node_modules/@private/web": {
       "resolved": "packages/web",
       "link": true
@@ -41,6 +45,7 @@
     "packages/style-export": {
       "name": "@private/style-export"
     },
+    "packages/style-main-field": {},
     "packages/web": {
       "name": "@private/web"
     }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/lib.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/lib.css
@@ -1,0 +1,3 @@
+@theme {
+    --color-beet: #8e3b46;
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/package.json
@@ -3,6 +3,7 @@
   "exports": {
     ".": {
       "style": "./lib.css"
-    }
+    },
+    "./theme": "./theme.css"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@private/style-export",
+  "exports": {
+    ".": {
+      "style": "./lib.css"
+    }
+  }
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/theme.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-export/theme.css
@@ -1,0 +1,3 @@
+@theme {
+    --color-orangepeel: #ff9f00;
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-main-field/lib.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-main-field/lib.css
@@ -1,0 +1,3 @@
+@theme {
+    --color-style-main: #8e3b46;
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-main-field/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/style-main-field/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@private/style-main-field",
+  "style": "./lib.css"
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/web/app.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/web/app.css
@@ -2,6 +2,7 @@
 @import '@private/shared/ui.css';
 @import '@private/style-export';
 @import '@private/style-export/theme';
+@import '@private/style-main-field';
 
 @theme {
   --color-potato: #907a70;

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/web/app.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/web/app.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import '@private/shared/ui.css';
 @import '@private/style-export';
+@import '@private/style-export/theme';
 
 @theme {
   --color-potato: #907a70;

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/web/app.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/packages/web/app.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 @import '@private/shared/ui.css';
+@import '@private/style-export';
+
 @theme {
   --color-potato: #907a70;
 }

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix hovers and CSS conflict detection in Vue `<style lang="sass">` blocks (#930)
 - Add support for `<script type="text/babel">` (#932)
 - Show pixel equivalents in completions and hovers of the theme() helper (#935)
+- Handle `style` exports condition when processing `@import`s (#934)
 
 ## 0.10.5
 


### PR DESCRIPTION
If you `@import "some-package"` we weren't handling the `style` export condition. This isn't handled by `postcss-import` (it doesn't support reading from `exports` at all because the `resolve` package doesn't). So here we pass a custom `resolve()` function to handle this situation.

Fixes #933
