### PR TITLE
Highlight `@theme` contents as a rule list

### DIFF
--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add support for `<script type="text/babel">` (#932)
 - Show pixel equivalents in completions and hovers of the theme() helper (#935)
 - Handle `style` exports condition when processing `@import`s (#934)
+- Highlight `@theme` contents as a rule list (#937)
 
 ## 0.10.5
 

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -125,6 +125,23 @@
       ]
     },
     {
+      "begin": "(?i)((@)theme)(?=[\\s{]|/\\*|$)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.at-rule.theme.tailwind"
+        },
+        "2": {
+          "name": "punctuation.definition.keyword.css"
+        }
+      },
+      "end": "(?<=}|;)(?!\\G)",
+      "patterns": [
+        {
+          "include": "source.css#rule-list"
+        }
+      ]
+    },
+    {
       "begin": "(?i)((@)variants)(?=[\\s{]|/\\*|$)",
       "beginCaptures": {
         "1": {


### PR DESCRIPTION
Fixes #920

Before:
<img width="474" alt="@theme with --animate-spin property where the value is not differentiated from the property name." src="https://github.com/tailwindlabs/tailwindcss-intellisense/assets/614993/65036d08-85b0-4724-b775-a45f2921b2c7">

After:
<img width="495" alt="@theme with --animate-spin property where the value is differentiated from the property name and has individual parts highlighted properly." src="https://github.com/tailwindlabs/tailwindcss-intellisense/assets/614993/1ca4fbb9-09cf-4c38-b252-d4be52c27158">
