### PR TITLE
Fix errors thrown by detecting content files with oxide (#942)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -725,6 +725,187 @@
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-lm7JE4JekG0tFgXSyBs4o3zhYA87hPxuYLzzPRQeTI72fJiCZmi6WbeTxzsaC0l3WI/o9U4pXoNRyeYSfsqdHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.11",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.11"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-qi19QzHktzkxv/IOtmW+gK3QW0ZAPvGZQsl/wGC4AmX50sONitNcVPQ9gVSnlJieoYc90jEo5qAHToBai8Af1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-Euk0uCWQq9HdMTK3p19JEvZj19jqj2XUapGnZUpUJC9OAcdfpgtNRcvkeDgYR5u+dyMt+V/2d5hF8CHYP6/cNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-Fp2DPc+W08u6iCBc2YzmZEnNq9PwsE+cFIpSem9fixHeevk0DnUBz/qE+qvBcJ7gqKrMN2qscLtUzqI2TFj11Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-ff52UF8Xp4osa7+klJ6Jkub34y3PzaR/ncuu5gWZHz2HbEy9+NzNAbL5k9If/UlOWhXpj1xYxe0NMhD9swdSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-2o//pMgEMXm+93dUTwiBZtj2il742tsYq9qPdgGoD4BKlhL/+mkotUZ/R9NA27bgCdvZb1yK96Nh/cbzTqRsvw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-qWx/C8NZpABS7VnXPsGkLP3OnJiz0buAgIisPJ+fdgRRLaX9pYrtJdd0a8ZG+Z8LawGsEGUGATGUwPGhpBH9EQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-lMPzrRALtI702kipt1pbRkTLNuRqcbYYM4Z8eX3Ld83jA3qBHuykSV1e1JUFzX+YNpIOi97fG3REQg3Oo2sycA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-XfJ3R9hgxf4pY2y6nedQQ9rvZrn5xsusmbCVJtvRLlBNjDHXucZxa6GAT9bbDTyqARLm5nN7QqJOef3Bi56uVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-N96utHhVp199QRvBtXx2D2CkUcfgWVPfXCUHQIa+zEn+b3I0PtkBOerRe08QdIP/iSeQZTWoxvrDB4JUFO8PtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-uBKEb0TI2JIJbKFIfaMtKrqbfGMvD/mb/plDHAauxu3zk19Ew+mrnju+JvTc1YuZt0/s8bFyV1hltBpPG8d5Zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.7.tgz",
@@ -7420,6 +7601,7 @@
         "@tailwindcss/forms": "0.5.3",
         "@tailwindcss/language-service": "*",
         "@tailwindcss/line-clamp": "0.4.2",
+        "@tailwindcss/oxide": "^4.0.0-alpha.11",
         "@tailwindcss/typography": "0.5.7",
         "@types/color-name": "^1.1.3",
         "@types/culori": "^2.1.0",

--- a/packages/tailwindcss-language-server/package.json
+++ b/packages/tailwindcss-language-server/package.json
@@ -39,6 +39,7 @@
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/language-service": "*",
     "@tailwindcss/line-clamp": "0.4.2",
+    "@tailwindcss/oxide": "^4.0.0-alpha.11",
     "@tailwindcss/typography": "0.5.7",
     "@types/color-name": "^1.1.3",
     "@types/culori": "^2.1.0",

--- a/packages/tailwindcss-language-server/src/project-locator.test.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.test.ts
@@ -29,6 +29,16 @@ function testFixture(fixture: string, details: any[]) {
       let configPath = path.relative(fixturePath, project.config.path)
 
       expect(configPath).toEqual(detail?.config)
+
+      if (detail?.content) {
+        let expected = detail?.content.map((path) => path.replace('{URL}', fixturePath))
+
+        let actual = project.documentSelector
+          .filter((selector) => selector.priority === 1 /** content */)
+          .map((selector) => selector.pattern)
+
+        expect(actual).toEqual(expected)
+      }
     }
 
     expect(projects).toHaveLength(details.length)
@@ -83,4 +93,17 @@ testFixture('v4/workspaces', [
   // { config: 'packages/shared/ui.css' }, // Should this be included?
   // { config: 'packages/style-export/lib.css' }, // Should this be included?
   { config: 'packages/web/app.css' },
+])
+
+testFixture('v4/auto-content', [
+  //
+  {
+    config: 'src/app.css',
+    content: [
+      '{URL}/package.json',
+      '{URL}/src/index.html',
+      '{URL}/src/components/example.html',
+      '{URL}/src/**/*.{py,tpl,js,vue,php,mjs,cts,jsx,tsx,rhtml,slim,handlebars,twig,rs,njk,svelte,liquid,pug,md,ts,heex,mts,astro,nunjucks,rb,eex,haml,cjs,html,hbs,jade,aspx,razor,erb,mustache,mdx}',
+    ],
+  },
 ])

--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -303,14 +303,6 @@ export class ProjectLocator {
     // Create a graph of all the CSS files that might (indirectly) use Tailwind
     let graph = new Graph<FileEntry>()
 
-    // We flatten the index file on publish so there are no imports that
-    // need to be resolved. But this messes with our graph traversal, so
-    // we need to manually connect the index file to the theme and utilities
-    // files so we do not get extra roots in the graph.
-    // - node_modules/tailwindcss/index.css
-    // -> node_modules/tailwindcss/theme.css
-    // -> node_modules/tailwindcss/utilities.css
-
     let indexPath: string | null = null
     let themePath: string | null = null
     let utilitiesPath: string | null = null
@@ -336,6 +328,14 @@ export class ProjectLocator {
         utilitiesPath = file.path
       }
     }
+
+    // We flatten the index file on publish so there are no imports that
+    // need to be resolved. But this messes with our graph traversal, so
+    // we need to manually connect the index file to the theme and utilities
+    // files so we do not get extra roots in the graph.
+    // - node_modules/tailwindcss/index.css
+    // -> node_modules/tailwindcss/theme.css
+    // -> node_modules/tailwindcss/utilities.css
 
     if (indexPath && themePath) graph.connect(indexPath, themePath)
     if (indexPath && utilitiesPath) graph.connect(indexPath, utilitiesPath)

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -310,8 +310,8 @@ withFixture('v4/basic', (c) => {
     let result = await completion({ lang, text, position, settings })
     let textEdit = expect.objectContaining({ range: { start: position, end: position } })
 
-    expect(result.items.length).toBe(12106)
-    expect(result.items.filter((item) => item.label.endsWith(':')).length).toBe(215)
+    expect(result.items.length).toBe(12312)
+    expect(result.items.filter((item) => item.label.endsWith(':')).length).toBe(216)
     expect(result).toEqual({
       isIncomplete: false,
       items: expect.arrayContaining([
@@ -522,11 +522,12 @@ withFixture('v4/basic', (c) => {
 
     expect(resolved).toEqual({
       ...item,
-      detail: 'font-size: 0.875rem /* 8.75px */; line-height: 1.25rem /* 12.5px */;',
+      detail:
+        'font-size: var(--font-size-sm, 0.875rem /* 8.75px */); line-height: var(--font-size-sm--line-height, 1.25rem /* 12.5px */);',
       documentation: {
         kind: 'markdown',
         value:
-          '```css\n.text-sm {\n  font-size: 0.875rem /* 8.75px */;\n  line-height: 1.25rem /* 12.5px */;\n}\n```',
+          '```css\n.text-sm {\n  font-size: var(--font-size-sm, 0.875rem /* 8.75px */);\n  line-height: var(--font-size-sm--line-height, 1.25rem /* 12.5px */);\n}\n```',
       },
     })
   })
@@ -548,7 +549,7 @@ withFixture('v4/basic', (c) => {
 
     expect(resolved).toEqual({
       ...item,
-      detail: 'background-color: #ef4444;',
+      detail: 'background-color: var(--color-red-500, #ef4444);',
       documentation: '#ef4444',
     })
   })
@@ -577,19 +578,19 @@ withFixture('v4/workspaces', (c) => {
 
     expect(resolved[0]).toEqual({
       ...items[0],
-      detail: 'background-color: #8e3b46;',
+      detail: 'background-color: var(--color-beet, #8e3b46);',
       documentation: '#8e3b46',
     })
 
     expect(resolved[1]).toEqual({
       ...items[1],
-      detail: 'background-color: #ff9f00;',
+      detail: 'background-color: var(--color-orangepeel, #ff9f00);',
       documentation: '#ff9f00',
     })
 
     expect(resolved[2]).toEqual({
       ...items[2],
-      detail: 'background-color: #8e3b46;',
+      detail: 'background-color: var(--color-style-main, #8e3b46);',
       documentation: '#8e3b46',
     })
   })

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package-lock.json
@@ -1,0 +1,188 @@
+{
+  "name": "auto-content",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@tailwindcss/oxide": "4.0.0-alpha.9",
+        "tailwindcss": "4.0.0-alpha.9"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-TXuxyOODFpv9fEP7vA6J1fDMUxb2s/HZ1LFTerqy6Qt1OLHnhHvPya9SPs7ne8WIOJjShzpccaAAsHNgu7lquw==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.9",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.9"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-cOMgHx9VaNRHcDG5oZFK1Smrgz76chXK44LfE5bJiimyqYhHIK5WWDVAsnN5cWEefusNIhBaYfEQ216NDV+Wew==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-QbPvLqibYnzRqMPGlJqMauPx/a5XU23RSfsff4S8qm7NEOCWlmVuPgkvpLgvRmACJmwvrkPfHpqW4SUlzSXlZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-f+Gj1NH5TcbrhUtyMEz+c2H75m/YSgnYUPEaRZaq3I2eaNYcIU6WhW2kYqIkSn1LBOV2DKP7sDRGhQBplUyT9w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-oIIJyQHOJGc5WBVoVCTCUPissQisp+k0mjoeEpv87J4dYQ9Z7+IWTTbITEEh+6n3jJpPfh0oqVkB7R4nlC16mw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-8KVsIsdkP1lWEAqsgEnFeI07GkZ/dLOkYjnE15EPN8WcJga8KgSrxqSfIEdUb5r4X30XkpX9Ds//GfxkJNagaw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-JMSWrZI93LkHzHnTG3Jum8Bi59cFewAsACNJMKryGT66dAx/Off10Jguz1n63QfTqTKOcilVcwwzW5EakTSQXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-3cISi3NuNFYJB2OouiQHraW9rzL/1Q3WfdQ763Dmw0Qfm50PeYRRlc3sphQSNBs4qwyzvqbf3F6IXBOp/0nMrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-v4i0FG9haj4/8ptAJw94U7rRcgd6jAz6alnmFYZShPfYGjZDe7ylmmpLMfT+yCLh/j84piy2ur+YqG4fCi34wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-zta659O1azAoNuEbqF9vwR/R3zSNsOaylRlvAmL8ntbvmxIr7pHrZun2i8SFc5AhCfOKJOX4/3JiSb9CNSGaxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-TdbzzLSoFaIZjUDuHmY8+ma8pSDqXXTOjfMGfg2+aeOTJopNGa5olSp7nG9NlsLJXOe0gLWlKzrqRWvZUcH/lA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.9.tgz",
+      "integrity": "sha512-y0fM8FgMWyc/gbzd3Ag3TmNtXSwIC9gLIe7J1g8/KzkApL0UFPYt/T/Z29CbvTYVlPEf/QOSNsGM63qeip9jzw=="
+    }
+  }
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package-lock.json
@@ -5,34 +5,34 @@
   "packages": {
     "": {
       "dependencies": {
-        "@tailwindcss/oxide": "4.0.0-alpha.9",
-        "tailwindcss": "4.0.0-alpha.9"
+        "@tailwindcss/oxide": "^4.0.0-alpha.12",
+        "tailwindcss": "^4.0.0-alpha.12"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-TXuxyOODFpv9fEP7vA6J1fDMUxb2s/HZ1LFTerqy6Qt1OLHnhHvPya9SPs7ne8WIOJjShzpccaAAsHNgu7lquw==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-+6RkjElcptAtqHrX9cEgJB66oUJ1LFEIK3DwFmbXUGaNehjVvZj6NLUVo2+ktlSH5O1i4Uc3pud2PW66MWUPAg==",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.9",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.9"
+        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.12",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.12"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-cOMgHx9VaNRHcDG5oZFK1Smrgz76chXK44LfE5bJiimyqYhHIK5WWDVAsnN5cWEefusNIhBaYfEQ216NDV+Wew==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-/tkfEfdnviM8COURaRxfKhOcdy1SHWR792/HzzLqqdQOAnsi860Hxn/8kA1SfU+D+pw5aGs4WOEp988JXKZMpw==",
       "cpu": [
         "arm64"
       ],
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-QbPvLqibYnzRqMPGlJqMauPx/a5XU23RSfsff4S8qm7NEOCWlmVuPgkvpLgvRmACJmwvrkPfHpqW4SUlzSXlZQ==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-7JCKQs7EZSJG5bhoggT0UkZm+xHT8CEw33+2/rlOAbMZgTBYcObe8ljPwLHsno21D5kriQ7e31UWBpYSq2OOEQ==",
       "cpu": [
         "arm64"
       ],
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-f+Gj1NH5TcbrhUtyMEz+c2H75m/YSgnYUPEaRZaq3I2eaNYcIU6WhW2kYqIkSn1LBOV2DKP7sDRGhQBplUyT9w==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-2lIr+lRRPNOd6rm6PaC0M5YXfq/t1daknU6IHMgBPXB9nR1ubxJH47gYtOAmlDY8jSKeiFXXbU7uSiGPjVt/wg==",
       "cpu": [
         "x64"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-oIIJyQHOJGc5WBVoVCTCUPissQisp+k0mjoeEpv87J4dYQ9Z7+IWTTbITEEh+6n3jJpPfh0oqVkB7R4nlC16mw==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-czVoVzOE5+fZXtcUF650u0ZQPKuJvjN3ZgM1m5ww2kM7NK9Yh01lJcY5wsD3anX18jz4a9T9s/JQh7HGWwThCg==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-8KVsIsdkP1lWEAqsgEnFeI07GkZ/dLOkYjnE15EPN8WcJga8KgSrxqSfIEdUb5r4X30XkpX9Ds//GfxkJNagaw==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-Cnz3dNW1jfdaDiCQGTsTDIF/qBxFm+99+97U2pkoPCmTsPiiLprRwsF8IBKr0aMoosRQzsRWFimh4e+3IK9eXQ==",
       "cpu": [
         "arm"
       ],
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-JMSWrZI93LkHzHnTG3Jum8Bi59cFewAsACNJMKryGT66dAx/Off10Jguz1n63QfTqTKOcilVcwwzW5EakTSQXQ==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-eJRVRGrTLXSdU/jDRcyTNbgUBW5Qbqy15gFioGac/Jr2T8Y3AH5jsaZoWlgaw2NcJ0389OW+r4+C39amWKkbRA==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-3cISi3NuNFYJB2OouiQHraW9rzL/1Q3WfdQ763Dmw0Qfm50PeYRRlc3sphQSNBs4qwyzvqbf3F6IXBOp/0nMrQ==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-6mNcy53T1cSScPFBDEUbkfuC5r63ts48lAuF69T2uBZ9AM6ehNY10Bfy2AS0nEdV9L02hMpA52zuJfkteiFbsQ==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-v4i0FG9haj4/8ptAJw94U7rRcgd6jAz6alnmFYZShPfYGjZDe7ylmmpLMfT+yCLh/j84piy2ur+YqG4fCi34wQ==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-4H5zJitpU3aNGQy164RKDckeGaV3ZU6oqrntc4pGaTMbAOjwWCXto5QBqimpfuzJVHMiUt80BK82luYoGpiwLg==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-zta659O1azAoNuEbqF9vwR/R3zSNsOaylRlvAmL8ntbvmxIr7pHrZun2i8SFc5AhCfOKJOX4/3JiSb9CNSGaxQ==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-nfWooi5sZ26ZIA9aO+yquevIlKTPmlZueD7qWU6x5CWyhmUW8DSTQYXhw+daffWWJg3caqtBWx1PdX+V7o5l4A==",
       "cpu": [
         "x64"
       ],
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-TdbzzLSoFaIZjUDuHmY8+ma8pSDqXXTOjfMGfg2+aeOTJopNGa5olSp7nG9NlsLJXOe0gLWlKzrqRWvZUcH/lA==",
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-u8M3KVyAxd9BtzC+ATrCzfvEP5eQXOG0U5S3zo+CUob62GG1LNBZs9bEJfrah9Aa0SGUFbTGatpguTePrnKFPg==",
       "cpu": [
         "x64"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-y0fM8FgMWyc/gbzd3Ag3TmNtXSwIC9gLIe7J1g8/KzkApL0UFPYt/T/Z29CbvTYVlPEf/QOSNsGM63qeip9jzw=="
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-ogYUtw4cs5z20eKU8S0YxlYeWgnZObl9BmOED0IAvKuECxPaEt9Expdghi7Hsvy+0ibHkeH/6dyZqzQBO/E4Bg=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "tailwindcss": "4.0.0-alpha.9",
+    "@tailwindcss/oxide": "4.0.0-alpha.9"
+  }
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "tailwindcss": "4.0.0-alpha.9",
-    "@tailwindcss/oxide": "4.0.0-alpha.9"
+    "tailwindcss": "^4.0.0-alpha.12",
+    "@tailwindcss/oxide": "^4.0.0-alpha.12"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/src/app.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/src/app.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/src/components/example.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/src/components/example.html
@@ -1,0 +1,1 @@
+<div class="underline">Test</div>

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/src/index.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/src/index.html
@@ -1,0 +1,1 @@
+<div class="flex">Test</div>

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.9"
+        "tailwindcss": "^4.0.0-alpha.12"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-y0fM8FgMWyc/gbzd3Ag3TmNtXSwIC9gLIe7J1g8/KzkApL0UFPYt/T/Z29CbvTYVlPEf/QOSNsGM63qeip9jzw=="
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-ogYUtw4cs5z20eKU8S0YxlYeWgnZObl9BmOED0IAvKuECxPaEt9Expdghi7Hsvy+0ibHkeH/6dyZqzQBO/E4Bg=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.9"
+    "tailwindcss": "^4.0.0-alpha.12"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.9"
+        "tailwindcss": "^4.0.0-alpha.12"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-y0fM8FgMWyc/gbzd3Ag3TmNtXSwIC9gLIe7J1g8/KzkApL0UFPYt/T/Z29CbvTYVlPEf/QOSNsGM63qeip9jzw=="
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-ogYUtw4cs5z20eKU8S0YxlYeWgnZObl9BmOED0IAvKuECxPaEt9Expdghi7Hsvy+0ibHkeH/6dyZqzQBO/E4Bg=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.9"
+    "tailwindcss": "^4.0.0-alpha.12"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
@@ -8,7 +8,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.9"
+        "tailwindcss": "^4.0.0-alpha.12"
       }
     },
     "node_modules/@private/admin": {
@@ -32,9 +32,9 @@
       "link": true
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.9.tgz",
-      "integrity": "sha512-y0fM8FgMWyc/gbzd3Ag3TmNtXSwIC9gLIe7J1g8/KzkApL0UFPYt/T/Z29CbvTYVlPEf/QOSNsGM63qeip9jzw=="
+      "version": "4.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.12.tgz",
+      "integrity": "sha512-ogYUtw4cs5z20eKU8S0YxlYeWgnZObl9BmOED0IAvKuECxPaEt9Expdghi7Hsvy+0ibHkeH/6dyZqzQBO/E4Bg=="
     },
     "packages/admin": {
       "name": "@private/admin"
@@ -45,7 +45,9 @@
     "packages/style-export": {
       "name": "@private/style-export"
     },
-    "packages/style-main-field": {},
+    "packages/style-main-field": {
+      "name": "@private/style-main-field"
+    },
     "packages/web": {
       "name": "@private/web"
     }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package.json
@@ -1,8 +1,6 @@
 {
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.9"
+    "tailwindcss": "^4.0.0-alpha.12"
   }
 }

--- a/packages/tailwindcss-language-server/tests/hover/hover.test.js
+++ b/packages/tailwindcss-language-server/tests/hover/hover.test.js
@@ -190,7 +190,7 @@ withFixture('v4/basic', (c) => {
   testHover('hover', {
     text: '<div class="bg-red-500">',
     position: { line: 0, character: 13 },
-    expected: '.bg-red-500 {\n  background-color: #ef4444;\n}',
+    expected: '.bg-red-500 {\n  background-color: var(--color-red-500, #ef4444);\n}',
     expectedRange: {
       start: { line: 0, character: 12 },
       end: { line: 0, character: 22 },


### PR DESCRIPTION
I had the same problem as described in #942, which seem to have been closed preemptively 🙂 By adding oxide as a devDependency and then checking the import with a type guard we get an error that explains the issue:

<img width="624" alt="Screenshot 2024-04-03 at 21 43 10" src="https://github.com/tailwindlabs/tailwindcss-intellisense/assets/3395492/0b785939-ddb1-45a3-8000-60b53f1b8d74">

So by ignoring the globs when creating the DocumentSelectors, `normalizePath` no longer throws and the server starts up properly in a fresh v4 setup 👍 