### PR TITLE
feat: add VS Code configuration defaults

### DIFF
--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -323,6 +323,14 @@
           "markdownDescription": "Enable the Node.js inspector agent for the language server and listen on the specified port."
         }
       }
+    },
+    "configurationDefaults": {
+      "files.associations": {
+        "*.css": "tailwindcss"
+      },
+      "editor.quickSuggestions": {
+        "strings": "on"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
The [recommended VS code settings](https://github.com/tailwindlabs/tailwindcss-intellisense#recommended-vs-code-settings) can be provided by default when the extension is installed using the [configuration defaults](https://code.visualstudio.com/api/references/contribution-points#contributes.configurationDefaults) contribution point in the extension `package.json`. This would mean less setup for users who install the extension and benefits people who may have missed reading the README first (sadly I was one of those people).