### PR TITLE
Don't break when generating rules produces an error

### DIFF
--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -19,26 +19,14 @@ import { Utils, URI } from 'vscode-uri'
 import { getLanguageModelCache } from './languageModelCache'
 import { Stylesheet } from 'vscode-css-languageservice'
 import dlv from 'dlv'
+import { interceptLogs } from '../util/logs'
 
 let connection = createConnection(ProposedFeatures.all)
 
-console.log = connection.console.log.bind(connection.console)
-console.error = connection.console.error.bind(connection.console)
-
-function formatError(message: string, err: any): string {
-  if (err instanceof Error) {
-    let error = <Error>err
-    return `${message}: ${error.message}\n${error.stack}`
-  } else if (typeof err === 'string') {
-    return `${message}: ${err}`
-  } else if (err) {
-    return `${message}: ${err.toString()}`
-  }
-  return message
-}
+interceptLogs(console, connection)
 
 process.on('unhandledRejection', (e: any) => {
-  connection.console.error(formatError(`Unhandled exception`, e))
+  console.error("Unhandled exception", e)
 })
 
 let documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument)

--- a/packages/tailwindcss-language-server/src/server.ts
+++ b/packages/tailwindcss-language-server/src/server.ts
@@ -1,9 +1,9 @@
 import './lib/env'
 import { createConnection } from 'vscode-languageserver/node'
-import { formatError } from './util/error'
 // @ts-ignore
 import preflight from 'tailwindcss/lib/css/preflight.css'
 import { TW } from './tw'
+import { interceptLogs } from './util/logs'
 
 // @ts-ignore
 // new Function(…) is used to work around issues with esbuild
@@ -25,11 +25,10 @@ new Function(
 const connection =
   process.argv.length <= 2 ? createConnection(process.stdin, process.stdout) : createConnection()
 
-console.log = connection.console.log.bind(connection.console)
-console.error = connection.console.error.bind(connection.console)
+interceptLogs(console, connection)
 
 process.on('unhandledRejection', (e: any) => {
-  connection.console.error(formatError(`Unhandled exception`, e))
+  console.error(`Unhandled rejection`, e)
 })
 
 const tw = new TW(connection)

--- a/packages/tailwindcss-language-server/src/util/logs.ts
+++ b/packages/tailwindcss-language-server/src/util/logs.ts
@@ -1,0 +1,14 @@
+import type { Connection } from 'vscode-languageserver'
+import { format } from 'node:util'
+
+function formatForLogging(params: any[]): string {
+  return params.map((item) => format(item)).join(' ')
+}
+
+export function interceptLogs(console: Console, connection: Connection) {
+  console.debug = (...params: any[]) => connection.console.info(formatForLogging(params))
+  console.error = (...params: any[]) => connection.console.error(formatForLogging(params))
+  console.warn = (...params: any[]) => connection.console.warn(formatForLogging(params))
+  console.info = (...params: any[]) => connection.console.info(formatForLogging(params))
+  console.log = (...params: any[]) => connection.console.log(formatForLogging(params))
+}

--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -167,7 +167,16 @@ export function getColor(state: State, className: string): culori.Color | Keywor
       }
     }
 
-    let { root, rules } = jit.generateRules(state, [className])
+    let result!: ReturnType<typeof jit.generateRules>
+    try {
+      result = jit.generateRules(state, [className])
+    } catch (err) {
+      console.error(`Error generating rules for className: ${className}`)
+      console.error(err)
+      return null
+    }
+
+    let { root, rules } = result
     if (rules.length === 0) return null
 
     let decls: Record<string, string | string[]> = {}


### PR DESCRIPTION
Fixes #953

If `matchUtilities` generates an error we were completely failing during the initialization process and intellisense was basically doing nothing. This is not good. We can at least try to recover here and keep providing suggestions — even if some of them are missing due to the errors.

We'll log the errors if this happens.