### PR TITLE
Don’t throw when reading CSS file that might not exist

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -72,6 +72,7 @@ const TRIGGER_CHARACTERS = [
 
 async function getConfigFileFromCssFile(cssFile: string): Promise<string | null> {
   let css = await readCssFile(cssFile)
+  if (!css) return null
   let match = css.match(/@config\s*(?<config>'[^']+'|"[^"]+")/)
   if (!match) {
     return null


### PR DESCRIPTION
This happens likely because of a race condition when moving CSS files. If the event we get from the watcher isn’t a delete but the file doesn’t exist in that location any more the server will throw an error.
