### PR TITLE
Use one server to handle all folders in a workspace

### DIFF
--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -26,7 +26,7 @@ let connection = createConnection(ProposedFeatures.all)
 interceptLogs(console, connection)
 
 process.on('unhandledRejection', (e: any) => {
-  console.error("Unhandled exception", e)
+  console.error('Unhandled exception', e)
 })
 
 let documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument)

--- a/packages/tailwindcss-language-server/src/projects.ts
+++ b/packages/tailwindcss-language-server/src/projects.ts
@@ -182,6 +182,7 @@ export async function createProjectService(
   watchPatterns: (patterns: string[]) => void,
   initialTailwindVersion: string,
   getConfiguration: (uri?: string) => Promise<Settings>,
+  userLanguages: Record<string, string>,
 ): Promise<ProjectService> {
   let enabled = false
   const folder = projectConfig.folder
@@ -206,9 +207,7 @@ export async function createProjectService(
     editor: {
       connection,
       folder,
-      userLanguages: params.initializationOptions?.userLanguages
-        ? params.initializationOptions.userLanguages
-        : {},
+      userLanguages,
       // TODO
       capabilities: {
         configuration: true,

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -638,7 +638,7 @@ export class TW {
       (patterns: string[]) => watchPatterns(patterns),
       tailwindVersion,
       this.settingsCache.get,
-      userLanguages
+      userLanguages,
     )
     this.projects.set(key, project)
 

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package.json
@@ -1,5 +1,7 @@
 {
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "dependencies": {
     "tailwindcss": "^4.0.0-alpha.12"
   }

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -17,7 +17,11 @@ import {
   Range,
   RelativePattern,
 } from 'vscode'
-import type { DocumentFilter, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node'
+import type {
+  DocumentFilter,
+  LanguageClientOptions,
+  ServerOptions,
+} from 'vscode-languageclient/node'
 import {
   LanguageClient,
   TransportKind,
@@ -295,7 +299,6 @@ export async function activate(context: ExtensionContext) {
       let needsReboot = folders.some((folder) => {
         return (
           event.affectsConfiguration('tailwindCSS.experimental.configFile', folder) ||
-
           // TODO: Only reboot if the MAPPING changed instead of just the languages
           // e.g. "plaintext" already exists but you change it from "html" to "css"
           // TODO: This should not cause a reboot of the server but should instead
@@ -383,8 +386,11 @@ export async function activate(context: ExtensionContext) {
       module = context.asAbsolutePath(prod)
     } catch (_) {}
 
-    let workspaceFile = Workspace.workspaceFile?.scheme === 'file' ? Workspace.workspaceFile : undefined
-    let inspectPort = Workspace.getConfiguration('tailwindCSS', workspaceFile).get<number | null>('inspectPort') ?? null
+    let workspaceFile =
+      Workspace.workspaceFile?.scheme === 'file' ? Workspace.workspaceFile : undefined
+    let inspectPort =
+      Workspace.getConfiguration('tailwindCSS', workspaceFile).get<number | null>('inspectPort') ??
+      null
 
     let serverOptions: ServerOptions = {
       run: {
@@ -419,11 +425,7 @@ export async function activate(context: ExtensionContext) {
           let selections = editor.selections
           let edits = result.additionalTextEdits || []
 
-          if (
-            selections.length <= 1 ||
-            edits.length === 0 ||
-            result['data'] !== 'variant'
-          ) {
+          if (selections.length <= 1 || edits.length === 0 || result['data'] !== 'variant') {
             return result
           }
 
@@ -491,9 +493,7 @@ export async function activate(context: ExtensionContext) {
         workspace: {
           configuration: (params) => {
             return params.items.map(({ section, scopeUri }) => {
-              let scope: ConfigurationScope | null = scopeUri
-                ? Uri.parse(scopeUri)
-                : null
+              let scope: ConfigurationScope | null = scopeUri ? Uri.parse(scopeUri) : null
 
               let settings = Workspace.getConfiguration(section, scope)
 
@@ -564,7 +564,9 @@ export async function activate(context: ExtensionContext) {
     await bootWorkspaceClient()
   }
 
-  async function anyFolderNeedsLanguageServer(folders: readonly WorkspaceFolder[]): Promise<boolean> {
+  async function anyFolderNeedsLanguageServer(
+    folders: readonly WorkspaceFolder[],
+  ): Promise<boolean> {
     for (let folder of folders) {
       if (await folderNeedsLanguageServer(folder)) {
         return true

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -10,26 +10,19 @@ import type {
   TextEditorDecorationType,
   ConfigurationScope,
   WorkspaceConfiguration,
-  CompletionList,
-  ProviderResult,
   Selection,
 } from 'vscode'
 import {
   workspace as Workspace,
   window as Window,
-  languages as Languages,
   Uri,
   commands,
   SymbolInformation,
   Position,
   Range,
   RelativePattern,
-  CompletionItem,
-  CompletionItemKind,
-  SnippetString,
-  TextEdit,
 } from 'vscode'
-import type { LanguageClientOptions, ServerOptions, Disposable } from 'vscode-languageclient/node'
+import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node'
 import {
   LanguageClient,
   TransportKind,
@@ -45,6 +38,7 @@ import picomatch from 'picomatch'
 import { CONFIG_GLOB, CSS_GLOB } from '@tailwindcss/language-server/src/lib/constants'
 import braces from 'braces'
 import normalizePath from 'normalize-path'
+import * as servers from './servers/index'
 
 const colorNames = Object.keys(namedColors)
 
@@ -348,114 +342,6 @@ export async function activate(context: ExtensionContext) {
     }),
   )
 
-  let cssServerBooted = false
-  async function bootCssServer() {
-    if (cssServerBooted) return
-    cssServerBooted = true
-
-    let module = context.asAbsolutePath(path.join('dist', 'cssServer.js'))
-    let prod = path.join('dist', 'tailwindModeServer.js')
-
-    try {
-      await Workspace.fs.stat(Uri.joinPath(context.extensionUri, prod))
-      module = context.asAbsolutePath(prod)
-    } catch (_) {}
-
-    let client = new LanguageClient(
-      'tailwindcss-intellisense-css',
-      'Tailwind CSS',
-      {
-        run: {
-          module,
-          transport: TransportKind.ipc,
-        },
-        debug: {
-          module,
-          transport: TransportKind.ipc,
-          options: {
-            execArgv: ['--nolazy', '--inspect=6051'],
-          },
-        },
-      },
-      {
-        documentSelector: [{ language: 'tailwindcss' }],
-        outputChannelName: 'Tailwind CSS Language Mode',
-        synchronize: { configurationSection: ['css'] },
-        middleware: {
-          provideCompletionItem(document, position, context, token, next) {
-            function updateRanges(item: CompletionItem) {
-              const range = item.range
-              if (
-                range instanceof Range &&
-                range.end.isAfter(position) &&
-                range.start.isBeforeOrEqual(position)
-              ) {
-                item.range = { inserting: new Range(range.start, position), replacing: range }
-              }
-            }
-            function updateLabel(item: CompletionItem) {
-              if (item.kind === CompletionItemKind.Color) {
-                item.label = {
-                  label: item.label as string,
-                  description: item.documentation as string,
-                }
-              }
-            }
-            function updateProposals(
-              r: CompletionItem[] | CompletionList | null | undefined,
-            ): CompletionItem[] | CompletionList | null | undefined {
-              if (r) {
-                ;(Array.isArray(r) ? r : r.items).forEach(updateRanges)
-                ;(Array.isArray(r) ? r : r.items).forEach(updateLabel)
-              }
-              return r
-            }
-            const isThenable = <T>(obj: ProviderResult<T>): obj is Thenable<T> =>
-              obj && (<any>obj)['then']
-
-            const r = next(document, position, context, token)
-            if (isThenable<CompletionItem[] | CompletionList | null | undefined>(r)) {
-              return r.then(updateProposals)
-            }
-            return updateProposals(r)
-          },
-        },
-      },
-    )
-
-    await client.start()
-    context.subscriptions.push(initCompletionProvider())
-
-    function initCompletionProvider(): Disposable {
-      const regionCompletionRegExpr = /^(\s*)(\/(\*\s*(#\w*)?)?)?$/
-
-      return Languages.registerCompletionItemProvider(['tailwindcss'], {
-        provideCompletionItems(doc: TextDocument, pos: Position) {
-          let lineUntilPos = doc.getText(new Range(new Position(pos.line, 0), pos))
-          let match = lineUntilPos.match(regionCompletionRegExpr)
-          if (match) {
-            let range = new Range(new Position(pos.line, match[1].length), pos)
-            let beginProposal = new CompletionItem('#region', CompletionItemKind.Snippet)
-            beginProposal.range = range
-            TextEdit.replace(range, '/* #region */')
-            beginProposal.insertText = new SnippetString('/* #region $1*/')
-            beginProposal.documentation = 'Folding Region Start'
-            beginProposal.filterText = match[2]
-            beginProposal.sortText = 'za'
-            let endProposal = new CompletionItem('#endregion', CompletionItemKind.Snippet)
-            endProposal.range = range
-            endProposal.insertText = '/* #endregion */'
-            endProposal.documentation = 'Folding Region End'
-            endProposal.sortText = 'zb'
-            endProposal.filterText = match[2]
-            return [beginProposal, endProposal]
-          }
-          return null
-        },
-      })
-    }
-  }
-
   function bootWorkspaceClient(folder: WorkspaceFolder) {
     if (clients.has(folder.uri.toString())) {
       return
@@ -511,7 +397,7 @@ export async function activate(context: ExtensionContext) {
     }
 
     let clientOptions: LanguageClientOptions = {
-      documentSelector: languages.get(folder.uri.toString()).map((language) => ({
+      documentSelector: languages.get(folder.uri.toString())!.map((language) => ({
         scheme: 'file',
         language,
         pattern: normalizePath(`${folder.uri.fsPath.replace(/[\[\]\{\}]/g, '?')}/**/*`),
@@ -770,7 +656,7 @@ export async function activate(context: ExtensionContext) {
 
   async function didOpenTextDocument(document: TextDocument): Promise<void> {
     if (document.languageId === 'tailwindcss') {
-      bootCssServer()
+      servers.css.boot(context, outputChannel)
     }
 
     // We are only interested in language mode text

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -422,7 +422,6 @@ export async function activate(context: ExtensionContext) {
           if (
             selections.length <= 1 ||
             edits.length === 0 ||
-            // @ts-expect-error: use of private API / implementation details of our language server
             result['data'] !== 'variant'
           ) {
             return result

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -308,9 +308,6 @@ export async function activate(context: ExtensionContext) {
         return
       }
 
-      // IDEA: We might be able to service requests during a reboot by booting the
-      // new server, swapping it out, then stopping the old one
-
       // Stop the current server (if any)
       if (currentClient) {
         let client = await currentClient

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -633,7 +633,8 @@ export async function activate(context: ExtensionContext) {
   Workspace.textDocuments.forEach(didOpenTextDocument)
   context.subscriptions.push(
     Workspace.onDidChangeWorkspaceFolders(async () => {
-      if (Workspace.workspaceFolders?.length ?? 0 > 0) return
+      let folderCount = Workspace.workspaceFolders?.length ?? 0
+      if (folderCount > 0) return
       if (!currentClient) return
 
       let client = await currentClient

--- a/packages/vscode-tailwindcss/src/servers/css.ts
+++ b/packages/vscode-tailwindcss/src/servers/css.ts
@@ -1,0 +1,151 @@
+import * as path from 'path'
+import type {
+  ExtensionContext,
+  TextDocument,
+  CompletionList,
+  ProviderResult,
+  OutputChannel,
+} from 'vscode'
+import {
+  workspace as Workspace,
+  languages as Languages,
+  Uri,
+  Position,
+  Range,
+  CompletionItem,
+  CompletionItemKind,
+  SnippetString,
+  TextEdit,
+} from 'vscode'
+import type { Disposable, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node'
+import { LanguageClient, TransportKind } from 'vscode-languageclient/node'
+
+let booted = false
+
+/**
+ * Start the CSS language server
+ * We have a customized version of the CSS language server that supports Tailwind CSS completions
+ * It operates in the Tailwind CSS language mode only
+ */
+export async function boot(context: ExtensionContext, outputChannel: OutputChannel) {
+  if (booted) return
+  booted = true
+
+  let module = context.asAbsolutePath(path.join('dist', 'cssServer.js'))
+  let prod = path.join('dist', 'tailwindModeServer.js')
+
+  try {
+    await Workspace.fs.stat(Uri.joinPath(context.extensionUri, prod))
+    module = context.asAbsolutePath(prod)
+  } catch (_) {}
+
+  let serverOptions: ServerOptions = {
+    run: {
+      module,
+      transport: TransportKind.ipc,
+    },
+    debug: {
+      module,
+      transport: TransportKind.ipc,
+      options: {
+        execArgv: ['--nolazy', '--inspect=6051'],
+      },
+    },
+  }
+
+  let clientOptions: LanguageClientOptions = {
+    documentSelector: [{ language: 'tailwindcss' }],
+    outputChannelName: 'Tailwind CSS Language Mode',
+    synchronize: { configurationSection: ['css'] },
+    middleware: {
+      provideCompletionItem(document, position, context, token, next) {
+        function updateRanges(item: CompletionItem) {
+          const range = item.range
+          if (
+            range instanceof Range &&
+            range.end.isAfter(position) &&
+            range.start.isBeforeOrEqual(position)
+          ) {
+            item.range = { inserting: new Range(range.start, position), replacing: range }
+          }
+        }
+
+        function updateLabel(item: CompletionItem) {
+          if (item.kind === CompletionItemKind.Color) {
+            item.label = {
+              label: item.label as string,
+              description: item.documentation as string,
+            }
+          }
+        }
+
+        function updateProposals(
+          r: CompletionItem[] | CompletionList | null | undefined,
+        ): CompletionItem[] | CompletionList | null | undefined {
+          if (r) {
+            ;(Array.isArray(r) ? r : r.items).forEach(updateRanges)
+            ;(Array.isArray(r) ? r : r.items).forEach(updateLabel)
+          }
+          return r
+        }
+
+        const isThenable = <T>(obj: ProviderResult<T>): obj is Thenable<T> =>
+          obj && (<any>obj)['then']
+
+        const r = next(document, position, context, token)
+
+        if (isThenable<CompletionItem[] | CompletionList | null | undefined>(r)) {
+          return r.then(updateProposals)
+        }
+
+        return updateProposals(r)
+      },
+    },
+  }
+
+  outputChannel.appendLine(`Booting CSS server for Tailwind CSS language mode`)
+
+  let client = new LanguageClient(
+    'tailwindcss-intellisense-css',
+    'Tailwind CSS',
+    serverOptions,
+    clientOptions,
+  )
+
+  await client.start()
+
+  context.subscriptions.push(initCompletionProvider())
+
+  function initCompletionProvider(): Disposable {
+    const regionCompletionRegExpr = /^(\s*)(\/(\*\s*(#\w*)?)?)?$/
+
+    return Languages.registerCompletionItemProvider(['tailwindcss'], {
+      provideCompletionItems(doc: TextDocument, pos: Position) {
+        let lineUntilPos = doc.getText(new Range(new Position(pos.line, 0), pos))
+        let match = lineUntilPos.match(regionCompletionRegExpr)
+        if (!match) {
+          return null
+        }
+
+        let range = new Range(new Position(pos.line, match[1].length), pos)
+
+        let beginProposal = new CompletionItem('#region', CompletionItemKind.Snippet)
+        beginProposal.range = range
+        TextEdit.replace(range, '/* #region */')
+        beginProposal.insertText = new SnippetString('/* #region $1*/')
+        beginProposal.documentation = 'Folding Region Start'
+        beginProposal.filterText = match[2]
+        beginProposal.sortText = 'za'
+
+        let endProposal = new CompletionItem('#endregion', CompletionItemKind.Snippet)
+        endProposal.range = range
+        endProposal.insertText = '/* #endregion */'
+        endProposal.documentation = 'Folding Region End'
+        endProposal.sortText = 'zb'
+        endProposal.filterText = match[2]
+
+        return [beginProposal, endProposal]
+      },
+    })
+  }
+}

--- a/packages/vscode-tailwindcss/src/servers/index.ts
+++ b/packages/vscode-tailwindcss/src/servers/index.ts
@@ -1,0 +1,1 @@
+export * as css from './css'


### PR DESCRIPTION
Previously, if your workspace had multiple folders, we would boot a separate server per workspace folder. This was because our server didn't support workspace folders. However, it now does which means we can make use of this feature.

This change should help reduce CPU and memory usage in any workspace making use of multiple folders. This will also solve an issue where Intellisense would not load when a workspace that is open is a subdirectory of another workspace, the subdirectory folder was listed first, and that subdirectory didn't contain a tailwind config or tailwind-related CSS file.

Fixes #921