### PR TITLE
Fix v4 theme reloading on Windows

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -40,7 +40,7 @@ import resolveFrom from './util/resolveFrom'
 import * as parcel from './watcher/index.js'
 import { equal } from '@tailwindcss/language-service/src/util/array'
 import { CONFIG_GLOB, CSS_GLOB, PACKAGE_LOCK_GLOB } from './lib/constants'
-import { clearRequireCache, isObject, changeAffectsFile } from './utils'
+import { clearRequireCache, isObject, changeAffectsFile, normalizeDriveLetter } from './utils'
 import { DocumentService } from './documents'
 import { createProjectService, type ProjectService } from './projects'
 import { type SettingsCache, createSettingsCache } from './config'
@@ -273,6 +273,7 @@ export class TW {
 
       changeLoop: for (let change of changes) {
         let normalizedFilename = normalizePath(change.file)
+        normalizedFilename = normalizeDriveLetter(normalizedFilename)
 
         for (let ignorePattern of ignore) {
           let isIgnored = picomatch(ignorePattern, { dot: true })
@@ -311,6 +312,8 @@ export class TW {
             project.projectConfig.configPath,
             ...project.projectConfig.config.entries.map((entry) => entry.path),
           ]
+
+          reloadableFiles = reloadableFiles.map(normalizeDriveLetter)
 
           if (!changeAffectsFile(normalizedFilename, reloadableFiles)) continue
 

--- a/packages/tailwindcss-language-server/src/utils.ts
+++ b/packages/tailwindcss-language-server/src/utils.ts
@@ -70,6 +70,17 @@ export function dirContains(dir: string, file: string): boolean {
   return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative)
 }
 
+const WIN_DRIVE_LETTER = /^([a-zA-Z]):/
+
+/**
+ * Windows drive letters are case-insensitive and we may get them as either
+ * lower or upper case. This function normalizes the drive letter to uppercase
+ * to be consistent with the rest of the codebase.
+ */
+export function normalizeDriveLetter(filepath: string) {
+  return filepath.replace(WIN_DRIVE_LETTER, (_, letter) => letter.toUpperCase() + ':')
+}
+
 export function changeAffectsFile(change: string, files: string[]): boolean {
   for (let file of files) {
     if (change === file || dirContains(change, file)) {


### PR DESCRIPTION
This PR adds normalization of drive letters in watched files on Windows.

This is necessary because we receive paths from different sources (filesystem vs VS Code file watching notifications), and sometimes they start with `C:` and other times with `c:`.