### PR TITLE
Show color decorators when utility has an opacity modifier in v4

### DIFF
--- a/packages/tailwindcss-language-server/tests/colors/colors.test.js
+++ b/packages/tailwindcss-language-server/tests/colors/colors.test.js
@@ -87,6 +87,68 @@ withFixture('basic', (c) => {
       },
     ],
   })
+
+  testColors('gradient utilities show colors', {
+    text: '<div class="from-black from-black/50 via-black via-black/50 to-black to-black/50">',
+    expected: [
+      {
+        range: { start: { line: 0, character: 12 }, end: { line: 0, character: 22 } },
+        color: {
+          alpha: 1,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+      {
+        range: { start: { line: 0, character: 23 }, end: { line: 0, character: 36 } },
+        color: {
+          alpha: 0.5,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+
+      {
+        range: { start: { line: 0, character: 37 }, end: { line: 0, character: 46 } },
+        color: {
+          alpha: 1,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+      {
+        range: { start: { line: 0, character: 47 }, end: { line: 0, character: 59 } },
+        color: {
+          alpha: 0.5,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+
+      {
+        range: { start: { line: 0, character: 60 }, end: { line: 0, character: 68 } },
+        color: {
+          alpha: 1,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+      {
+        range: { start: { line: 0, character: 69 }, end: { line: 0, character: 80 } },
+        color: {
+          alpha: 0.5,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+    ],
+  })
 })
 
 withFixture('v4/basic', (c) => {
@@ -171,6 +233,68 @@ withFixture('v4/basic', (c) => {
           red: 0.9475942429386454,
           green: 0,
           blue: 0.14005415620741646,
+        },
+      },
+    ],
+  })
+
+  testColors('gradient utilities show colors', {
+    text: '<div class="from-black from-black/50 via-black via-black/50 to-black to-black/50">',
+    expected: [
+      {
+        range: { start: { line: 0, character: 12 }, end: { line: 0, character: 22 } },
+        color: {
+          alpha: 1,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+      {
+        range: { start: { line: 0, character: 23 }, end: { line: 0, character: 36 } },
+        color: {
+          alpha: 0.5,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+
+      {
+        range: { start: { line: 0, character: 37 }, end: { line: 0, character: 46 } },
+        color: {
+          alpha: 1,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+      {
+        range: { start: { line: 0, character: 47 }, end: { line: 0, character: 59 } },
+        color: {
+          alpha: 0.5,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+
+      {
+        range: { start: { line: 0, character: 60 }, end: { line: 0, character: 68 } },
+        color: {
+          alpha: 1,
+          red: 0,
+          green: 0,
+          blue: 0,
+        },
+      },
+      {
+        range: { start: { line: 0, character: 69 }, end: { line: 0, character: 80 } },
+        color: {
+          alpha: 0.5,
+          red: 0,
+          green: 0,
+          blue: 0,
         },
       },
     ],

--- a/packages/tailwindcss-language-server/tests/colors/colors.test.js
+++ b/packages/tailwindcss-language-server/tests/colors/colors.test.js
@@ -116,7 +116,6 @@ withFixture('v4/basic', (c) => {
     ],
   })
 
-  /*
   testColors('opacity modifier', {
     text: '<div class="bg-red-500/20">',
     expected: [
@@ -131,7 +130,6 @@ withFixture('v4/basic', (c) => {
       },
     ],
   })
-   */
 
   testColors('arbitrary value', {
     text: '<div class="bg-[red]">',
@@ -148,7 +146,6 @@ withFixture('v4/basic', (c) => {
     ],
   })
 
-  /*
   testColors('arbitrary value and opacity modifier', {
     text: '<div class="bg-[red]/[0.5]">',
     expected: [
@@ -163,7 +160,6 @@ withFixture('v4/basic', (c) => {
       },
     ],
   })
-  */
 
   testColors('oklch colors are parsed', {
     text: '<div class="bg-[oklch(60%_0.25_25)]">',

--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -58,10 +58,16 @@ function replaceColorVarsWithTheirDefaults(str: string): string {
 function getColorsInString(str: string): (culori.Color | KeywordColor)[] {
   if (/(?:box|drop)-shadow/.test(str)) return []
 
-  return Array.from(replaceColorVarsWithTheirDefaults(str).matchAll(colorRegex), (match) => {
+  function toColor(match: RegExpMatchArray) {
     let color = match[1].replace(/var\([^)]+\)/, '1')
     return getKeywordColor(color) ?? culori.parse(color)
-  }).filter(Boolean)
+  }
+
+  str = replaceColorVarsWithTheirDefaults(str)
+
+  let possibleColors = str.matchAll(colorRegex)
+
+  return Array.from(possibleColors, toColor).filter(Boolean)
 }
 
 function getColorFromDecls(

--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -145,6 +145,21 @@ function getColorFromDecls(
 }
 
 function getColorFromRoot(state: State, css: postcss.Root): culori.Color | KeywordColor | null {
+  // Remove any `@property` rules
+  css = css.clone()
+  css.walkAtRules((rule) => {
+    // Ignore declarations inside `@property` rules
+    if (rule.name === 'property') {
+      rule.remove()
+    }
+
+    // Ignore declarations @supports (-moz-orient: inline)
+    // this is a hack used for `@property` fallbacks in Firefox
+    if (rule.name === 'supports' && rule.params === '(-moz-orient: inline)') {
+      rule.remove()
+    }
+  })
+
   let decls: Record<string, string[]> = {}
 
   let rule = postcss.rule({

--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -71,6 +71,7 @@ function getColorsInString(str: string): (culori.Color | KeywordColor)[] {
 
   str = replaceHexColorVarsWithTheirDefaults(str)
   str = replaceColorVarsWithTheirDefaults(str)
+  str = removeColorMixWherePossible(str)
 
   let possibleColors = str.matchAll(colorRegex)
 
@@ -250,4 +251,20 @@ export function formatColor(color: culori.Color): string {
   }
 
   return culori.formatHex8(color)
+}
+
+const COLOR_MIX_REGEX = /color-mix\(in srgb, (.*?) (\d+|\.\d+|\d+\.\d+)%, transparent\)/g
+
+function removeColorMixWherePossible(str: string) {
+  return str.replace(COLOR_MIX_REGEX, (match, color, percentage) => {
+    if (color.startsWith('var(')) return match
+
+    let parsed = culori.parse(color)
+    if (!parsed) return match
+
+    let alpha = Number(percentage) / 100
+    if (Number.isNaN(alpha)) return match
+
+    return culori.formatRgb({ ...parsed, alpha })
+  })
 }

--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -55,6 +55,12 @@ function replaceColorVarsWithTheirDefaults(str: string): string {
   return str.replace(/((?:rgba?|hsla?|(?:ok)?(?:lab|lch))\(\s*)var\([^,]+,\s*([^)]+)\)/gi, '$1$2')
 }
 
+function replaceHexColorVarsWithTheirDefaults(str: string): string {
+  // var(--color-red-500, #ef4444)
+  // -> #ef4444
+  return str.replace(/var\([^,]+,\s*(#[^)]+)\)/gi, '$1')
+}
+
 function getColorsInString(str: string): (culori.Color | KeywordColor)[] {
   if (/(?:box|drop)-shadow/.test(str)) return []
 
@@ -63,6 +69,7 @@ function getColorsInString(str: string): (culori.Color | KeywordColor)[] {
     return getKeywordColor(color) ?? culori.parse(color)
   }
 
+  str = replaceHexColorVarsWithTheirDefaults(str)
   str = replaceColorVarsWithTheirDefaults(str)
 
   let possibleColors = str.matchAll(colorRegex)


### PR DESCRIPTION
We use `color-mix` to apply alpha values to colors — because of this we don't show color decorators for any utility with an opacity modifier in a v4 project.

We remove the wrapping `color-mix` and apply the alpha value to the color so we end up parsing a valid color string into their separate r, g, b, and a channels.

Also made sure that gradient utilities show their color swatches — they were being excluded because we were looking at declarations inside `@property` and then throwing stuff out.