### PR TITLE
feat: remove is-builtin-module dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2068,18 +2068,6 @@
         "node": "*"
       }
     },
-    "node_modules/builtin-modules": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
@@ -3886,21 +3874,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-builtin-module": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
-      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
-      "dev": true,
-      "dependencies": {
-        "builtin-modules": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-core-module": {
@@ -8099,7 +8072,6 @@
         "esbuild": "^0.20.2",
         "fast-glob": "3.2.4",
         "find-up": "5.0.0",
-        "is-builtin-module": "3.2.1",
         "klona": "2.0.4",
         "license-checker": "25.0.1",
         "minimist": "^1.2.8",

--- a/packages/tailwindcss-language-server/package.json
+++ b/packages/tailwindcss-language-server/package.json
@@ -66,7 +66,6 @@
     "esbuild": "^0.20.2",
     "fast-glob": "3.2.4",
     "find-up": "5.0.0",
-    "is-builtin-module": "3.2.1",
     "klona": "2.0.4",
     "license-checker": "25.0.1",
     "minimist": "^1.2.8",

--- a/packages/tailwindcss-language-server/src/lib/env.ts
+++ b/packages/tailwindcss-language-server/src/lib/env.ts
@@ -1,15 +1,16 @@
 import Module from 'module'
 import * as path from 'path'
 import resolveFrom from '../util/resolveFrom'
-import isBuiltinModule from 'is-builtin-module'
+import {builtinModules} from 'module'
 
 process.env.TAILWIND_MODE = 'build'
 process.env.TAILWIND_DISABLE_TOUCH = 'true'
 
 let oldResolveFilename = (Module as any)._resolveFilename
+const nodeModulePrefix = /^node:/i;
 
 ;(Module as any)._resolveFilename = (id: any, parent: any) => {
-  if (typeof id === 'string' && isBuiltinModule(id)) {
+  if (typeof id === 'string' && builtinModules.includes(id.replace(nodeModulePrefix, ''))) {
     return oldResolveFilename(id, parent)
   }
 

--- a/packages/tailwindcss-language-server/src/lib/env.ts
+++ b/packages/tailwindcss-language-server/src/lib/env.ts
@@ -1,16 +1,15 @@
-import Module from 'module'
-import * as path from 'path'
+import Module from 'node:module'
+import { isBuiltin } from 'node:module'
+import * as path from 'node:path'
 import resolveFrom from '../util/resolveFrom'
-import {builtinModules} from 'module'
 
 process.env.TAILWIND_MODE = 'build'
 process.env.TAILWIND_DISABLE_TOUCH = 'true'
 
 let oldResolveFilename = (Module as any)._resolveFilename
-const nodeModulePrefix = /^node:/i;
 
 ;(Module as any)._resolveFilename = (id: any, parent: any) => {
-  if (typeof id === 'string' && builtinModules.includes(id.replace(nodeModulePrefix, ''))) {
+  if (typeof id === 'string' && isBuiltin(id)) {
     return oldResolveFilename(id, parent)
   }
 


### PR DESCRIPTION
Node provides a list of built ins via `builtinModules`. We can test against this rather than including an extra (redundant) dependency.

In future, if we introduce a version constraint of node `>=16`, we can use `isBuiltin` which node provides:

```ts
import {isBuiltin} from 'node:module';

isBuiltin('fs'); // true
```