### PR TITLE
Bump minimum supported Node version to v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8080,7 +8080,7 @@
         "@types/dlv": "^1.1.4",
         "@types/find-up": "^4.0.0",
         "@types/license-checker": "^25.0.6",
-        "@types/node": "14.14.34",
+        "@types/node": "^18.19.33",
         "@types/normalize-path": "^3.0.2",
         "@types/picomatch": "^2.3.3",
         "@types/postcss-import": "^14.0.3",
@@ -8125,10 +8125,13 @@
       }
     },
     "packages/tailwindcss-language-server/node_modules/@types/node": {
-      "version": "14.14.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.34.tgz",
-      "integrity": "sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==",
-      "dev": true
+      "version": "18.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
+      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/tailwindcss-language-server/node_modules/esbuild": {
       "version": "0.20.2",

--- a/packages/tailwindcss-language-server/package.json
+++ b/packages/tailwindcss-language-server/package.json
@@ -47,7 +47,7 @@
     "@types/dlv": "^1.1.4",
     "@types/find-up": "^4.0.0",
     "@types/license-checker": "^25.0.6",
-    "@types/node": "14.14.34",
+    "@types/node": "^18.19.33",
     "@types/normalize-path": "^3.0.2",
     "@types/picomatch": "^2.3.3",
     "@types/postcss-import": "^14.0.3",
@@ -89,5 +89,8 @@
     "vscode-languageserver": "8.1.0",
     "vscode-languageserver-textdocument": "1.0.11",
     "vscode-uri": "3.0.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Node v14 and v16 have been EOL for a long time. Even v18 is in maintenance only mode now. I'll likely bump this to a minimum version of v20 at a (recent) future point.