### PR TITLE
Normalize drive letter in file path

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -774,6 +774,9 @@ export class TW {
         for (let selector of documentSelector) {
           let fsPath = URI.parse(document.uri).fsPath
           let pattern = selector.pattern.replace(/[\[\]{}]/g, (m) => `\\${m}`)
+
+          fsPath = normalizeDriveLetter(fsPath)
+
           if (pattern.startsWith('!') && picomatch(pattern.slice(1), { dot: true })(fsPath)) {
             break
           }


### PR DESCRIPTION
I've been trying to figure out why my files don't always get picked up by this extension. I tracked it back to an issue in VSCode where opening a workspace using a different casing than what's on disk can cause the 'wrong' value to be passed into this function, and then matching doesn't work. Even after I corrected the config on my end I was still having an inconsistent experience. What I then found was my pattern had an uppercase `C` (#960) while my file path had a lowercase `c`. Normalizing both paths seems to fix this but I'm not sure if there's other spots that may need to be updated too.

Some background on the VSCode issue since it was driving me nuts for weeks, if not months. The folder my repo is in uses PascalCase, but I apparently added it to GitHub Desktop using camelCase. Every time I opened a file, or the workspace, from GitHub Desktop it would pass VSCode a path like `c:/myProjects/Project`, but on disk it's actually `C:/MyProjects/Project`. This meant the value of `document.uri` had a different case than the `pattern` had so picomatch wasn't returning true. This was made worse by VSCode caching these file paths in `C:\Users\<user>\AppData\Roaming\Code\User\workspaceStorage\<workspace>\state.vscdb`. Correcting my path in GitHub Desktop, deleting the cache, and the drive letter normalization change here looks to fix my problem and I get IntelliSense again.
