### PR TITLE
Pass URI to configuration call not a file path

### DIFF
--- a/packages/tailwindcss-language-server/src/projects.ts
+++ b/packages/tailwindcss-language-server/src/projects.ts
@@ -1040,7 +1040,7 @@ export async function createProjectService(
       if (state.enabled) {
         refreshDiagnostics()
       }
-      if (settings.editor.colorDecorators) {
+      if (settings.editor?.colorDecorators) {
         updateCapabilities()
       } else {
         connection.sendNotification('@/tailwindCSS/clearColors')


### PR DESCRIPTION
Not a Zed bug — finally got the init messages to show in Zed. We're passing a path and not a `file://` URI which is a bug on our side. Also fixed another issue while I was in there related to settings updates and color decorators.