### PR TITLE
Fix loading projects on network drives

### DIFF
--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -3,7 +3,6 @@ import * as path from 'node:path'
 import * as fs from 'node:fs/promises'
 import glob from 'fast-glob'
 import picomatch from 'picomatch'
-import normalizePath from 'normalize-path'
 import type { Settings } from '@tailwindcss/language-service/src/util/state'
 import { CONFIG_GLOB, CSS_GLOB } from './lib/constants'
 import { readCssFile } from './util/css'
@@ -14,9 +13,8 @@ import { CacheMap } from './cache-map'
 import { getPackageRoot } from './util/get-package-root'
 import resolveFrom from './util/resolveFrom'
 import { type Feature, supportedFeatures } from '@tailwindcss/language-service/src/features'
-import { pathToFileURL } from 'node:url'
 import { resolveCssImports } from './resolve-css-imports'
-import { normalizeDriveLetter } from './utils'
+import { normalizeDriveLetter, normalizePath, pathToFileURL } from './utils'
 
 export interface ProjectConfig {
   /** The folder that contains the project */

--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -242,8 +242,20 @@ export class ProjectLocator {
       concurrency: Math.max(os.cpus().length, 1),
     })
 
-    // Resolve symlinks for all found files
-    files = await Promise.all(files.map(async (file) => normalizePath(await fs.realpath(file))))
+    files = await Promise.all(
+      files.map(async (file) => {
+        // Resolve symlinks for all found files
+        let actualPath = await fs.realpath(file)
+
+        // Ignore network paths on Windows. Resolving relative paths on a
+        // netshare throws in `enhanced-resolve` :/
+        if (actualPath.startsWith('\\') && process.platform === 'win32') {
+          return normalizePath(file)
+        }
+
+        return normalizePath(actualPath)
+      }),
+    )
 
     // Deduplicate the list of files and sort them for deterministic results
     // across environments

--- a/packages/tailwindcss-language-server/src/projects.ts
+++ b/packages/tailwindcss-language-server/src/projects.ts
@@ -20,7 +20,6 @@ import { FileChangeType } from 'vscode-languageserver/node'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
 import { showError, SilentError } from './util/error'
-import normalizePath from 'normalize-path'
 import * as path from 'path'
 import * as fs from 'fs'
 import findUp from 'find-up'
@@ -70,14 +69,15 @@ import {
   clearRequireCache,
   withFallback,
   isObject,
+  pathToFileURL,
   changeAffectsFile,
+  normalizePath,
 } from './utils'
 import type { DocumentService } from './documents'
 import type { ProjectConfig } from './project-locator'
 import { supportedFeatures } from '@tailwindcss/language-service/src/features'
 import { loadDesignSystem } from './util/v4'
 import { readCssFile } from './util/css'
-import { pathToFileURL } from 'url'
 
 const colorNames = Object.keys(namedColors)
 

--- a/packages/tailwindcss-language-server/src/util/getModuleDependencies.ts
+++ b/packages/tailwindcss-language-server/src/util/getModuleDependencies.ts
@@ -1,7 +1,7 @@
 // https://github.com/tailwindlabs/tailwindcss/blob/bac5ecf0040aa9a788d1b22d706506146ee831ff/src/lib/getModuleDependencies.js
 import fs from 'fs'
 import path from 'path'
-import normalizePath from 'normalize-path'
+import { normalizePath } from '../utils'
 
 let jsExtensions = ['.js', '.cjs', '.mjs']
 

--- a/packages/tailwindcss-language-server/src/util/resolveFrom.ts
+++ b/packages/tailwindcss-language-server/src/util/resolveFrom.ts
@@ -1,4 +1,5 @@
 import { equal } from '@tailwindcss/language-service/src/util/array'
+import * as path from 'node:path'
 import { createResolver } from './resolve'
 
 let pnpApi: any
@@ -16,7 +17,16 @@ export function setPnpApi(newPnpApi: any): void {
 }
 
 export default function resolveFrom(from?: string, id?: string): string {
+  // Network share path on Windows
   if (id.startsWith('\\\\')) return id
+
+  // Normalized network share path on Windows
+  if (id.startsWith('//') && path.sep === '\\') return id
+
+  // Normalized network share path on Windows
+  if (from.startsWith('//') && path.sep === '\\') {
+    from = '\\\\' + from.slice(2)
+  }
 
   let newExtensions = Object.keys(require.extensions)
   if (!equal(newExtensions, extensions)) {

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Fix loading projects on Windows network drives ([#996](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/996))
 
 ## 0.12.1
 


### PR DESCRIPTION
Opening a project on a networked drive (e.g. `Z:\my-project`) would fail because:
- We ask node for the "real" file path which returns a UNC share path (e.g. `\\MyShare\some-folder\my-project`)
- Improper path normalization
- Errors in `enhanced-resolve` with UNC paths

Additionally, opening projects on a network share directly (rather than a mapped network drive) would always fail to discover any projects.

I've made some improvements to file path handling such that:
- Loading a project on a network share directly does not outright fail — there are still some problems but they appear to be in `enhanced-resolve` when resolving relative file paths
- Loading a project on a networked drive no longer uses the UNC path returned by `fs.realpath` and uses the url that was passed in. This means that symlinks don't get resolved **however** it should (hopefully) solve most issues when using Intellisense with projects over the network

Fixes #994
