### PR TITLE
Fix server not launching on older versions of VSCode

### DIFF
--- a/packages/tailwindcss-language-server/src/lib/env.ts
+++ b/packages/tailwindcss-language-server/src/lib/env.ts
@@ -1,5 +1,4 @@
 import Module from 'node:module'
-import { isBuiltin } from 'node:module'
 import * as path from 'node:path'
 import resolveFrom from '../util/resolveFrom'
 
@@ -7,6 +6,18 @@ process.env.TAILWIND_MODE = 'build'
 process.env.TAILWIND_DISABLE_TOUCH = 'true'
 
 let oldResolveFilename = (Module as any)._resolveFilename
+
+function isBuiltin(id: string) {
+  // Node 16.17+, v18.6.0+, >= v20
+  // VSCode >= 1.78
+  if ('isBuiltin' in Module) {
+    return Module.isBuiltin(id)
+  }
+
+  // Older versions of Node and VSCode
+  // @ts-ignore
+  return Module.builtinModules.includes(id.replace(/^node:/, ''))
+}
 
 ;(Module as any)._resolveFilename = (id: any, parent: any) => {
   if (typeof id === 'string' && isBuiltin(id)) {

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Prerelease
 
 - Fix loading projects on Windows network drives ([#996](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/996))
+- Fix server not launching on older versions of VSCode ([#998](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/998))
 
 ## 0.12.1
 


### PR DESCRIPTION
Our use of `isBuiltin` does not work with VSCode < 1.78 and causes the server to not start. We have to use a different API for this when `isBuiltin` is not available.

Fixes #997