### PR TITLE
Make sure language specific settings are passed to the language server

### DIFF
--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Prerelease
 
-- Fix detection of v3 insiders builds  ([#1007](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1007))
+- Fix detection of v3 insiders builds ([#1007](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1007))
+- Make sure language-specific settings are passed to our language server ([#1006](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1006))
 
 ## 0.12.3
 

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -493,7 +493,23 @@ export async function activate(context: ExtensionContext) {
         workspace: {
           configuration: (params) => {
             return params.items.map(({ section, scopeUri }) => {
-              let scope: ConfigurationScope | null = scopeUri ? Uri.parse(scopeUri) : null
+              let scope: ConfigurationScope | null = null
+
+              if (scopeUri) {
+                let uri = Uri.parse(scopeUri)
+                let doc = Workspace.textDocuments.find((doc) => doc.uri.toString() === scopeUri)
+
+                // Make sure we ask VSCode for language specific settings for
+                // the document as it does not do this automatically
+                if (doc) {
+                  scope = {
+                    uri,
+                    languageId: doc.languageId,
+                  }
+                } else {
+                  scope = uri
+                }
+              }
 
               let settings = Workspace.getConfiguration(section, scope)
 


### PR DESCRIPTION
We have to augment requests when getting settings for a document to make sure the language of the document is passed. If we don't VSCode does not account for language-specific settings.

This was previously handled (in < v0.10.x) but accidentally removed during some code clean up.

Fixes #1005