### PR TITLE
Fix detection of v3 insiders builds

### DIFF
--- a/packages/tailwindcss-language-service/src/features.ts
+++ b/packages/tailwindcss-language-service/src/features.ts
@@ -22,11 +22,13 @@ export type Feature =
 export function supportedFeatures(version: string): Feature[] {
   let features: Feature[] = []
 
-  if (semver.gte(version, '4.0.0-alpha.1')) {
+  let isInsidersV3 = version.startsWith('0.0.0-insiders')
+
+  if (!isInsidersV3 && semver.gte(version, '4.0.0-alpha.1')) {
     return ['css-at-theme', 'layer:base', 'content-list']
   }
 
-  if (version.startsWith('0.0.0-oxide')) {
+  if (!isInsidersV3 && version.startsWith('0.0.0-oxide')) {
     return ['css-at-theme', 'layer:base', 'content-list']
   }
 

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Fix detection of v3 insiders builds  ([#1007](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1007))
 
 ## 0.12.3
 


### PR DESCRIPTION
Our semver checks basically always pass on insiders build. This messes up checking for v4 though so we have to be more explicit about it when determining what features a given project supports.

Fixes #990