### PR TITLE
Fix initialization when path has parentheses

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -820,7 +820,7 @@ export class TW {
       console.debug('[GLOBAL] Checking selectors', documentSelector)
 
       for (let selector of documentSelector) {
-        let pattern = selector.pattern.replace(/[\[\]{}]/g, (m) => `\\${m}`)
+        let pattern = selector.pattern.replace(/[\[\]{}()]/g, (m) => `\\${m}`)
 
         if (pattern.startsWith('!')) {
           if (picomatch(pattern.slice(1), { dot: true })(fsPath)) {

--- a/packages/tailwindcss-language-server/tests/env/document-selection.test.js
+++ b/packages/tailwindcss-language-server/tests/env/document-selection.test.js
@@ -1,0 +1,92 @@
+import { test } from 'vitest'
+import * as path from 'node:path'
+import { withFixture, withWorkspace } from '../common'
+import { DidChangeWorkspaceFoldersNotification, HoverRequest } from 'vscode-languageserver'
+
+withFixture('document-selection/basic', (c) => {
+  test('basic: should provide hovers', async ({ expect }) => {
+    let textDocument = await c.openDocument({
+      text: '<div class="bg-[#000]">',
+    })
+
+    let res = await c.sendRequest(HoverRequest.type, {
+      textDocument,
+      position: { line: 0, character: 13 },
+    })
+
+    expect(res).toEqual({
+      contents: {
+        language: 'css',
+        value:
+          '.bg-\\[\\#000\\] {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 0 / var(--tw-bg-opacity)) /* #000000 */;\n}',
+      },
+      range: { start: { line: 0, character: 12 }, end: { line: 0, character: 21 } },
+    })
+  })
+})
+
+withFixture('document-selection/(parens)', (c) => {
+  test('parens: should provide hovers', async ({ expect }) => {
+    let textDocument = await c.openDocument({
+      text: '<div class="bg-[#000]">',
+    })
+
+    let res = await c.sendRequest(HoverRequest.type, {
+      textDocument,
+      position: { line: 0, character: 13 },
+    })
+
+    expect(res).toEqual({
+      contents: {
+        language: 'css',
+        value:
+          '.bg-\\[\\#000\\] {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 0 / var(--tw-bg-opacity)) /* #000000 */;\n}',
+      },
+      range: { start: { line: 0, character: 12 }, end: { line: 0, character: 21 } },
+    })
+  })
+})
+
+withFixture('document-selection/[brackets]', (c) => {
+  test('brackets: should provide hovers', async ({ expect }) => {
+    let textDocument = await c.openDocument({
+      text: '<div class="bg-[#000]">',
+    })
+
+    let res = await c.sendRequest(HoverRequest.type, {
+      textDocument,
+      position: { line: 0, character: 13 },
+    })
+
+    expect(res).toEqual({
+      contents: {
+        language: 'css',
+        value:
+          '.bg-\\[\\#000\\] {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 0 / var(--tw-bg-opacity)) /* #000000 */;\n}',
+      },
+      range: { start: { line: 0, character: 12 }, end: { line: 0, character: 21 } },
+    })
+  })
+})
+
+withFixture('document-selection/{curlies}', (c) => {
+  test('curlies: should provide hovers', async ({ expect }) => {
+    let textDocument = await c.openDocument({
+      text: '<div class="bg-[#000]">',
+    })
+
+    let res = await c.sendRequest(HoverRequest.type, {
+      textDocument,
+      position: { line: 0, character: 13 },
+    })
+
+    expect(res).toEqual({
+      contents: {
+        language: 'css',
+        value:
+          '.bg-\\[\\#000\\] {\n  --tw-bg-opacity: 1;\n  background-color: rgb(0 0 0 / var(--tw-bg-opacity)) /* #000000 */;\n}',
+      },
+      range: { start: { line: 0, character: 12 }, end: { line: 0, character: 21 } },
+    })
+  })
+})

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/(parens)/file.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/(parens)/file.html
@@ -1,0 +1,1 @@
+<div class="bg-[#f00]">test</div>

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/(parens)/tailwind.config.js
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/(parens)/tailwind.config.js
@@ -1,0 +1,3 @@
+export default {
+  //
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/[brackets]/file.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/[brackets]/file.html
@@ -1,0 +1,1 @@
+<div class="bg-[#0f0]">test</div>

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/[brackets]/tailwind.config.js
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/[brackets]/tailwind.config.js
@@ -1,0 +1,3 @@
+export default {
+  //
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/basic/file.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/basic/file.html
@@ -1,0 +1,1 @@
+<div class="bg-[#000]">test</div>

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/basic/tailwind.config.js
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/basic/tailwind.config.js
@@ -1,0 +1,3 @@
+export default {
+  //
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/{curlies}/file.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/{curlies}/file.html
@@ -1,0 +1,1 @@
+<div class="bg-[#00f]">test</div>

--- a/packages/tailwindcss-language-server/tests/fixtures/document-selection/{curlies}/tailwind.config.js
+++ b/packages/tailwindcss-language-server/tests/fixtures/document-selection/{curlies}/tailwind.config.js
@@ -1,0 +1,3 @@
+export default {
+  //
+}

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix detection of v3 insiders builds ([#1007](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1007))
 - Make sure language-specific settings are passed to our language server ([#1006](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1006))
+- Fix initialization when path contains parentheses ([#1009](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1009))
 
 ## 0.12.3
 


### PR DESCRIPTION
Project paths are turned into "selectors" passed to `picomatch`. However, parentheses are special characters in `picomatch` and must be escaped. This PR does this and adds tests for these cases as well.

Fixes #1008