### PR TITLE
feat(util/languages): add built-in support for `.svx` files

### DIFF
--- a/packages/tailwindcss-language-service/src/util/languages.ts
+++ b/packages/tailwindcss-language-service/src/util/languages.ts
@@ -33,6 +33,7 @@ export const htmlLanguages = [
   'razor',
   'slim',
   'surface',
+  'svx',
   'twig',
 ]
 


### PR DESCRIPTION
`.svx` is an extension used by [MDsveX](https://github.com/pngwn/MDsveX).

Current workaround is to add `.svx` in `settings.json` to support tailwindcss intellisense:

```json
{
  "tailwindCSS.includeLanguages": {
    "svx": "html"
  }
}
```

![Screenshot 2024-07-04 001843](https://github.com/tailwindlabs/tailwindcss-intellisense/assets/50759463/64b208c9-70d6-4bc8-89bd-36ca527c83d8)
