### PR TITLE
fix: enable $ in the `classAttributes` setting

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -158,7 +158,13 @@ async function findCustomClassLists(
 }
 
 export function matchClassAttributes(text: string, attributes: string[]): RegExpMatchArray[] {
-  const attrs = attributes.filter((x) => typeof x === 'string').flatMap((a) => [a, `\\[${a}\\]`])
+  const attrs = attributes.filter((x) => typeof x === 'string')
+    .map(a => {
+      // escape $, since it is the only character that is both a special RegExp character and a valid JSX + XML attribute
+      if (a.includes('\\$')) return a; // they already escaped this, so escaping again would produce a useless RegExp (with $)
+      return a.replaceAll('$', '\\$')
+    })
+    .flatMap((a) => [a, `\\[${a}\\]`])
   const re = /(?:\s|:|\()(ATTRS)\s*=\s*['"`{]/
   return findAll(new RegExp(re.source.replace('ATTRS', attrs.join('|')), 'gi'), text)
 }
@@ -212,7 +218,7 @@ export async function findClassListsInHtmlRange(
           currentClassList = undefined
         }
       }
-    } catch (_) {}
+    } catch (_) { }
 
     if (currentClassList) {
       classLists.push({


### PR DESCRIPTION
We maintain backward compatibility by checking if the existing classAttributes setting is already escaping the dollar sign.

The current workaround for this is to simply escape the `$` manually, which is what I can do in the meantime.

![2024-07-04 phosphor code-workspace — phosphor (Workspace) at 12 32PM@2x](https://github.com/tailwindlabs/tailwindcss-intellisense/assets/2925395/d228a23f-698d-45e3-b6f4-87348001c73c)
