### PR TITLE
Use paths relative to opened folder when searching for projects

### DIFF
--- a/packages/tailwindcss-language-server/src/project-locator.test.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.test.ts
@@ -40,6 +40,14 @@ function testFixture(fixture: string, details: any[]) {
 
         expect(actual).toEqual(expected)
       }
+
+      if (detail?.selectors) {
+        let expected = detail?.selectors.map((path) => path.replace('{URL}', fixturePath)).sort()
+
+        let actual = project.documentSelector.map((selector) => selector.pattern).sort()
+
+        expect(actual).toEqual(expected)
+      }
     }
 
     expect(projects).toHaveLength(details.length)
@@ -90,10 +98,35 @@ testFixture('v4/multi-config', [
 ])
 
 testFixture('v4/workspaces', [
-  { config: 'packages/admin/app.css' },
-  // { config: 'packages/shared/ui.css' }, // Should this be included?
-  // { config: 'packages/style-export/lib.css' }, // Should this be included?
-  { config: 'packages/web/app.css' },
+  {
+    config: 'packages/admin/app.css',
+    selectors: [
+      '{URL}/node_modules/tailwindcss/**',
+      '{URL}/node_modules/tailwindcss/index.css',
+      '{URL}/node_modules/tailwindcss/theme.css',
+      '{URL}/node_modules/tailwindcss/utilities.css',
+      '{URL}/packages/admin/**',
+      '{URL}/packages/admin/app.css',
+      '{URL}/packages/admin/package.json',
+    ],
+  },
+  {
+    config: 'packages/web/app.css',
+    selectors: [
+      '{URL}/node_modules/tailwindcss/**',
+      '{URL}/node_modules/tailwindcss/index.css',
+      '{URL}/node_modules/tailwindcss/theme.css',
+      '{URL}/node_modules/tailwindcss/utilities.css',
+      '{URL}/packages/style-export/**',
+      '{URL}/packages/style-export/lib.css',
+      '{URL}/packages/style-export/theme.css',
+      '{URL}/packages/style-main-field/**',
+      '{URL}/packages/style-main-field/lib.css',
+      '{URL}/packages/web/**',
+      '{URL}/packages/web/app.css',
+      '{URL}/packages/web/package.json',
+    ],
+  },
 ])
 
 testFixture('v4/auto-content', [

--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -242,20 +242,8 @@ export class ProjectLocator {
       concurrency: Math.max(os.cpus().length, 1),
     })
 
-    files = await Promise.all(
-      files.map(async (file) => {
-        // Resolve symlinks for all found files
-        let actualPath = await fs.realpath(file)
-
-        // Ignore network paths on Windows. Resolving relative paths on a
-        // netshare throws in `enhanced-resolve` :/
-        if (actualPath.startsWith('\\') && process.platform === 'win32') {
-          return normalizePath(file)
-        }
-
-        return normalizePath(actualPath)
-      }),
-    )
+    // Make sure Windows-style paths are normalized
+    files = files.map((file) => normalizePath(file))
 
     // Deduplicate the list of files and sort them for deterministic results
     // across environments

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -798,11 +798,6 @@ export class TW {
     // to normalize it so that we can compare it properly.
     fsPath = normalizeDriveLetter(fsPath)
 
-    console.debug('[GLOBAL] Matching project to document', {
-      fsPath,
-      normalPath,
-    })
-
     for (let project of this.projects.values()) {
       if (!project.projectConfig.configPath) {
         fallbackProject = fallbackProject ?? project
@@ -852,7 +847,16 @@ export class TW {
       }
     }
 
-    return matchedProject ?? fallbackProject
+    let project = matchedProject ?? fallbackProject
+
+    if (!project) {
+      console.debug('[GLOBAL] No matching project for document', {
+        fsPath,
+        normalPath,
+      })
+    }
+
+    return project
   }
 
   async onDocumentColor(params: DocumentColorParams): Promise<ColorInformation[]> {

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -634,9 +634,15 @@ export class TW {
   }
 
   private filterNewWatchPatterns(patterns: string[]) {
-    let newWatchPatterns = patterns.filter((pattern) => !this.watched.includes(pattern))
-    this.watched.push(...newWatchPatterns)
-    return newWatchPatterns
+    // Make sure the list of patterns is unique
+    patterns = Array.from(new Set(patterns))
+
+    // Filter out any patterns that are already being watched
+    patterns = patterns.filter((pattern) => !this.watched.includes(pattern))
+
+    this.watched.push(...patterns)
+
+    return patterns
   }
 
   private async addProject(

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Use paths relative to opened folder when searching for projects ([#1013](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1013))
 
 ## 0.12.4
 


### PR DESCRIPTION
In Intellisense we look through a workspace's folders to find JS/TS config files (v3) and CSS config files (v4). In v4 specifically, we must do import resolution and graphing to ensure we find the "root" CSS files in a project. Doing so correctly requires the use of a file's "real path" because we may encounter symlinks that point back to the same file.

However, we're currently using the real path in all paths we find when searching for files in a project. The problem is that files opened in VSCode are not matched against the real path but the path that was opened. For example, if you open a file through a symlink, all paths we see are generally relative to that symlink. Given that we're using the real path to a file this means matching files to a project can fail because, while the file may be tecnically the same, the path of the opened file does not match the real path of the project itself.

This can affect opening projects when:
- It's opened via a symlink — can affect Windows, Linux, or macOS
- On Windows, it's on a virtual disk that's mounted as a directory on another drive (e.g. `C:\Users\sarahjane\Projects` points to `E:\`)
- On Windows, you've opened a file on a mapped network drive (e.g. `Z:` points to `\\server\share\project`)

Given this, it's best for us is to perform globs, file lookups, and pattern matching against paths relative to the opened file URIs. However, we still use real paths internally when doing CSS graph traversal so we can find the correct CSS files in a project. We also use these real paths to help eliminate symlinks when we're already considering the real path of a file.
