### PR TITLE
Merge user languages from initialization options and include languages

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -169,6 +169,14 @@ export class TW {
   }
 
   private async _initFolder(baseUri: URI): Promise<void> {
+    let initUserLanguages = this.initializeParams.initializationOptions?.userLanguages ?? {}
+
+    if (Object.keys(initUserLanguages).length > 0) {
+      console.warn(
+        'Language mappings are currently set via initialization options (`userLanguages`). This is deprecated and will be removed in a future release. Please use the `tailwindCSS.includeLanguages` setting instead.',
+      )
+    }
+
     let base = baseUri.fsPath
     let workspaceFolders: Array<ProjectConfig> = []
     let globalSettings = await this.settingsCache.get()
@@ -176,11 +184,11 @@ export class TW {
 
     // Get user languages for the given workspace folder
     let folderSettings = await this.settingsCache.get(baseUri.toString())
-    let userLanguages = folderSettings.tailwindCSS.includeLanguages
 
-    // Fall back to settings defined in `initializationOptions` if invalid
-    if (!isObject(userLanguages)) {
-      userLanguages = this.initializeParams.initializationOptions?.userLanguages ?? {}
+    // Merge the languages from the global settings with the languages from the workspace folder
+    let userLanguages = {
+      ...initUserLanguages,
+      ...(folderSettings.tailwindCSS.includeLanguages ?? {}),
     }
 
     let cssFileConfigMap: Map<string, string> = new Map()


### PR DESCRIPTION
Before v0.12.x we'd look at the `tailwindCSS.includeLanguages` setting in the extension, populate the `userLanguages` initialization option, and start the server. This setup necessitated a restart of the process whenever this setting changed. In v0.12.x we changed this so that we'd request the user's languages from the settings instead from the initiialization options. This allows us to keep the server running even when the settings change.

As part of this, for attempted backwards compatability, in v0.12.x (language server v0.0.16+) we'd still look at the `userLanguages` initialization option if it was present and only use it if no `tailwindCSS.includeLanguages` setting was present for a given workspace folder. However, it appears that this setting may end up populated and we'd ignore the `userLanguages` setting altogether when we shouldn't have.

To fix this we're going to merge in the `userLanguages` setting from the initialization options with the `tailwindCSS.includeLanguages` setting if present. Any mappings from settings will take precedence over those from the `userLanguages` initialization option.

I'm also explicitly warning when the `userLanguages` initialization option is present and noting it as a deprecated feature and telling users to use the `tailwindCSS.includeLanguages` setting instead.

Fixes #1002