### PR TITLE
Delay activation

### DIFF
--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -34,9 +34,7 @@
     "color": "#f9fafb"
   },
   "icon": "media/icon.png",
-  "activationEvents": [
-    "onStartupFinished"
-  ],
+  "activationEvents": [],
   "main": "dist/extension.js",
   "capabilities": {
     "virtualWorkspaces": false


### PR DESCRIPTION
This PR changes `activationEvents` from `onStartupFinished` to `onLanguage:tailwindcss`, which will be generated automatically since VSCode 1.74, so omitted.

Reference: https://code.visualstudio.com/api/references/activation-events#onLanguage