### PR TITLE
adjust `HAS_IMPORT` regex

### DIFF
--- a/packages/tailwindcss-language-server/src/project-locator.test.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.test.ts
@@ -152,6 +152,19 @@ testFixture('v4/auto-content', [
   },
 ])
 
+testFixture('v4/auto-content-split', [
+  //
+  {
+    config: 'src/app.css',
+    content: [
+      '{URL}/package.json',
+      '{URL}/src/index.html',
+      '{URL}/src/components/example.html',
+      '{URL}/src/**/*.{py,tpl,js,vue,php,mjs,cts,jsx,tsx,rhtml,slim,handlebars,twig,rs,njk,svelte,liquid,pug,md,ts,heex,mts,astro,nunjucks,rb,eex,haml,cjs,html,hbs,jade,aspx,razor,erb,mustache,mdx}',
+    ],
+  },
+])
+
 testFixture('v4/custom-source', [
   //
   {

--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -661,7 +661,7 @@ class FileEntry {
   isMaybeTailwindRelated(): boolean {
     if (!this.content) return false
 
-    let HAS_IMPORT = /@import\s*('[^']+'|"[^"]+");/
+    let HAS_IMPORT = /@import\s*['"]/
     let HAS_TAILWIND = /@tailwind\s*[^;]+;/
     let HAS_DIRECTIVE = /@(theme|plugin|config|utility|variant|apply)\s*[^;{]+[;{]/
 

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package-lock.json
@@ -1,0 +1,200 @@
+{
+  "name": "auto-content-split",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@tailwindcss/oxide": "^4.0.0-alpha.25",
+        "tailwindcss": "^4.0.0-alpha.25"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-B5ynEG7AuiYrIY8a+IZZ23fPAzMfViemqtt6A0CBC1qdEXQoUfX9IuZ/s6eGAaUQ+Ify+5rfCPyUFZPQHC8kGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.25",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.25"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-3YOWSqtVRxw7cQMlkZsIax4J6+0oeCCZzl7bsJXdorHCW4UQuNZWsnGo3u58fON2/H6TM8O38LY18NS/ibPtog==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-YlfFSA7HTFELwspc4jFF5e9SO/Yj2wXpMOHPLiXKix3ykK44703mSs/JHRIJApL0cLYL12Xk2cJDXu/kvf3zDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-Ml9nmmff/RXtQ3BWXmnMT+UuXa1zpDLv7tUe7Wk5Ji1Vzb+N98TeC307HjM4/nnq+2sivN7NQ0Bezuoc3zeoFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-qE4BSZfamzpyX0pTNCGYPxK65v+BbyCP2LyJLLINCf95QDLKMjjHaheJ/VDtJ0t3Yx7fgv4uqkxsavmSYsModA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-2lHD9BvBzAbxnSxpZ2CTIHTAOwImf78V7WFALoJLx7jpRw/NRkC4UhDdML/qBka2ARGr9C7cwKr7KsI+8FK88w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-X8nohOQ/0u1bGoG25/4kZGV2N0aYBuvztTh/iAJwKj2zfZtZ082kv+6Ye4heDIGk2pZslsQchw9mtBkcA8rHVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-OFb6hRpFD9WgV1EtYifxcB/KuqzUOsEebEAvT7OGu6CaLc0EMTWFOy0vaiF8flp67oofyqoj65Q12p305+SzSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-hnAWqYGqsjoC2kxJAEMKQoNK4lQfd/k/EZJw7Ep8ETMwEF7Y0bIuT/0IWwQ/JnFkRsYKYYuPt+6VwpJ6nGXclQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-LpE7gYpHZPMHaHivri3bMau/ib3uqSGzsEoKZmMF1FAahsqXS6gjoxlH2zlrQUYSHwcopIJ+uTS2LKn+7SvOiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-LafwWEuJl/2Jba6yArcE49GGA/bGT9GeLo1NyKqi0n7sGAdQwUXKVFWyL3OimNGS335l4cH8uuv3AnstsVm3Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.25.tgz",
+      "integrity": "sha512-nysTVicWw8JC06+EAJvT8+4RAV7qZpuKwz0QOpfL88/+XKG+HIrawSz5XxXigF48l37ehZfREbqGiS7cCN90jg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "tailwindcss": "^4.0.0-alpha.25",
+    "@tailwindcss/oxide": "^4.0.0-alpha.25"
+  }
+}

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/src/app.css
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/src/app.css
@@ -1,0 +1,3 @@
+@import "tailwindcss/preflight" layer(base);
+@import "tailwindcss/theme" layer(theme);
+@import "tailwindcss/utilities" layer(utilities);

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/src/components/example.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/src/components/example.html
@@ -1,0 +1,1 @@
+<div class="underline">Test</div>

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/src/index.html
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/src/index.html
@@ -1,0 +1,1 @@
+<div class="flex">Test</div>


### PR DESCRIPTION
fix #1060 

match RegExp `HAS_IMPORT` with `fileMayBeTailwindRelated()`

---

```js
let HAS_IMPORT = /@import\s*('[^']+'|"[^"]+");/
let HAS_IMPORT = /@import\s*['"]/ // from fileMayBeTailwindRelated()
```

It seemed like the regex only accepted `@import '~~~';`, so `@import '~~~' layer(xxx);` did not match.
Therefore, I loosened the regex of `HAS_IMPORT` a bit so that it would match the other parts.

<sub>translated from japanese</sub>