### PR TITLE
Fix display of color swatches using new v4 oklch color palette 

### DIFF
--- a/packages/tailwindcss-language-server/tests/colors/colors.test.js
+++ b/packages/tailwindcss-language-server/tests/colors/colors.test.js
@@ -1,4 +1,4 @@
-import { test } from 'vitest'
+import { test, expect } from 'vitest'
 import { withFixture } from '../common'
 
 withFixture('basic', (c) => {
@@ -169,9 +169,9 @@ withFixture('v4/basic', (c) => {
       {
         range: { start: { line: 0, character: 12 }, end: { line: 0, character: 22 } },
         color: {
-          red: 0.9372549019607843,
-          green: 0.26666666666666666,
-          blue: 0.26666666666666666,
+          red: expect.closeTo(0.98, 0.01),
+          green: expect.closeTo(0.172, 0.01),
+          blue: expect.closeTo(0.21, 0.01),
           alpha: 1,
         },
       },
@@ -184,9 +184,9 @@ withFixture('v4/basic', (c) => {
       {
         range: { start: { line: 0, character: 12 }, end: { line: 0, character: 25 } },
         color: {
-          red: 0.9372549019607843,
-          green: 0.26666666666666666,
-          blue: 0.26666666666666666,
+          red: expect.closeTo(0.98, 0.01),
+          green: expect.closeTo(0.172, 0.01),
+          blue: expect.closeTo(0.21, 0.01),
           alpha: 0.2,
         },
       },

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -310,8 +310,8 @@ withFixture('v4/basic', (c) => {
     let result = await completion({ lang, text, position, settings })
     let textEdit = expect.objectContaining({ range: { start: position, end: position } })
 
-    expect(result.items.length).toBe(12398)
-    expect(result.items.filter((item) => item.label.endsWith(':')).length).toBe(224)
+    expect(result.items.length).toBe(12492)
+    expect(result.items.filter((item) => item.label.endsWith(':')).length).toBe(270)
     expect(result).toEqual({
       isIncomplete: false,
       items: expect.arrayContaining([
@@ -553,11 +553,11 @@ withFixture('v4/basic', (c) => {
     expect(resolved).toEqual({
       ...item,
       detail:
-        'font-size: var(--font-size-sm, 0.875rem /* 8.75px */); line-height: var(--font-size-sm--line-height, 1.25rem /* 12.5px */);',
+        'font-size: var(--font-size-sm, 0.875rem /* 8.75px */); line-height: var(--tw-leading, var(--font-size-sm--line-height, 1.25rem /* 12.5px */));',
       documentation: {
         kind: 'markdown',
         value:
-          '```css\n.text-sm {\n  font-size: var(--font-size-sm, 0.875rem /* 8.75px */);\n  line-height: var(--font-size-sm--line-height, 1.25rem /* 12.5px */);\n}\n```',
+          '```css\n.text-sm {\n  font-size: var(--font-size-sm, 0.875rem /* 8.75px */);\n  line-height: var(--tw-leading, var(--font-size-sm--line-height, 1.25rem /* 12.5px */));\n}\n```',
       },
     })
   })
@@ -579,8 +579,8 @@ withFixture('v4/basic', (c) => {
 
     expect(resolved).toEqual({
       ...item,
-      detail: 'background-color: var(--color-red-500, #ef4444);',
-      documentation: '#ef4444',
+      detail: 'background-color: var(--color-red-500, oklch(0.637 0.237 25.331));',
+      documentation: '#fb2c36',
     })
   })
 })

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package-lock.json
@@ -5,39 +5,37 @@
   "packages": {
     "": {
       "dependencies": {
-        "@tailwindcss/oxide": "^4.0.0-alpha.25",
-        "tailwindcss": "^4.0.0-alpha.25"
+        "@tailwindcss/oxide": "^4.0.0-alpha.30",
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-B5ynEG7AuiYrIY8a+IZZ23fPAzMfViemqtt6A0CBC1qdEXQoUfX9IuZ/s6eGAaUQ+Ify+5rfCPyUFZPQHC8kGQ==",
-      "license": "MIT",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-aH+q+sLQvO2t/mxQqhXlgjg+QOpvzzDlXDFVzT4V8jmUtPm3UpkVtUiZDF6AlxP6uyBSTmucnGOkQlIOyDf2+w==",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.25",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.25"
+        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.30"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-3YOWSqtVRxw7cQMlkZsIax4J6+0oeCCZzl7bsJXdorHCW4UQuNZWsnGo3u58fON2/H6TM8O38LY18NS/ibPtog==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-x28uMkZKYuFCcEZcBrInec5kSRlrd/GdjxA110esxHYtig7C0/cyIlwRI03m4jqS0IlO6eMj4LzLSlj1pgsMpg==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -47,13 +45,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-YlfFSA7HTFELwspc4jFF5e9SO/Yj2wXpMOHPLiXKix3ykK44703mSs/JHRIJApL0cLYL12Xk2cJDXu/kvf3zDA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-MuNVa6+loTi39ET3HxVXonL47az62MX/S9TX4hSIXKOo84nB3hYascqUnB4ZuyQTQSvwzZPgjLc29TufcezxFw==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -63,13 +60,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-Ml9nmmff/RXtQ3BWXmnMT+UuXa1zpDLv7tUe7Wk5Ji1Vzb+N98TeC307HjM4/nnq+2sivN7NQ0Bezuoc3zeoFQ==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-+kj9hAbzZxq9bvMMNKh8A3FBV6mHS736Y8z4QcBNdZN6+0qBvs2wtACY5oa26E2VZ9ZhKs38NFI2gj1iOhTwjQ==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -79,13 +75,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-qE4BSZfamzpyX0pTNCGYPxK65v+BbyCP2LyJLLINCf95QDLKMjjHaheJ/VDtJ0t3Yx7fgv4uqkxsavmSYsModA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-ThicD5q5uZnHW6sk4eQXDIwkAUhrHz93ELyZ9tB+0vhCim/wDQWRyhmjWDggRJ7yuUi9PDGqcQkY0JPHFDm/WA==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -95,13 +90,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-2lHD9BvBzAbxnSxpZ2CTIHTAOwImf78V7WFALoJLx7jpRw/NRkC4UhDdML/qBka2ARGr9C7cwKr7KsI+8FK88w==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-tG9MaQQ+wcRjy3EPpDzQu4/EXyE1JayxQHMOlfI23rrm7SmRToo9XAnweSAMdEbOHtaQHEzVPn3hb4rvCSY0Zw==",
       "cpu": [
         "arm"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -111,13 +105,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-X8nohOQ/0u1bGoG25/4kZGV2N0aYBuvztTh/iAJwKj2zfZtZ082kv+6Ye4heDIGk2pZslsQchw9mtBkcA8rHVA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-/hjhV7dnk3iOhGrXA8sOZepG9UXdtc0kYy/jY56qQEk3O7BW97NFHDXdKbf3Devb2/2kq7u7iUsO8iULMxIlKA==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -127,13 +120,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-OFb6hRpFD9WgV1EtYifxcB/KuqzUOsEebEAvT7OGu6CaLc0EMTWFOy0vaiF8flp67oofyqoj65Q12p305+SzSw==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-ATa4Sp8Q5PUbF3YTMsVOWAKnqGMQsfnpBcYfr6LCEStXl5ZR6cmYdcb6D8GJnWe7dnmiEss/7ou/X3N64Fr/YQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -143,13 +135,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-hnAWqYGqsjoC2kxJAEMKQoNK4lQfd/k/EZJw7Ep8ETMwEF7Y0bIuT/0IWwQ/JnFkRsYKYYuPt+6VwpJ6nGXclQ==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-DW3FkPQ3qXL+3hV0i01KR7e0klvoJFUOTwdpw1cJnlLIEjHc1C7y5Etbe+t/DRbYf0rgD8bwUW4Iob0PwtPF+A==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -159,13 +150,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-LpE7gYpHZPMHaHivri3bMau/ib3uqSGzsEoKZmMF1FAahsqXS6gjoxlH2zlrQUYSHwcopIJ+uTS2LKn+7SvOiA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-TEHzeAPrn81IgqSj4qfBONWRS5v0A+tEhK3MdagebNgypZeZYfIogNKEmEZ2hUA31hxpaSnIv8YBV64cj61rqw==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -175,13 +165,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-LafwWEuJl/2Jba6yArcE49GGA/bGT9GeLo1NyKqi0n7sGAdQwUXKVFWyL3OimNGS335l4cH8uuv3AnstsVm3Bw==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-SmxTfm5Tluqhl9qOETsTM/tSk7LnV03lHMlgVXtHv8BUmqNKx1ZsJe/wnRHq2P0BvlfRrHiqTH/GRM5q9wewRw==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -191,10 +180,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.25.tgz",
-      "integrity": "sha512-nysTVicWw8JC06+EAJvT8+4RAV7qZpuKwz0QOpfL88/+XKG+HIrawSz5XxXigF48l37ehZfREbqGiS7cCN90jg==",
-      "license": "MIT"
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content-split/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.25",
-    "@tailwindcss/oxide": "^4.0.0-alpha.25"
+    "tailwindcss": "^4.0.0-alpha.30",
+    "@tailwindcss/oxide": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package-lock.json
@@ -5,34 +5,34 @@
   "packages": {
     "": {
       "dependencies": {
-        "@tailwindcss/oxide": "^4.0.0-alpha.21",
-        "tailwindcss": "^4.0.0-alpha.21"
+        "@tailwindcss/oxide": "^4.0.0-alpha.30",
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-58l1/FQrYbQM15ksVmwRcAqQfO6s40ihpYM2vJUDdKQXl9FNipl9rRI7TnvwV93degUgaC/hdLId8LoJOrTQ1Q==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-aH+q+sLQvO2t/mxQqhXlgjg+QOpvzzDlXDFVzT4V8jmUtPm3UpkVtUiZDF6AlxP6uyBSTmucnGOkQlIOyDf2+w==",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.21",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.21"
+        "@tailwindcss/oxide-android-arm64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-darwin-x64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.0-alpha.30",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.0-alpha.30"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-GXMA77D4+qI3lCo7EMU4HEETm8jgyUshuVkhJQczLlR2nBqaQZ3xk4aFBNmyTjAdKWVjwXVj7uINe4ggZJSvXg==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-x28uMkZKYuFCcEZcBrInec5kSRlrd/GdjxA110esxHYtig7C0/cyIlwRI03m4jqS0IlO6eMj4LzLSlj1pgsMpg==",
       "cpu": [
         "arm64"
       ],
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-F0pxXQV+IWLRWFmlrgvo3yDtQpMx2DzvjCoC40IHGS9WnWtLO6H0JRInhatQT/04Ov+JIbOF/aXSUo/uAwXQCA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-MuNVa6+loTi39ET3HxVXonL47az62MX/S9TX4hSIXKOo84nB3hYascqUnB4ZuyQTQSvwzZPgjLc29TufcezxFw==",
       "cpu": [
         "arm64"
       ],
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-EyYoSEQQxYxEkWKaXs3hh5QXPjd4JQIsKXBhZvAmFPLLMyD3THL5SO8Jt2AQC5SXPFSCJRhCLDfaiACpw1orUA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-+kj9hAbzZxq9bvMMNKh8A3FBV6mHS736Y8z4QcBNdZN6+0qBvs2wtACY5oa26E2VZ9ZhKs38NFI2gj1iOhTwjQ==",
       "cpu": [
         "x64"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-FShflqJxKlMs6sYb+tvfT6SIkz9P8VrJ1FCrv/poQJaC/MP0MWmHWVsGbyz0M3MpYh7rzuNFnDTrMNCkvq2ahg==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-ThicD5q5uZnHW6sk4eQXDIwkAUhrHz93ELyZ9tB+0vhCim/wDQWRyhmjWDggRJ7yuUi9PDGqcQkY0JPHFDm/WA==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Pw4lony5efd8JpcY0WXL1VtqXjAuegQXthHKkXd9I83WcSxZ8gt6HHCt5DYzwPl52CVQDAzz796bX7LTGxpEAA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-tG9MaQQ+wcRjy3EPpDzQu4/EXyE1JayxQHMOlfI23rrm7SmRToo9XAnweSAMdEbOHtaQHEzVPn3hb4rvCSY0Zw==",
       "cpu": [
         "arm"
       ],
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-JGpy9u3JWUw4lJZCoFsxbuSnEsjN2E7Kq5frmG0RIoJKImwxShyQwrop1gE15iPP3GvF66zPqb/T5xQuq553xQ==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-/hjhV7dnk3iOhGrXA8sOZepG9UXdtc0kYy/jY56qQEk3O7BW97NFHDXdKbf3Devb2/2kq7u7iUsO8iULMxIlKA==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-wwQuSCMbaXpopzMyvrcZOpDhXmClwFV+WUZltr1Ij8B9Nyzw6ic1d3rVanXcS2B/e6x5ffyFLX63tp3GNXXU4A==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-ATa4Sp8Q5PUbF3YTMsVOWAKnqGMQsfnpBcYfr6LCEStXl5ZR6cmYdcb6D8GJnWe7dnmiEss/7ou/X3N64Fr/YQ==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-EPEX+T6F/UK6PKM8O9St+kT9vA2ohhy4orqxRQhWlByueDAfzcyALzPZFu+wafMpjIts6eU06lRcEy75tPc8+Q==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-DW3FkPQ3qXL+3hV0i01KR7e0klvoJFUOTwdpw1cJnlLIEjHc1C7y5Etbe+t/DRbYf0rgD8bwUW4Iob0PwtPF+A==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-spHkaxSSF7qzjT3+reWTEyfFQgduDJNjy/ceQ/tVesZ8NzV1yDO5YDMj0VHSnGYovVeeT5a4CofN0HZ0M1ydqg==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-TEHzeAPrn81IgqSj4qfBONWRS5v0A+tEhK3MdagebNgypZeZYfIogNKEmEZ2hUA31hxpaSnIv8YBV64cj61rqw==",
       "cpu": [
         "x64"
       ],
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-sGD+VsRLzXDGv51yhlXREzrWpLkNJWvbE/8fwpnobnevlHHhf8qlMs+T51OLGclT/VIMUtdZ7h7zt2a3ettdoA==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-SmxTfm5Tluqhl9qOETsTM/tSk7LnV03lHMlgVXtHv8BUmqNKx1ZsJe/wnRHq2P0BvlfRrHiqTH/GRM5q9wewRw==",
       "cpu": [
         "x64"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg=="
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/auto-content/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.21",
-    "@tailwindcss/oxide": "^4.0.0-alpha.21"
+    "tailwindcss": "^4.0.0-alpha.30",
+    "@tailwindcss/oxide": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.21"
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg=="
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/basic/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.21"
+    "tailwindcss": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/css-loading-js/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/css-loading-js/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.21"
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg=="
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/css-loading-js/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/css-loading-js/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.21"
+    "tailwindcss": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/custom-source/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/custom-source/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.21"
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg=="
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/custom-source/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/custom-source/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.21"
+    "tailwindcss": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/dependencies/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/dependencies/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.21"
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg=="
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/dependencies/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/dependencies/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.21"
+    "tailwindcss": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.21"
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg=="
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     }
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/multi-config/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.21"
+    "tailwindcss": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package-lock.json
@@ -8,7 +8,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "tailwindcss": "^4.0.0-alpha.21"
+        "tailwindcss": "^4.0.0-alpha.30"
       }
     },
     "node_modules/@private/admin": {
@@ -32,9 +32,9 @@
       "link": true
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.21.tgz",
-      "integrity": "sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg=="
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-e6OsN8n1nRLca2X8ix1QSa+oZA1IYktHw+epLI07+CeQzbLbIDNJieRdbcctM32TAy3vHKvEgdp0rM1WUbpIMQ=="
     },
     "packages/admin": {
       "name": "@private/admin"

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/workspaces/package.json
@@ -3,6 +3,6 @@
     "packages/*"
   ],
   "dependencies": {
-    "tailwindcss": "^4.0.0-alpha.21"
+    "tailwindcss": "^4.0.0-alpha.30"
   }
 }

--- a/packages/tailwindcss-language-server/tests/hover/hover.test.js
+++ b/packages/tailwindcss-language-server/tests/hover/hover.test.js
@@ -190,7 +190,8 @@ withFixture('v4/basic', (c) => {
   testHover('hover', {
     text: '<div class="bg-red-500">',
     position: { line: 0, character: 13 },
-    expected: '.bg-red-500 {\n  background-color: var(--color-red-500, #ef4444);\n}',
+    expected:
+      '.bg-red-500 {\n  background-color: var(--color-red-500, oklch(0.637 0.237 25.331));\n}',
     expectedRange: {
       start: { line: 0, character: 12 },
       end: { line: 0, character: 22 },

--- a/packages/tailwindcss-language-service/src/util/css-vars.test.ts
+++ b/packages/tailwindcss-language-service/src/util/css-vars.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+import { replaceCssVarsWithFallbacks } from './css-vars'
+
+test('replacing CSS variables with their fallbacks (when they have them)', () => {
+  expect(replaceCssVarsWithFallbacks('var(--foo, red)')).toBe(' red')
+  expect(replaceCssVarsWithFallbacks('var(--foo, )')).toBe(' ')
+
+  expect(replaceCssVarsWithFallbacks('rgb(var(--foo, 255 0 0))')).toBe('rgb( 255 0 0)')
+  expect(replaceCssVarsWithFallbacks('rgb(var(--foo, var(--bar)))')).toBe('rgb( var(--bar))')
+
+  expect(
+    replaceCssVarsWithFallbacks('rgb(var(var(--bar, var(--baz), var(--qux), var(--thing))))'),
+  ).toBe('rgb(var(var(--bar, var(--baz), var(--qux), var(--thing))))')
+
+  expect(
+    replaceCssVarsWithFallbacks(
+      'rgb(var(--one, var(--bar, var(--baz), var(--qux), var(--thing))))',
+    ),
+  ).toBe('rgb(  var(--baz), var(--qux), var(--thing))')
+
+  expect(
+    replaceCssVarsWithFallbacks(
+      'color-mix(in srgb, var(--color-primary, oklch(0 0 0 / 2.5)), var(--color-secondary, oklch(0 0 0 / 2.5)), 50%)',
+    ),
+  ).toBe('color-mix(in srgb,  oklch(0 0 0 / 2.5),  oklch(0 0 0 / 2.5), 50%)')
+})

--- a/packages/tailwindcss-language-service/src/util/css-vars.ts
+++ b/packages/tailwindcss-language-service/src/util/css-vars.ts
@@ -1,0 +1,29 @@
+export function replaceCssVarsWithFallbacks(str: string): string {
+  for (let i = 0; i < str.length; ++i) {
+    if (!str.startsWith('var(', i)) continue
+
+    let depth = 0
+    let fallbackStart = null
+
+    for (let j = i + 4; i < str.length; ++j) {
+      if (str[j] === '(') {
+        depth++
+      } else if (str[j] === ')' && depth > 0) {
+        depth--
+      } else if (str[j] === ',' && depth === 0 && fallbackStart === null) {
+        fallbackStart = j + 1
+      } else if (str[j] === ')' && depth === 0) {
+        if (fallbackStart === null) {
+          i = j + 1
+          break
+        }
+
+        let fallbackEnd = j
+        str = str.slice(0, i) + str.slice(fallbackStart, fallbackEnd) + str.slice(j + 1)
+        break
+      }
+    }
+  }
+
+  return str
+}

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Fix display of color swatches using new v4 oklch color palette ([#1073](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1073))
 
 ## 0.12.11
 


### PR DESCRIPTION
The new oklch color palette doesn't show swatches in some cases due to how we were detecting fallback values for CSS variables. I've made the code much more general and it should be able to handle any number of CSS var fallbacks regardless of how its nested.