### PR TITLE
Improve support for `source(…)` feature in v4

### DIFF
--- a/packages/tailwindcss-language-server/src/config.ts
+++ b/packages/tailwindcss-language-server/src/config.ts
@@ -27,6 +27,7 @@ function getDefaultSettings(): Settings {
         invalidVariant: 'error',
         invalidConfigPath: 'error',
         invalidTailwindDirective: 'error',
+        invalidSourceDirective: 'error',
         recommendedVariantOrder: 'warning',
       },
       showPixelEquivalents: true,

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -346,6 +346,12 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
         /@media(\s+screen\s*\([^)]+\))/g,
         (_match, screen) => `@media (${MEDIA_MARKER})${' '.repeat(screen.length - 4)}`,
       )
+      // Replace `@import "…" source()` with `@import "…"` otherwise we'll
+      // get warnings about expecting a semi-colon instead of the source function
+      .replace(
+        /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*source\([^)]+\)/g,
+        (_match, url) => `@import "${url.slice(1, -1)}"`,
+      )
       .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_')
 
   return TextDocument.create(

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -352,6 +352,12 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
         /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*source\([^)]+\)/g,
         (_match, url) => `@import "${url.slice(1, -1)}"`,
       )
+      // Replace `@import "…" theme()` with `@import "…"` otherwise we'll
+      // get warnings about expecting a semi-colon instead of the theme function
+      .replace(
+        /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*theme\([^)]+\)/g,
+        (_match, url) => `@import "${url.slice(1, -1)}"`,
+      )
       .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_')
 
   return TextDocument.create(

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -358,6 +358,12 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
         /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*theme\([^)]+\)/g,
         (_match, url) => `@import "${url.slice(1, -1)}"`,
       )
+      // Replace `@import "…" prefix()` with `@import "…"` otherwise we'll
+      // get warnings about expecting a semi-colon instead of the theme function
+      .replace(
+        /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*prefix\([^)]+\)/g,
+        (_match, url) => `@import "${url.slice(1, -1)}"`,
+      )
       .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_')
 
   return TextDocument.create(

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -346,22 +346,10 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
         /@media(\s+screen\s*\([^)]+\))/g,
         (_match, screen) => `@media (${MEDIA_MARKER})${' '.repeat(screen.length - 4)}`,
       )
-      // Replace `@import "…" source()` with `@import "…"` otherwise we'll
-      // get warnings about expecting a semi-colon instead of the source function
+      // Remove`source(…)`, `theme(…)`, and `prefix(…)` from `@import`s
+      // otherwise we'll show syntax-error diagnostics which we don't want
       .replace(
-        /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*source\([^)]+\)/g,
-        (_match, url) => `@import "${url.slice(1, -1)}"`,
-      )
-      // Replace `@import "…" theme()` with `@import "…"` otherwise we'll
-      // get warnings about expecting a semi-colon instead of the theme function
-      .replace(
-        /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*theme\([^)]+\)/g,
-        (_match, url) => `@import "${url.slice(1, -1)}"`,
-      )
-      // Replace `@import "…" prefix()` with `@import "…"` otherwise we'll
-      // get warnings about expecting a semi-colon instead of the theme function
-      .replace(
-        /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*prefix\([^)]+\)/g,
+        /@import\s*("(?:[^"]+)"|'(?:[^']+)')\s*((source|theme|prefix)\([^)]+\)\s*)+/g,
         (_match, url) => `@import "${url.slice(1, -1)}"`,
       )
       .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_')

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -336,11 +336,7 @@ function replace(delta = 0) {
 }
 
 function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
-  return TextDocument.create(
-    textDocument.uri,
-    textDocument.languageId,
-    textDocument.version,
-    textDocument
+  let content = textDocument
       .getText()
       .replace(/@screen(\s+[^{]+){/g, replace(-2))
       .replace(/@variants(\s+[^{]+){/g, replace())
@@ -350,7 +346,13 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
         /@media(\s+screen\s*\([^)]+\))/g,
         (_match, screen) => `@media (${MEDIA_MARKER})${' '.repeat(screen.length - 4)}`,
       )
-      .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_'),
+      .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_')
+
+  return TextDocument.create(
+    textDocument.uri,
+    textDocument.languageId,
+    textDocument.version,
+    content,
   )
 }
 

--- a/packages/tailwindcss-language-server/tests/completions/at-config.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/at-config.test.js
@@ -296,4 +296,90 @@ withFixture('v4/dependencies', (c) => {
       ],
     })
   })
+
+  test.concurrent('@import "…" source(…)', async ({ expect }) => {
+    let result = await completion({
+      text: '@import "tailwindcss" source("',
+      lang: 'css',
+      position: {
+        line: 0,
+        character: 30,
+      },
+    })
+
+    expect(result).toEqual({
+      isIncomplete: false,
+      items: [
+        {
+          label: 'sub-dir/',
+          kind: 19,
+          command: { command: 'editor.action.triggerSuggest', title: '' },
+          data: expect.anything(),
+          textEdit: {
+            newText: 'sub-dir/',
+            range: { start: { line: 0, character: 30 }, end: { line: 0, character: 30 } },
+          },
+        },
+      ],
+    })
+  })
+
+  test.concurrent('@tailwind utilities source(…)', async ({ expect }) => {
+    let result = await completion({
+      text: '@tailwind utilities source("',
+      lang: 'css',
+      position: {
+        line: 0,
+        character: 28,
+      },
+    })
+
+    expect(result).toEqual({
+      isIncomplete: false,
+      items: [
+        {
+          label: 'sub-dir/',
+          kind: 19,
+          command: { command: 'editor.action.triggerSuggest', title: '' },
+          data: expect.anything(),
+          textEdit: {
+            newText: 'sub-dir/',
+            range: { start: { line: 0, character: 28 }, end: { line: 0, character: 28 } },
+          },
+        },
+      ],
+    })
+  })
+
+  test.concurrent('@import "…" source(…) directory', async ({ expect }) => {
+    let result = await completion({
+      text: '@import "tailwindcss" source("sub-dir/',
+      lang: 'css',
+      position: {
+        line: 0,
+        character: 38,
+      },
+    })
+
+    expect(result).toEqual({
+      isIncomplete: false,
+      items: [],
+    })
+  })
+
+  test.concurrent('@tailwind utilities source(…) directory', async ({ expect }) => {
+    let result = await completion({
+      text: '@tailwind utilities source("sub-dir/',
+      lang: 'css',
+      position: {
+        line: 0,
+        character: 36,
+      },
+    })
+
+    expect(result).toEqual({
+      isIncomplete: false,
+      items: [],
+    })
+  })
 })

--- a/packages/tailwindcss-language-server/tests/completions/completions.test.js
+++ b/packages/tailwindcss-language-server/tests/completions/completions.test.js
@@ -507,6 +507,40 @@ withFixture('v4/basic', (c) => {
     )
   })
 
+  test.concurrent('@theme suggests options', async ({ expect }) => {
+    let result = await completion({
+      lang: 'css',
+      text: '@theme ',
+      position: { line: 0, character: 7 },
+    })
+
+    expect(result.items.length).toBe(3)
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'reference' }),
+        expect.objectContaining({ label: 'inline' }),
+        expect.objectContaining({ label: 'default' }),
+      ]),
+    )
+  })
+
+  test.concurrent('@import "…" theme(…) suggests options', async ({ expect }) => {
+    let result = await completion({
+      lang: 'css',
+      text: '@import "tailwindcss/theme" theme()',
+      position: { line: 0, character: 34 },
+    })
+
+    expect(result.items.length).toBe(3)
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'reference' }),
+        expect.objectContaining({ label: 'inline' }),
+        expect.objectContaining({ label: 'default' }),
+      ]),
+    )
+  })
+
   test.concurrent('resolve', async ({ expect }) => {
     let result = await completion({
       text: '<div class="">',

--- a/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
@@ -314,4 +314,34 @@ withFixture('v4/basic', (c) => {
       },
     ],
   })
+
+  testMatch('Old Tailwind directives warn when used in a v4 project', {
+    language: 'css',
+    code: `
+      @tailwind base;
+      @tailwind preflight;
+    `,
+    expected: [
+      {
+        code: 'invalidTailwindDirective',
+        message:
+          "'@tailwind base' is no longer available in v4. Use '@import \"tailwindcss/base\"' instead.",
+        range: {
+          start: { line: 1, character: 16 },
+          end: { line: 1, character: 20 },
+        },
+        severity: 1,
+      },
+      {
+        code: 'invalidTailwindDirective',
+        message:
+          "'@tailwind preflight' is no longer available in v4. Use '@import \"tailwindcss/base\"' instead.",
+        range: {
+          start: { line: 2, character: 16 },
+          end: { line: 2, character: 25 },
+        },
+        severity: 1,
+      },
+    ],
+  })
 })

--- a/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
@@ -320,6 +320,9 @@ withFixture('v4/basic', (c) => {
     code: `
       @tailwind base;
       @tailwind preflight;
+      @tailwind components;
+      @tailwind screens;
+      @tailwind variants;
     `,
     expected: [
       {
@@ -339,6 +342,36 @@ withFixture('v4/basic', (c) => {
         range: {
           start: { line: 2, character: 16 },
           end: { line: 2, character: 25 },
+        },
+        severity: 1,
+      },
+      {
+        code: 'invalidTailwindDirective',
+        message:
+          "'@tailwind components' is no longer available in v4. Use '@tailwind utilities' instead.",
+        range: {
+          start: { line: 3, character: 16 },
+          end: { line: 3, character: 26 },
+        },
+        severity: 1,
+      },
+      {
+        code: 'invalidTailwindDirective',
+        message:
+          "'@tailwind screens' is no longer available in v4. Use '@tailwind utilities' instead.",
+        range: {
+          start: { line: 4, character: 16 },
+          end: { line: 4, character: 23 },
+        },
+        severity: 1,
+      },
+      {
+        code: 'invalidTailwindDirective',
+        message:
+          "'@tailwind variants' is no longer available in v4. Use '@tailwind utilities' instead.",
+        range: {
+          start: { line: 5, character: 16 },
+          end: { line: 5, character: 24 },
         },
         severity: 1,
       },

--- a/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
@@ -329,6 +329,7 @@ withFixture('v4/basic', (c) => {
         code: 'invalidTailwindDirective',
         message:
           "'@tailwind base' is no longer available in v4. Use '@import \"tailwindcss/base\"' instead.",
+        suggestions: [],
         range: {
           start: { line: 1, character: 16 },
           end: { line: 1, character: 20 },
@@ -339,6 +340,7 @@ withFixture('v4/basic', (c) => {
         code: 'invalidTailwindDirective',
         message:
           "'@tailwind preflight' is no longer available in v4. Use '@import \"tailwindcss/base\"' instead.",
+        suggestions: [],
         range: {
           start: { line: 2, character: 16 },
           end: { line: 2, character: 25 },
@@ -349,6 +351,7 @@ withFixture('v4/basic', (c) => {
         code: 'invalidTailwindDirective',
         message:
           "'@tailwind components' is no longer available in v4. Use '@tailwind utilities' instead.",
+        suggestions: ['utilities'],
         range: {
           start: { line: 3, character: 16 },
           end: { line: 3, character: 26 },
@@ -359,6 +362,7 @@ withFixture('v4/basic', (c) => {
         code: 'invalidTailwindDirective',
         message:
           "'@tailwind screens' is no longer available in v4. Use '@tailwind utilities' instead.",
+        suggestions: ['utilities'],
         range: {
           start: { line: 4, character: 16 },
           end: { line: 4, character: 23 },
@@ -369,6 +373,7 @@ withFixture('v4/basic', (c) => {
         code: 'invalidTailwindDirective',
         message:
           "'@tailwind variants' is no longer available in v4. Use '@tailwind utilities' instead.",
+        suggestions: ['utilities'],
         range: {
           start: { line: 5, character: 16 },
           end: { line: 5, character: 24 },

--- a/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
@@ -328,7 +328,7 @@ withFixture('v4/basic', (c) => {
       {
         code: 'invalidTailwindDirective',
         message:
-          "'@tailwind base' is no longer available in v4. Use '@import \"tailwindcss/base\"' instead.",
+          "'@tailwind base' is no longer available in v4. Use '@import \"tailwindcss/preflight\"' instead.",
         suggestions: [],
         range: {
           start: { line: 1, character: 16 },
@@ -339,7 +339,7 @@ withFixture('v4/basic', (c) => {
       {
         code: 'invalidTailwindDirective',
         message:
-          "'@tailwind preflight' is no longer available in v4. Use '@import \"tailwindcss/base\"' instead.",
+          "'@tailwind preflight' is no longer available in v4. Use '@import \"tailwindcss/preflight\"' instead.",
         suggestions: [],
         range: {
           start: { line: 2, character: 16 },

--- a/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
@@ -1,8 +1,6 @@
 import { expect, test } from 'vitest'
 import { withFixture } from '../common'
 
-const css = String.raw
-
 withFixture('v4/basic', (c) => {
   function runTest(name, { code, expected, language }) {
     test(name, async () => {

--- a/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
@@ -90,7 +90,7 @@ withFixture('v4/basic', (c) => {
     expected: [
       {
         code: 'invalidSourceDirective',
-        message: '`source(no)` is invalid. Did you mean `source(none)`.',
+        message: '`source(no)` is invalid. Did you mean `source(none)`?',
         range: {
           start: { line: 1, character: 35 },
           end: { line: 1, character: 37 },
@@ -98,7 +98,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: '`source(no)` is invalid. Did you mean `source(none)`.',
+        message: '`source(no)` is invalid. Did you mean `source(none)`?',
         range: {
           start: { line: 2, character: 33 },
           end: { line: 2, character: 35 },

--- a/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
@@ -1,0 +1,194 @@
+import { expect, test } from 'vitest'
+import { withFixture } from '../common'
+
+const css = String.raw
+
+withFixture('v4/basic', (c) => {
+  function runTest(name, { code, expected, language }) {
+    test(name, async () => {
+      let promise = new Promise((resolve) => {
+        c.onNotification('textDocument/publishDiagnostics', ({ diagnostics }) => {
+          resolve(diagnostics)
+        })
+      })
+
+      let doc = await c.openDocument({ text: code, lang: language })
+      let diagnostics = await promise
+
+      expected = JSON.parse(JSON.stringify(expected).replaceAll('{{URI}}', doc.uri))
+
+      expect(diagnostics).toMatchObject(expected)
+    })
+  }
+
+  runTest('Source directives require paths', {
+    language: 'css',
+    code: `
+      @import 'tailwindcss' source();
+      @import 'tailwindcss' source('');
+      @import 'tailwindcss' source("");
+      @tailwind utilities source();
+      @tailwind utilities source('');
+      @tailwind utilities source("");
+    `,
+    expected: [
+      {
+        code: 'invalidSourceDirective',
+        message: 'Need a path for the source directive',
+        range: {
+          start: { line: 1, character: 35 },
+          end: { line: 1, character: 35 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: 'Need a path for the source directive',
+        range: {
+          start: { line: 2, character: 35 },
+          end: { line: 2, character: 37 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: 'Need a path for the source directive',
+        range: {
+          start: { line: 3, character: 35 },
+          end: { line: 3, character: 37 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: 'Need a path for the source directive',
+        range: {
+          start: { line: 4, character: 33 },
+          end: { line: 4, character: 33 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: 'Need a path for the source directive',
+        range: {
+          start: { line: 5, character: 33 },
+          end: { line: 5, character: 35 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: 'Need a path for the source directive',
+        range: {
+          start: { line: 6, character: 33 },
+          end: { line: 6, character: 35 },
+        },
+      },
+    ],
+  })
+
+  runTest('source(none) must not be mispelled', {
+    language: 'css',
+    code: `
+      @import 'tailwindcss' source(no);
+      @tailwind utilities source(no);
+    `,
+    expected: [
+      {
+        code: 'invalidSourceDirective',
+        message: '`source(no)` is invalid. Did you mean `source(none)`.',
+        range: {
+          start: { line: 1, character: 35 },
+          end: { line: 1, character: 37 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: '`source(no)` is invalid. Did you mean `source(none)`.',
+        range: {
+          start: { line: 2, character: 33 },
+          end: { line: 2, character: 35 },
+        },
+      },
+    ],
+  })
+
+  runTest('source("…") does not produce diagnostics', {
+    language: 'css',
+    code: `
+      @import 'tailwindcss' source('../app');
+      @tailwind utilities source('../app');
+      @import 'tailwindcss' source("../app");
+      @tailwind utilities source("../app");
+    `,
+    expected: [],
+  })
+
+  runTest('source("…") must not be a glob', {
+    language: 'css',
+    code: `
+      @import 'tailwindcss' source('../app/**/*.html');
+      @import 'tailwindcss' source('../app/index.{html,js}');
+      @tailwind utilities source('../app/**/*.html');
+      @tailwind utilities source('../app/index.{html,js}');
+    `,
+    expected: [
+      {
+        code: 'invalidSourceDirective',
+        message: `source('../app/**/*.html') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        range: {
+          start: { line: 1, character: 35 },
+          end: { line: 1, character: 53 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: `source('../app/index.{html,js}') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        range: {
+          start: { line: 2, character: 35 },
+          end: { line: 2, character: 59 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: `source('../app/**/*.html') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        range: {
+          start: { line: 3, character: 33 },
+          end: { line: 3, character: 51 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message: `source('../app/index.{html,js}') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        range: {
+          start: { line: 4, character: 33 },
+          end: { line: 4, character: 57 },
+        },
+      },
+    ],
+  })
+
+  runTest('paths given to source("…") must error when not POSIX', {
+    language: 'css',
+    code: String.raw`
+      @import 'tailwindcss' source('C:\\absolute\\path');
+      @import 'tailwindcss' source('C:relative.txt');
+    `,
+    expected: [
+      {
+        code: 'invalidSourceDirective',
+        message:
+          'POSIX-style paths are required with source() but `C:\\absolute\\path` is a Windows-style path.',
+        range: {
+          start: { line: 1, character: 35 },
+          end: { line: 1, character: 55 },
+        },
+      },
+      {
+        code: 'invalidSourceDirective',
+        message:
+          'POSIX-style paths are required with source() but `C:relative.txt` is a Windows-style path.',
+        range: {
+          start: { line: 2, character: 35 },
+          end: { line: 2, character: 51 },
+        },
+      },
+    ],
+  })
+})

--- a/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
@@ -32,7 +32,7 @@ withFixture('v4/basic', (c) => {
     expected: [
       {
         code: 'invalidSourceDirective',
-        message: 'Need a path for the source directive',
+        message: 'The source directive requires a path to a directory.',
         range: {
           start: { line: 1, character: 35 },
           end: { line: 1, character: 35 },
@@ -40,7 +40,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: 'Need a path for the source directive',
+        message: 'The source directive requires a path to a directory.',
         range: {
           start: { line: 2, character: 35 },
           end: { line: 2, character: 37 },
@@ -48,7 +48,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: 'Need a path for the source directive',
+        message: 'The source directive requires a path to a directory.',
         range: {
           start: { line: 3, character: 35 },
           end: { line: 3, character: 37 },
@@ -56,7 +56,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: 'Need a path for the source directive',
+        message: 'The source directive requires a path to a directory.',
         range: {
           start: { line: 4, character: 33 },
           end: { line: 4, character: 33 },
@@ -64,7 +64,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: 'Need a path for the source directive',
+        message: 'The source directive requires a path to a directory.',
         range: {
           start: { line: 5, character: 33 },
           end: { line: 5, character: 35 },
@@ -72,7 +72,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: 'Need a path for the source directive',
+        message: 'The source directive requires a path to a directory.',
         range: {
           start: { line: 6, character: 33 },
           end: { line: 6, character: 35 },
@@ -129,7 +129,7 @@ withFixture('v4/basic', (c) => {
     expected: [
       {
         code: 'invalidSourceDirective',
-        message: `source('../app/**/*.html') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        message: `\`source('../app/**/*.html')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
         range: {
           start: { line: 1, character: 35 },
           end: { line: 1, character: 53 },
@@ -137,7 +137,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: `source('../app/index.{html,js}') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        message: `\`source('../app/index.{html,js}')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
         range: {
           start: { line: 2, character: 35 },
           end: { line: 2, character: 59 },
@@ -145,7 +145,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: `source('../app/**/*.html') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        message: `\`source('../app/**/*.html')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
         range: {
           start: { line: 3, character: 33 },
           end: { line: 3, character: 51 },
@@ -153,7 +153,7 @@ withFixture('v4/basic', (c) => {
       },
       {
         code: 'invalidSourceDirective',
-        message: `source('../app/index.{html,js}') uses a glob but a glob cannot be used here. Use a directory name instead.`,
+        message: `\`source('../app/index.{html,js}')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
         range: {
           start: { line: 4, character: 33 },
           end: { line: 4, character: 57 },
@@ -172,7 +172,7 @@ withFixture('v4/basic', (c) => {
       {
         code: 'invalidSourceDirective',
         message:
-          'POSIX-style paths are required with source() but `C:\\absolute\\path` is a Windows-style path.',
+          'POSIX-style paths are required with `source(…)` but `C:\\absolute\\path` is a Windows-style path.',
         range: {
           start: { line: 1, character: 35 },
           end: { line: 1, character: 55 },
@@ -181,7 +181,7 @@ withFixture('v4/basic', (c) => {
       {
         code: 'invalidSourceDirective',
         message:
-          'POSIX-style paths are required with source() but `C:relative.txt` is a Windows-style path.',
+          'POSIX-style paths are required with `source(…)` but `C:relative.txt` is a Windows-style path.',
         range: {
           start: { line: 2, character: 35 },
           end: { line: 2, character: 51 },

--- a/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
@@ -118,50 +118,6 @@ withFixture('v4/basic', (c) => {
     expected: [],
   })
 
-  runTest('source("…") must not be a glob', {
-    language: 'css',
-    code: `
-      @import 'tailwindcss' source('../app/**/*.html');
-      @import 'tailwindcss' source('../app/index.{html,js}');
-      @tailwind utilities source('../app/**/*.html');
-      @tailwind utilities source('../app/index.{html,js}');
-    `,
-    expected: [
-      {
-        code: 'invalidSourceDirective',
-        message: `\`source('../app/**/*.html')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
-        range: {
-          start: { line: 1, character: 35 },
-          end: { line: 1, character: 53 },
-        },
-      },
-      {
-        code: 'invalidSourceDirective',
-        message: `\`source('../app/index.{html,js}')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
-        range: {
-          start: { line: 2, character: 35 },
-          end: { line: 2, character: 59 },
-        },
-      },
-      {
-        code: 'invalidSourceDirective',
-        message: `\`source('../app/**/*.html')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
-        range: {
-          start: { line: 3, character: 33 },
-          end: { line: 3, character: 51 },
-        },
-      },
-      {
-        code: 'invalidSourceDirective',
-        message: `\`source('../app/index.{html,js}')\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
-        range: {
-          start: { line: 4, character: 33 },
-          end: { line: 4, character: 57 },
-        },
-      },
-    ],
-  })
-
   runTest('paths given to source("…") must error when not POSIX', {
     language: 'css',
     code: String.raw`

--- a/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/source-diagnostics.test.js
@@ -83,7 +83,7 @@ withFixture('v4/basic', (c) => {
     ],
   })
 
-  runTest('source(none) must not be mispelled', {
+  runTest('source(none) must not be misspelled', {
     language: 'css',
     code: `
       @import 'tailwindcss' source(no);

--- a/packages/tailwindcss-language-server/tests/document-links/document-links.test.js
+++ b/packages/tailwindcss-language-server/tests/document-links/document-links.test.js
@@ -157,4 +157,19 @@ withFixture('v4/basic', (c) => {
     lang: 'css',
     expected: [],
   })
+
+  testDocumentLinks('Windows paths in source(…) do not show links', {
+    text: String.raw`
+      @import "tailwindcss" source("..\foo\bar");
+      @tailwind utilities source("..\foo\bar");
+
+      @import "tailwindcss" source("C:\foo\bar");
+      @tailwind utilities source("C:\foo\bar");
+
+      @import "tailwindcss" source("C:foo");
+      @tailwind utilities source("C:bar");
+    `,
+    lang: 'css',
+    expected: [],
+  })
 })

--- a/packages/tailwindcss-language-server/tests/document-links/document-links.test.js
+++ b/packages/tailwindcss-language-server/tests/document-links/document-links.test.js
@@ -130,4 +130,22 @@ withFixture('v4/basic', (c) => {
       },
     ],
   })
+
+  testDocumentLinks('Directories in source(…) show links', {
+    text: `
+      @import "tailwindcss" source("../../");
+      @tailwind utilities source("../../");
+    `,
+    lang: 'css',
+    expected: [
+      {
+        target: `file://${path.resolve('./tests/fixtures').replace(/@/g, '%40')}`,
+        range: { start: { line: 1, character: 35 }, end: { line: 1, character: 43 } },
+      },
+      {
+        target: `file://${path.resolve('./tests/fixtures').replace(/@/g, '%40')}`,
+        range: { start: { line: 2, character: 33 }, end: { line: 2, character: 41 } },
+      },
+    ],
+  })
 })

--- a/packages/tailwindcss-language-server/tests/document-links/document-links.test.js
+++ b/packages/tailwindcss-language-server/tests/document-links/document-links.test.js
@@ -148,4 +148,13 @@ withFixture('v4/basic', (c) => {
       },
     ],
   })
+
+  testDocumentLinks('Globs in source(…) do not show links', {
+    text: `
+      @import "tailwindcss" source("../{a,b,c}");
+      @tailwind utilities source("../{a,b,c}");
+    `,
+    lang: 'css',
+    expected: [],
+  })
 })

--- a/packages/tailwindcss-language-server/tests/fixtures/v4/dependencies/file.d.ts
+++ b/packages/tailwindcss-language-server/tests/fixtures/v4/dependencies/file.d.ts
@@ -1,0 +1,1 @@
+export type ColorSpace = 'srgb' | 'display-p3'

--- a/packages/tailwindcss-language-service/package.json
+++ b/packages/tailwindcss-language-service/package.json
@@ -19,6 +19,7 @@
     "@types/culori": "^2.1.0",
     "@types/moo": "0.5.3",
     "@types/semver": "7.3.10",
+    "braces": "3.0.3",
     "color-name": "1.1.4",
     "css.escape": "1.5.1",
     "culori": "^4.0.1",

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -1602,7 +1602,7 @@ function isInsideAtRule(name: string, document: TextDocument, position: Position
 
 // Provide completions for directives that take file paths
 const PATTERN_AT_THEME = /@(?<directive>theme)\s+(?:(?<parts>[^{]+)\s$|$)/
-const PATTERN_IMPORT_THEME = /@(?<directive>import)\s*[^;]+?theme\((?<parts>[^)]+)?\s$/
+const PATTERN_IMPORT_THEME = /@(?<directive>import)\s*[^;]+?theme\((?:(?<parts>[^)]+)\s$|$)/
 
 async function provideThemeDirectiveCompletions(
   state: State,

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -1615,8 +1615,6 @@ async function provideThemeDirectiveCompletions(
 
   let match = text.match(PATTERN_AT_THEME) ?? text.match(PATTERN_IMPORT_THEME)
 
-  console.log({ text, match })
-
   // Are we in a context where suggesting theme(…) stuff makes sense?
   if (!match) return null
 

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -1626,6 +1626,9 @@ async function provideFileDirectiveCompletions(
 
     if (suggest === 'source') return IS_TEMPLATE_SOURCE.test(name)
 
+    // Files are not allowed but directories are
+    if (suggest === 'directory') return false
+
     return false
   }
 
@@ -1638,16 +1641,16 @@ async function provideFileDirectiveCompletions(
     return type.isDirectory || isAllowedFile(name)
   })
 
+  let items: CompletionItem[] = entries.map(([name, type]) => ({
+    label: type.isDirectory ? name + '/' : name,
+    kind: type.isDirectory ? 19 : 17,
+    command: type.isDirectory ? { command: 'editor.action.triggerSuggest', title: '' } : undefined,
+  }))
+
   return withDefaults(
     {
       isIncomplete: false,
-      items: entries.map(([name, type]) => ({
-        label: type.isDirectory ? name + '/' : name,
-        kind: type.isDirectory ? 19 : 17,
-        command: type.isDirectory
-          ? { command: 'editor.action.triggerSuggest', title: '' }
-          : undefined,
-      })),
+      items,
     },
     {
       data: {

--- a/packages/tailwindcss-language-service/src/completions/file-paths.test.ts
+++ b/packages/tailwindcss-language-service/src/completions/file-paths.test.ts
@@ -1,12 +1,55 @@
 import { expect, test } from 'vitest'
 import { findFileDirective } from './file-paths'
 
-let findV3 = (text: string) => findFileDirective({ enabled: true, v4: false }, text)
-let findV4 = (text: string) => findFileDirective({ enabled: true, v4: true }, text)
+test('Detecting v3 directives that point to files', async () => {
+  function find(text: string) {
+    return findFileDirective({ enabled: true, v4: false }, text)
+  }
 
-test('…', async () => {
-  await expect(findV4('@import "tailwindcss" source("./')).resolves.toEqual({
+  await expect(find('@config "./')).resolves.toEqual({
+    directive: 'config',
+    partial: './',
+    suggest: 'script',
+  })
+
+  // The following are not supported in v3
+  await expect(find('@plugin "./')).resolves.toEqual(null)
+  await expect(find('@source "./')).resolves.toEqual(null)
+  await expect(find('@import "tailwindcss" source("./')).resolves.toEqual(null)
+  await expect(find('@tailwind utilities source("./')).resolves.toEqual(null)
+})
+
+test('Detecting v4 directives that point to files', async () => {
+  function find(text: string) {
+    return findFileDirective({ enabled: true, v4: true }, text)
+  }
+
+  await expect(find('@config "./')).resolves.toEqual({
+    directive: 'config',
+    partial: './',
+    suggest: 'script',
+  })
+
+  await expect(find('@plugin "./')).resolves.toEqual({
+    directive: 'plugin',
+    partial: './',
+    suggest: 'script',
+  })
+
+  await expect(find('@source "./')).resolves.toEqual({
+    directive: 'source',
+    partial: './',
+    suggest: 'source',
+  })
+
+  await expect(find('@import "tailwindcss" source("./')).resolves.toEqual({
     directive: 'import',
+    partial: './',
+    suggest: 'directory',
+  })
+
+  await expect(find('@tailwind utilities source("./')).resolves.toEqual({
+    directive: 'tailwind',
     partial: './',
     suggest: 'directory',
   })

--- a/packages/tailwindcss-language-service/src/completions/file-paths.test.ts
+++ b/packages/tailwindcss-language-service/src/completions/file-paths.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { findFileDirective } from './file-paths'
+
+let findV3 = (text: string) => findFileDirective({ enabled: true, v4: false }, text)
+let findV4 = (text: string) => findFileDirective({ enabled: true, v4: true }, text)
+
+test('…', async () => {
+  await expect(findV4('@import "tailwindcss" source("./')).resolves.toEqual({
+    directive: 'import',
+    partial: './',
+    suggest: 'directory',
+  })
+})

--- a/packages/tailwindcss-language-service/src/completions/file-paths.ts
+++ b/packages/tailwindcss-language-service/src/completions/file-paths.ts
@@ -1,0 +1,40 @@
+import type { State } from '../util/state'
+
+// @config, @plugin, @source
+const PATTERN_CUSTOM_V4 = /@(?<directive>config|plugin|source)\s*(?<partial>'[^']*|"[^"]*)$/
+const PATTERN_CUSTOM_V3 = /@(?<directive>config)\s*(?<partial>'[^']*|"[^"]*)$/
+
+export type FileDirective = {
+  directive: string
+  partial: string
+  suggest: 'script' | 'source'
+}
+
+export async function findFileDirective(state: State, text: string): Promise<FileDirective | null> {
+  if (state.v4) {
+    let match = text.match(PATTERN_CUSTOM_V4)
+
+    if (!match) return null
+
+    let directive = match.groups.directive
+    let partial = match.groups.partial.slice(1) // remove leading quote
+
+    // Most suggestions are for JS files so we'll default to that
+    let suggest: FileDirective['suggest'] = 'script'
+
+    // If we're looking at @source then it's for a template file
+    if (directive === 'source') {
+      suggest = 'source'
+    }
+
+    return { directive, partial, suggest }
+  }
+
+  let match = text.match(PATTERN_CUSTOM_V3)
+  if (!match) return null
+
+  let directive = match.groups.directive
+  let partial = match.groups.partial.slice(1) // remove leading quote
+
+  return { directive, partial, suggest: 'script' }
+}

--- a/packages/tailwindcss-language-service/src/completions/file-paths.ts
+++ b/packages/tailwindcss-language-service/src/completions/file-paths.ts
@@ -4,20 +4,27 @@ import type { State } from '../util/state'
 const PATTERN_CUSTOM_V4 = /@(?<directive>config|plugin|source)\s*(?<partial>'[^']*|"[^"]*)$/
 const PATTERN_CUSTOM_V3 = /@(?<directive>config)\s*(?<partial>'[^']*|"[^"]*)$/
 
+// @import … source('…')
+// @tailwind utilities source('…')
+const PATTERN_IMPORT_SOURCE = /@(?<directive>import)\s*(?<path>'[^']*'|"[^"]*")\s*source\((?<partial>'[^']*|"[^"]*)$/
+const PATTERN_UTIL_SOURCE = /@(?<directive>tailwind)\s+utilities\s+source\((?<partial>'[^']*|"[^"]*)?$/
+
 export type FileDirective = {
   directive: string
   partial: string
-  suggest: 'script' | 'source'
+  suggest: 'script' | 'source' | 'directory'
 }
 
 export async function findFileDirective(state: State, text: string): Promise<FileDirective | null> {
   if (state.v4) {
     let match = text.match(PATTERN_CUSTOM_V4)
+      ?? text.match(PATTERN_IMPORT_SOURCE)
+      ?? text.match(PATTERN_UTIL_SOURCE)
 
     if (!match) return null
 
     let directive = match.groups.directive
-    let partial = match.groups.partial.slice(1) // remove leading quote
+    let partial = match.groups.partial?.slice(1) ?? "" // remove leading quote
 
     // Most suggestions are for JS files so we'll default to that
     let suggest: FileDirective['suggest'] = 'script'
@@ -25,6 +32,12 @@ export async function findFileDirective(state: State, text: string): Promise<Fil
     // If we're looking at @source then it's for a template file
     if (directive === 'source') {
       suggest = 'source'
+    }
+
+    // If we're looking at @import … source('…') or @tailwind … source('…') then
+    // we want to list directories instead of files
+    else if (directive === 'import' || directive === 'tailwind') {
+      suggest = 'directory'
     }
 
     return { directive, partial, suggest }

--- a/packages/tailwindcss-language-service/src/diagnostics/diagnosticsProvider.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/diagnosticsProvider.ts
@@ -8,6 +8,7 @@ import { getInvalidVariantDiagnostics } from './getInvalidVariantDiagnostics'
 import { getInvalidConfigPathDiagnostics } from './getInvalidConfigPathDiagnostics'
 import { getInvalidTailwindDirectiveDiagnostics } from './getInvalidTailwindDirectiveDiagnostics'
 import { getRecommendedVariantOrderDiagnostics } from './getRecommendedVariantOrderDiagnostics'
+import { getInvalidSourceDiagnostics } from './getInvalidSourceDiagnostics'
 
 export async function doValidate(
   state: State,
@@ -19,6 +20,7 @@ export async function doValidate(
     DiagnosticKind.InvalidVariant,
     DiagnosticKind.InvalidConfigPath,
     DiagnosticKind.InvalidTailwindDirective,
+    DiagnosticKind.InvalidSourceDirective,
     DiagnosticKind.RecommendedVariantOrder,
   ],
 ): Promise<AugmentedDiagnostic[]> {
@@ -43,6 +45,9 @@ export async function doValidate(
           : []),
         ...(only.includes(DiagnosticKind.InvalidTailwindDirective)
           ? getInvalidTailwindDirectiveDiagnostics(state, document, settings)
+          : []),
+        ...(only.includes(DiagnosticKind.InvalidSourceDirective)
+          ? getInvalidSourceDiagnostics(state, document, settings)
           : []),
         ...(only.includes(DiagnosticKind.RecommendedVariantOrder)
           ? await getRecommendedVariantOrderDiagnostics(state, document, settings)

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
@@ -121,22 +121,6 @@ export function getInvalidSourceDiagnostics(
         })
       }
 
-      // Detection of globs in non-`@source` directives
-      else if (
-        directive !== 'source' &&
-        (source.includes('*') || source.includes('{') || source.includes('}'))
-      ) {
-        let range = {
-          start: indexToPosition(text, sourceRange[0]),
-          end: indexToPosition(text, sourceRange[1]),
-        }
-
-        add({
-          message: `\`source(${rawSource})\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
-          range: absoluteRange(range, block.range),
-        })
-      }
-
       // `@source none` is invalid
       else if (directive === 'source' && source === 'none') {
         let range = {

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
@@ -1,8 +1,5 @@
 import type { State, Settings } from '../util/state'
-import {
-  DiagnosticKind,
-  InvalidSourceDirectiveDiagnostic,
-} from './types'
+import { DiagnosticKind, InvalidSourceDirectiveDiagnostic } from './types'
 import { findAll, indexToPosition } from '../util/find'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import { getCssBlocks } from '../util/language-blocks'
@@ -104,7 +101,7 @@ export function getInvalidSourceDiagnostics(
         }
 
         add({
-          message: `\`source(${source})\` is invalid. Did you mean \`source(none)\`.`,
+          message: `\`source(${source})\` is invalid. Did you mean \`source(none)\`?`,
           range: absoluteRange(range, block.range),
         })
       }

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
@@ -1,22 +1,11 @@
 import type { State, Settings } from '../util/state'
-import { Diagnostic, type Range } from 'vscode-languageserver'
 import {
-  type InvalidConfigPathDiagnostic,
   DiagnosticKind,
   InvalidSourceDirectiveDiagnostic,
 } from './types'
-import { findAll, findHelperFunctionsInDocument, indexToPosition } from '../util/find'
-import { stringToPath } from '../util/stringToPath'
-import isObject from '../util/isObject'
-import { closest, distance } from '../util/closest'
-import { combinations } from '../util/combinations'
-import dlv from 'dlv'
+import { findAll, indexToPosition } from '../util/find'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
-import type { DesignSystem } from '../util/v4'
-import { getLanguageBoundaries } from '../util/getLanguageBoundaries'
-import { isCssDoc } from '../util/css'
 import { getCssBlocks } from '../util/language-blocks'
-import { isSemicolonlessCssLanguage } from '../util/languages'
 import { absoluteRange } from '../util/absoluteRange'
 
 // @import … source('…')

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
@@ -1,0 +1,185 @@
+import type { State, Settings } from '../util/state'
+import { Diagnostic, type Range } from 'vscode-languageserver'
+import {
+  type InvalidConfigPathDiagnostic,
+  DiagnosticKind,
+  InvalidSourceDirectiveDiagnostic,
+} from './types'
+import { findAll, findHelperFunctionsInDocument, indexToPosition } from '../util/find'
+import { stringToPath } from '../util/stringToPath'
+import isObject from '../util/isObject'
+import { closest, distance } from '../util/closest'
+import { combinations } from '../util/combinations'
+import dlv from 'dlv'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import type { DesignSystem } from '../util/v4'
+import { getLanguageBoundaries } from '../util/getLanguageBoundaries'
+import { isCssDoc } from '../util/css'
+import { getCssBlocks } from '../util/language-blocks'
+import { isSemicolonlessCssLanguage } from '../util/languages'
+import { absoluteRange } from '../util/absoluteRange'
+
+// @import … source('…')
+// @tailwind utilities source('…')
+const PATTERN_IMPORT_SOURCE =
+  /(?:\s|^)@(?<directive>import)\s*(?<path>'[^']*'|"[^"]*")\s*source\((?<source>'[^']*'?|"[^"]*"?|[a-z]*|\)|;)/dg
+const PATTERN_UTIL_SOURCE =
+  /(?:\s|^)@(?<directive>tailwind)\s+(?<layer>\S+)\s+source\((?<source>'[^']*'?|"[^"]*"?|[a-z]*|\)|;)/dg
+
+// @source …
+const PATTERN_AT_SOURCE =
+  /(?:\s|^)@(?<directive>source)\s*(?<source>'[^']*'?|"[^"]*"?|[a-z]*|\)|;)/dg
+
+const HAS_DRIVE_LETTER = /^[A-Z]:/
+
+export function getInvalidSourceDiagnostics(
+  state: State,
+  document: TextDocument,
+  settings: Settings,
+): InvalidSourceDirectiveDiagnostic[] {
+  let severity = settings.tailwindCSS.lint.invalidSourceDirective
+  if (severity === 'ignore') return []
+
+  let diagnostics: InvalidSourceDirectiveDiagnostic[] = []
+
+  function add(diag: Omit<InvalidSourceDirectiveDiagnostic, 'code' | 'severity'>) {
+    diagnostics.push({
+      code: DiagnosticKind.InvalidSourceDirective,
+      severity:
+        severity === 'error'
+          ? 1 /* DiagnosticSeverity.Error */
+          : 2 /* DiagnosticSeverity.Warning */,
+      ...diag,
+    })
+  }
+
+  for (let block of getCssBlocks(state, document)) {
+    let text = block.text
+
+    let matches = [
+      ...findAll(PATTERN_IMPORT_SOURCE, text),
+      ...findAll(PATTERN_UTIL_SOURCE, text),
+      ...findAll(PATTERN_AT_SOURCE, text),
+    ]
+
+    for (let match of matches) {
+      let directive = match.groups.directive
+      let source = match.groups.source?.trim() ?? ''
+      let rawSource = source
+      let sourceRange = match.indices.groups.source
+      let isQuoted = false
+
+      if (source.startsWith("'")) {
+        source = source.slice(1)
+        isQuoted = true
+      } else if (source.startsWith('"')) {
+        source = source.slice(1)
+        isQuoted = true
+      }
+
+      if (source.endsWith("'")) {
+        source = source.slice(0, -1)
+        isQuoted = true
+      } else if (source.endsWith('"')) {
+        source = source.slice(0, -1)
+        isQuoted = true
+      }
+
+      source = source.trim()
+
+      // - `@import "tailwindcss" source()`
+      // - `@import "tailwindcss" source('')`
+      // - `@import "tailwindcss" source("")`
+
+      // - `@source ;`
+      // - `@source '';`
+      // - `@source "";`
+      if (source === '' || source === ')' || source === ';') {
+        let range = {
+          start: indexToPosition(text, sourceRange[0]),
+          end: indexToPosition(text, sourceRange[1]),
+        }
+
+        add({
+          message: 'Need a path for the source directive',
+          range: absoluteRange(range, block.range),
+        })
+      }
+
+      // - `@import "tailwindcss" source(no)`
+      // - `@tailwind utilities source('')`
+      else if (directive !== 'source' && source !== 'none' && !isQuoted) {
+        let range = {
+          start: indexToPosition(text, sourceRange[0]),
+          end: indexToPosition(text, sourceRange[1]),
+        }
+
+        add({
+          message: `\`source(${source})\` is invalid. Did you mean \`source(none)\`.`,
+          range: absoluteRange(range, block.range),
+        })
+      }
+
+      // Detection of Windows-style paths
+      else if (source.includes('\\\\') || HAS_DRIVE_LETTER.test(source)) {
+        source = source.replaceAll('\\\\', '\\')
+
+        let range = {
+          start: indexToPosition(text, sourceRange[0]),
+          end: indexToPosition(text, sourceRange[1]),
+        }
+
+        add({
+          message: `POSIX-style paths are required with source() but \`${source}\` is a Windows-style path.`,
+          range: absoluteRange(range, block.range),
+        })
+      }
+
+      // Detection of globs in non-`@source` directives
+      else if (
+        directive !== 'source' &&
+        (source.includes('*') || source.includes('{') || source.includes('}'))
+      ) {
+        let range = {
+          start: indexToPosition(text, sourceRange[0]),
+          end: indexToPosition(text, sourceRange[1]),
+        }
+
+        add({
+          message: `source(${rawSource}) uses a glob but a glob cannot be used here. Use a directory name instead.`,
+          range: absoluteRange(range, block.range),
+        })
+      }
+
+      // `@source none` is invalid
+      else if (directive === 'source' && source === 'none') {
+        let range = {
+          start: indexToPosition(text, sourceRange[0]),
+          end: indexToPosition(text, sourceRange[1]),
+        }
+
+        add({
+          message:
+            '`@source none;` is not valid. Did you mean to use `source(none)` on an `@import`?',
+          range: absoluteRange(range, block.range),
+        })
+      }
+
+      // - `@import "tailwindcss" source(no)`
+      // - `@tailwind utilities source('')`
+      else if (directive === 'source' && source !== 'none' && !isQuoted) {
+        let range = {
+          start: indexToPosition(text, sourceRange[0]),
+          end: indexToPosition(text, sourceRange[1]),
+        }
+
+        add({
+          message: `\`@source ${rawSource};\` is invalid.`,
+          range: absoluteRange(range, block.range),
+        })
+      }
+    }
+  }
+
+  return diagnostics
+}

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
@@ -87,7 +87,7 @@ export function getInvalidSourceDiagnostics(
         }
 
         add({
-          message: 'Need a path for the source directive',
+          message: 'The source directive requires a path to a directory.',
           range: absoluteRange(range, block.range),
         })
       }
@@ -116,7 +116,7 @@ export function getInvalidSourceDiagnostics(
         }
 
         add({
-          message: `POSIX-style paths are required with source() but \`${source}\` is a Windows-style path.`,
+          message: `POSIX-style paths are required with \`source(…)\` but \`${source}\` is a Windows-style path.`,
           range: absoluteRange(range, block.range),
         })
       }
@@ -132,7 +132,7 @@ export function getInvalidSourceDiagnostics(
         }
 
         add({
-          message: `source(${rawSource}) uses a glob but a glob cannot be used here. Use a directory name instead.`,
+          message: `\`source(${rawSource})\` uses a glob but a glob cannot be used here. Use a directory name instead.`,
           range: absoluteRange(range, block.range),
         })
       }

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidSourceDiagnostics.ts
@@ -107,7 +107,7 @@ export function getInvalidSourceDiagnostics(
       }
 
       // Detection of Windows-style paths
-      else if (source.includes('\\\\') || HAS_DRIVE_LETTER.test(source)) {
+      else if (source.includes('\\') || HAS_DRIVE_LETTER.test(source)) {
         source = source.replaceAll('\\\\', '\\')
 
         let range = {

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -93,7 +93,7 @@ function validateLayerName(
     if (layerName === 'components' || layerName === 'screens' || layerName === 'variants') {
       return {
         message: `'@tailwind ${layerName}' is no longer available in v4. Use '@tailwind utilities' instead.`,
-        suggestions: [],
+        suggestions: ['utilities'],
       }
     }
 

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -81,6 +81,14 @@ function validateLayerName(
       return null
     }
 
+    // `@tailwind base | preflight` do not exist in v4
+    if (layerName === 'base' || layerName === 'preflight') {
+      return {
+        message: `'@tailwind ${layerName}' is no longer available in v4. Use '@import "tailwindcss/base"' instead.`,
+        suggestions: [],
+      }
+    }
+
     let parts = layerName.split(/\s+/)
 
     // `@tailwind utilities source(…)` is valid

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -75,6 +75,25 @@ function validateLayerName(
   state: State,
   layerName: string,
 ): { message: string; suggestions: string[] } | null {
+  if (state.v4) {
+    // `@tailwind utilities` is valid
+    if (layerName === 'utilities') {
+      return null
+    }
+
+    let parts = layerName.split(/\s+/)
+
+    // `@tailwind utilities source(…)` is valid
+    if (parts[0] === 'utilities' && parts[1]?.startsWith('source(')) {
+      return null
+    }
+
+    return {
+      message: `'${layerName}' is not a valid value.`,
+      suggestions: [],
+    }
+  }
+
   let valid = ['utilities', 'components', 'screens']
 
   if (semver.gte(state.version, '1.0.0-beta.1')) {

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -89,6 +89,14 @@ function validateLayerName(
       }
     }
 
+    // `@tailwind components | screens | variants` do not exist in v4
+    if (layerName === 'components' || layerName === 'screens' || layerName === 'variants') {
+      return {
+        message: `'@tailwind ${layerName}' is no longer available in v4. Use '@tailwind utilities' instead.`,
+        suggestions: [],
+      }
+    }
+
     let parts = layerName.split(/\s+/)
 
     // `@tailwind utilities source(…)` is valid

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidTailwindDirectiveDiagnostics.ts
@@ -84,7 +84,7 @@ function validateLayerName(
     // `@tailwind base | preflight` do not exist in v4
     if (layerName === 'base' || layerName === 'preflight') {
       return {
-        message: `'@tailwind ${layerName}' is no longer available in v4. Use '@import "tailwindcss/base"' instead.`,
+        message: `'@tailwind ${layerName}' is no longer available in v4. Use '@import "tailwindcss/preflight"' instead.`,
         suggestions: [],
       }
     }

--- a/packages/tailwindcss-language-service/src/diagnostics/types.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/types.ts
@@ -8,6 +8,7 @@ export enum DiagnosticKind {
   InvalidVariant = 'invalidVariant',
   InvalidConfigPath = 'invalidConfigPath',
   InvalidTailwindDirective = 'invalidTailwindDirective',
+  InvalidSourceDirective = 'invalidSourceDirective',
   RecommendedVariantOrder = 'recommendedVariantOrder',
 }
 
@@ -78,6 +79,16 @@ export function isInvalidTailwindDirectiveDiagnostic(
   return diagnostic.code === DiagnosticKind.InvalidTailwindDirective
 }
 
+export type InvalidSourceDirectiveDiagnostic = Diagnostic & {
+  code: DiagnosticKind.InvalidSourceDirective
+}
+
+export function isInvalidSourceDirectiveDiagnostic(
+  diagnostic: AugmentedDiagnostic,
+): diagnostic is InvalidSourceDirectiveDiagnostic {
+  return diagnostic.code === DiagnosticKind.InvalidSourceDirective
+}
+
 export type RecommendedVariantOrderDiagnostic = Diagnostic & {
   code: DiagnosticKind.RecommendedVariantOrder
   suggestions: string[]
@@ -96,4 +107,5 @@ export type AugmentedDiagnostic =
   | InvalidVariantDiagnostic
   | InvalidConfigPathDiagnostic
   | InvalidTailwindDirectiveDiagnostic
+  | InvalidSourceDirectiveDiagnostic
   | RecommendedVariantOrderDiagnostic

--- a/packages/tailwindcss-language-service/src/documentLinksProvider.ts
+++ b/packages/tailwindcss-language-service/src/documentLinksProvider.ts
@@ -1,10 +1,7 @@
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import type { State } from './util/state'
 import type { DocumentLink, Range } from 'vscode-languageserver'
-import { isCssDoc } from './util/css'
-import { getLanguageBoundaries } from './util/getLanguageBoundaries'
 import { findAll, indexToPosition } from './util/find'
-import { getTextWithoutComments } from './util/doc'
 import { absoluteRange } from './util/absoluteRange'
 import * as semver from './util/semver'
 import { getCssBlocks } from './util/language-blocks'
@@ -14,9 +11,7 @@ export function getDocumentLinks(
   document: TextDocument,
   resolveTarget: (linkPath: string) => string,
 ): DocumentLink[] {
-  let patterns = [
-    /@config\s*(?<path>'[^']+'|"[^"]+")/g,
-  ]
+  let patterns = [/@config\s*(?<path>'[^']+'|"[^"]+")/g]
 
   if (state.v4) {
     patterns.push(

--- a/packages/tailwindcss-language-service/src/documentLinksProvider.ts
+++ b/packages/tailwindcss-language-service/src/documentLinksProvider.ts
@@ -54,6 +54,11 @@ function getDirectiveLinks(
     for (let match of matches) {
       let path = match.groups.path.slice(1, -1)
 
+      // Ignore glob-like paths
+      if (path.includes('*') || path.includes('{') || path.includes('}')) {
+        continue
+      }
+
       let range = {
         start: indexToPosition(text, match.index + match[0].length - match.groups.path.length),
         end: indexToPosition(text, match.index + match[0].length),

--- a/packages/tailwindcss-language-service/src/documentLinksProvider.ts
+++ b/packages/tailwindcss-language-service/src/documentLinksProvider.ts
@@ -6,6 +6,8 @@ import { absoluteRange } from './util/absoluteRange'
 import * as semver from './util/semver'
 import { getCssBlocks } from './util/language-blocks'
 
+const HAS_DRIVE_LETTER = /^[A-Z]:/
+
 export function getDocumentLinks(
   state: State,
   document: TextDocument,
@@ -51,6 +53,11 @@ function getDirectiveLinks(
 
       // Ignore glob-like paths
       if (path.includes('*') || path.includes('{') || path.includes('}')) {
+        continue
+      }
+
+      // Ignore Windows-style paths
+      if (path.includes('\\') || HAS_DRIVE_LETTER.test(path)) {
         continue
       }
 

--- a/packages/tailwindcss-language-service/src/documentLinksProvider.ts
+++ b/packages/tailwindcss-language-service/src/documentLinksProvider.ts
@@ -22,6 +22,8 @@ export function getDocumentLinks(
     patterns.push(
       /@plugin\s*(?<path>'[^']+'|"[^"]+")/g,
       /@source\s*(?<path>'[^']+'|"[^"]+")/g,
+      /@import\s*('[^']*'|"[^"]*")\s*source\((?<path>'[^']*'?|"[^"]*"?)/g,
+      /@tailwind\s*utilities\s*source\((?<path>'[^']*'?|"[^"]*"?)/g,
     )
   }
 

--- a/packages/tailwindcss-language-service/src/hoverProvider.ts
+++ b/packages/tailwindcss-language-service/src/hoverProvider.ts
@@ -57,7 +57,7 @@ async function provideCssHelperHover(
       helperFn.helper === 'theme' ? ['theme'] : [],
     )
 
-    // This property may not exist in the state object because of compatability with Tailwind Play
+    // This property may not exist in the state object because of compatibility with Tailwind Play
     let value = validated.isValid ? stringifyConfigValue(validated.value) : null
     if (value === null) return null
 

--- a/packages/tailwindcss-language-service/src/metadata/extensions.ts
+++ b/packages/tailwindcss-language-service/src/metadata/extensions.ts
@@ -3,9 +3,9 @@ let scriptExtensions = [
   'js',
   'cjs',
   'mjs',
-  'ts',
-  'mts',
-  'cts',
+  '(?<!d.)ts', // matches .ts but not .d.ts
+  '(?<!d.)mts', // matches .mts but not .d.mts
+  '(?<!d.)cts', // matches .cts but not .d.cts
 ]
 
 let templateExtensions = [
@@ -20,14 +20,14 @@ let templateExtensions = [
   // JS
   'astro',
   'cjs',
-  'cts',
+  '(?<!d.)cts', // matches .cts but not .d.cts
   'jade',
   'js',
   'jsx',
   'mjs',
-  'mts',
+  '(?<!d.)mts', // matches .mts but not .d.mts
   'svelte',
-  'ts',
+  '(?<!d.)ts', // matches .ts but not .d.ts
   'tsx',
   'vue',
 

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -354,6 +354,24 @@ export function findHelperFunctionsInRange(
     text,
   )
 
+  // Eliminate matches that are on an `@import`
+  matches = matches.filter((match) => {
+    // Scan backwards to see if we're in an `@import` statement
+    for (let i = match.index - 1; i >= 0; i--) {
+      let char = text[i]
+      if (char === '\n') break
+      if (char === ';') break
+      // Detecting theme(…) inside the media query list of `@import` is okay
+      if (char === '(') break
+      if (char === ')') break
+      if (text.startsWith('@import', i)) {
+        return false
+      }
+    }
+
+    return true
+  })
+
   return matches.map((match) => {
     let quotesBefore = ''
     let path = match.groups.path

--- a/packages/tailwindcss-language-service/src/util/language-blocks.ts
+++ b/packages/tailwindcss-language-service/src/util/language-blocks.ts
@@ -12,7 +12,6 @@ export interface LanguageBlock {
   readonly text: string
 }
 
-/** */
 export function* getCssBlocks(
   state: State,
   document: TextDocument,

--- a/packages/tailwindcss-language-service/src/util/language-blocks.ts
+++ b/packages/tailwindcss-language-service/src/util/language-blocks.ts
@@ -1,0 +1,46 @@
+import type { State } from '../util/state'
+import { type Range } from 'vscode-languageserver'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import { getLanguageBoundaries } from '../util/getLanguageBoundaries'
+import { isCssDoc } from '../util/css'
+import { getTextWithoutComments } from './doc'
+
+export interface LanguageBlock {
+  document: TextDocument
+  range: Range | undefined
+  lang: string
+  readonly text: string
+}
+
+/** */
+export function* getCssBlocks(
+  state: State,
+  document: TextDocument,
+): Iterable<LanguageBlock | undefined> {
+  if (isCssDoc(state, document)) {
+    yield {
+      document,
+      range: undefined,
+      lang: document.languageId,
+      get text() {
+        return getTextWithoutComments(document, 'css')
+      },
+    }
+  } else {
+    let boundaries = getLanguageBoundaries(state, document)
+    if (!boundaries) return []
+
+    for (let boundary of boundaries) {
+      if (boundary.type !== 'css') continue
+
+      yield {
+        document,
+        range: boundary.range,
+        lang: boundary.lang ?? document.languageId,
+        get text() {
+          return getTextWithoutComments(document, 'css', boundary.range)
+        },
+      }
+    }
+  }
+}

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -59,6 +59,7 @@ export type TailwindCssSettings = {
     invalidVariant: DiagnosticSeveritySetting
     invalidConfigPath: DiagnosticSeveritySetting
     invalidTailwindDirective: DiagnosticSeveritySetting
+    invalidSourceDirective: DiagnosticSeveritySetting
     recommendedVariantOrder: DiagnosticSeveritySetting
   }
   experimental: {

--- a/packages/tailwindcss-language-service/src/util/v4/design-system.ts
+++ b/packages/tailwindcss-language-service/src/util/v4/design-system.ts
@@ -3,7 +3,7 @@ import type { Rule } from './ast'
 import type { NamedVariant } from './candidate'
 
 export interface Theme {
-  // Prefix didn't exist on
+  // Prefix didn't exist for earlier Tailwind versions
   prefix?: string
   entries(): [string, any][]
 }

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Add suggestions for theme options ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Add suggestions when using `@source "…"` and `source(…)` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Show brace expansion when hovering `@source` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Highlight `source(…)`, `theme(…)`, and `prefix(…)` when used with `@import "…"` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Highlight `@tailwind utilities source(…)` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Show document links when using `source(…)` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+
+- Ensure language server starts as needed ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Don't show syntax errors when using `source(…)`, `theme(…)`, or `prefix(…)` with `@import "…"` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Don't show warning when using `@tailwind utilities source(…)` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Don't suggest TypeScript declaration files for `@config`, `@plugin`, and `@source` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Don't link Windows-style paths in `@source`, `@config`, and `@plugin` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+
+- Warn on invalid uses of `source(…)`, `@source`, `@config`, and `@plugin` ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
+- Warn when a v4 project uses an old `@tailwind` directive ([#1083](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1083))
 
 ## 0.12.13
 

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -609,7 +609,7 @@ export async function activate(context: ExtensionContext) {
       return
     }
 
-    if (!anyFolderNeedsLanguageServer(Workspace.workspaceFolders ?? [])) {
+    if (!await anyFolderNeedsLanguageServer(Workspace.workspaceFolders ?? [])) {
       return
     }
 

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -5,6 +5,47 @@
   "name": "TailwindCSS",
   "patterns": [
     {
+      "begin": "(?i)((@)import)(?:\\s+|$|(?=['\"]|/\\*))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.at-rule.import.css"
+        },
+        "2": {
+          "name": "punctuation.definition.keyword.css"
+        }
+      },
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.terminator.rule.css"
+        }
+      },
+      "name": "meta.at-rule.import.css",
+      "patterns": [
+        {
+          "begin": "\\G\\s*(?=/\\*)",
+          "end": "(?<=\\*/)\\s*",
+          "patterns": [
+            {
+              "include": "source.css#comment-block"
+            }
+          ]
+        },
+        {
+          "include": "source.css#string"
+        },
+        {
+          "include": "source.css#url"
+        },
+        {
+          "include": "#source-fn"
+        },
+        {
+          "include": "source.css#media-query-list"
+        }
+      ]
+    },
+    {
       "begin": "(?i)((@)tailwind)(?=\\s|/\\*|$)",
       "beginCaptures": {
         "1": {

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -534,7 +534,7 @@
           "begin": "(?i)(?:\\s*)(?<![\\w@-])(theme)([(])",
           "beginCaptures": {
             "1": {
-              "name": "support.function.meta.css"
+              "name": "support.function.theme.css"
             },
             "2": {
               "name": "punctuation.section.function.begin.bracket.round.css"

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -29,6 +29,9 @@
           "include": "source.css#escapes"
         },
         {
+          "include": "#source-fn"
+        },
+        {
           "match": "[^\\s;]+?",
           "name": "variable.parameter.tailwind.tailwind"
         }
@@ -444,6 +447,36 @@
         {
           "match": ";",
           "name": "punctuation.terminator.rule.css"
+        }
+      ]
+    },
+    "source-fn": {
+      "patterns": [
+        {
+          "begin": "(?i)(?:\\s*)(?<![\\w@-])(source)([(])",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.source.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "[)]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "match": "none(?=[)])",
+              "name": "variable.other.css"
+            },
+            {
+              "include": "source.css#string"
+            }
+          ]
         }
       ]
     }

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -204,6 +204,10 @@
       },
       "patterns": [
         {
+          "match": "none(?=;)",
+          "name": "invalid.illegal.invalid-source.css"
+        },
+        {
           "include": "source.css#string"
         }
       ]

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -41,6 +41,9 @@
           "include": "#source-fn"
         },
         {
+          "include": "#theme-meta-fn"
+        },
+        {
           "include": "source.css#media-query-list"
         }
       ]
@@ -520,6 +523,53 @@
             },
             {
               "include": "source.css#string"
+            }
+          ]
+        }
+      ]
+    },
+    "theme-meta-fn": {
+      "patterns": [
+        {
+          "begin": "(?i)(?:\\s*)(?<![\\w@-])(theme)([(])",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.meta.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "[)]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\s+",
+              "name": "variable.other.css"
+            },
+            {
+              "match": "reference",
+              "name": "variable.other.css"
+            },
+            {
+              "match": "inline",
+              "name": "variable.other.css"
+            },
+            {
+              "match": "default",
+              "name": "variable.other.css"
+            },
+            {
+              "match": "deprecated",
+              "name": "variable.other.css"
+            },
+            {
+              "match": "[^)]+",
+              "name": "invalid.illegal.invalid-source.css"
             }
           ]
         }

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -44,6 +44,9 @@
           "include": "#theme-meta-fn"
         },
         {
+          "include": "#prefix-meta-fn"
+        },
+        {
           "include": "source.css#media-query-list"
         }
       ]
@@ -569,6 +572,37 @@
             },
             {
               "match": "[^)]+",
+              "name": "invalid.illegal.invalid-source.css"
+            }
+          ]
+        }
+      ]
+    },
+    "prefix-meta-fn": {
+      "patterns": [
+        {
+          "begin": "(?i)(?:\\s*)(?<![\\w@-])(prefix)([(])",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.prefix.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "[)]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "match": "[a-z]+",
+              "name": "variable.other.css"
+            },
+            {
+              "match": "[^a-z]+",
               "name": "invalid.illegal.invalid-source.css"
             }
           ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@types/semver':
         specifier: 7.3.10
         version: 7.3.10
+      braces:
+        specifier: 3.0.3
+        version: 3.0.3
       color-name:
         specifier: 1.1.4
         version: 1.1.4


### PR DESCRIPTION
This PR mades a fair number of changes to improve the developer experience in v4. Most of it is related to `@source` and `source(…)` but there are some additional tweaks:

- [x] Make sure `@import "…" source(…)` does not issue syntax warnings
- [x] Make sure `@import "…" theme(…)` does not issue syntax warnings
- [x] Make sure `@import "…" prefix(…)` does not issue syntax warnings
- [x] Make sure `@tailwind utilities source(…)` isn't diagnosed as invalid
- [x] Add suggestions for `@theme` options
- [x] Add suggestions for `@import "…" theme(…)` options
- [x] Directory auto-completion for `source(…)`
- [x] Directory auto-completion for `@source "…"`
- [x] Don’t suggest TypeScript declaration files for `@config`, `@plugin`, and `@source`
- [x] In a new workspace creating/editing a CSS file should check if it's the language server needs to start.
- [x] Show brace expansion when hovering `@source`
- [x] Highlight `@import "…" source(…)` properly
- [x] Highlight `@import "…" theme(…)` properly
- [x] Highlight `@import "…" prefix(…)` properly
- [x] Highlight `@tailwind utilities source(…)` properly
- [x] Highlight uses of `source(none)` explicitly
- [x] Link paths in valid uses of `source("…")`
- [x] Don't link Windows-style paths in `@source`, `@config`, and `@plugin`
- [x] Warn that `@source none` is invalid
- [x] Highlight `@source none` as invalid (theme-dependent)
- [x] Warn when `source(…)` is not passed anything
- [x] Warn when `source(none)` is mispelled
- [x] Warn when a v4 project uses `@tailwind base` or `@tailwind components`
- [x] Warn when non-POSIX paths are passed to `@source` and `source(…)`
- [x] Warn when `@tailwind base` is used in a v4 project
- [x] Warn when `@tailwind preflight` is used in a v4 project
- [x] Warn when `@tailwind components` is used in a v4 project
- [x] Warn when `@tailwind screens` is used in a v4 project
- [x] Warn when `@tailwind variants` is used in a v4 project


I had some stretch goals but I don't think I'll get to them in this PR unless we think they're important enough to hold up the PR:

- [ ] Warn when braces surround a single item in `@source` globs
- [ ] Warn when unsupported glob syntax is used in `@source`
- [ ] Warn when a v4 project uses `@import "tailwindcss/tailwind"`
- [ ] Warn when a v4 project uses `@import "tailwindcss/tailwind.css"`
- [ ] Highlight glob parts in `@source "…"` strings
- [ ] Auto-complete `source(none)` when typing `source(…)`
