### PR TITLE
Hide completions from CSS language server inside `@import "…" source(…)`

### DIFF
--- a/packages/tailwindcss-language-server/src/language/css-server.ts
+++ b/packages/tailwindcss-language-server/src/language/css-server.ts
@@ -121,6 +121,7 @@ export class CssServer {
     async function withDocumentAndSettings<T>(
       uri: string,
       callback: (result: {
+        original: TextDocument
         document: TextDocument
         settings: LanguageSettings | undefined
       }) => T | Promise<T>,
@@ -130,13 +131,14 @@ export class CssServer {
         return null
       }
       return await callback({
+        original: document,
         document: createVirtualCssDocument(document),
         settings: await getDocumentSettings(document),
       })
     }
 
     connection.onCompletion(async ({ textDocument, position }, _token) =>
-      withDocumentAndSettings(textDocument.uri, async ({ document, settings }) => {
+      withDocumentAndSettings(textDocument.uri, async ({ original, document, settings }) => {
         let result = await cssLanguageService.doComplete2(
           document,
           position,

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Hide completions from CSS language server inside `@import "…" source(…)` ([#1091](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1091))
 
 # 0.14.12
 


### PR DESCRIPTION
This hides completions from the CSS language server when inside `@import source(…)`, `@import theme(…)`, and `@import prefix(…)`

Because of the way we fake stuff to the underlying service it thinks these are valid places to provide standard CSS completions but they're not.

before:

<img width="510" alt="Screenshot 2025-03-28 at 21 32 08" src="https://github.com/user-attachments/assets/68f581b6-86a2-4deb-9a71-c68cb32a1da5" />

after:
<img width="537" alt="Screenshot 2025-03-28 at 21 34 38" src="https://github.com/user-attachments/assets/97e10b1b-fd88-4bfe-8b12-753c36123ee6" />
