### PR TITLE
Stop auto-switching CSS files to the Tailwind CSS language mode

### DIFF
--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Stop auto-switching CSS files to the Tailwind CSS language mode ([#1116](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1116))
 
 ## 0.12.17
 

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -16,7 +16,6 @@ import {
   Position,
   Range,
   RelativePattern,
-  languages,
 } from 'vscode'
 import type {
   DocumentFilter,
@@ -125,15 +124,11 @@ async function getActiveTextEditorProject(): Promise<{ version: string } | null>
   let editor = Window.activeTextEditor
   if (!editor) return null
 
-  return projectForDocument(editor.document)
-}
-
-async function projectForDocument(document: TextDocument): Promise<{ version: string } | null> {
   // No server yet, no project
   if (!currentClient) return null
 
   // No workspace folder, no project
-  let uri = document.uri
+  let uri = editor.document.uri
   let folder = Workspace.getWorkspaceFolder(uri)
   if (!folder) return null
 
@@ -165,41 +160,12 @@ async function activeTextEditorSupportsClassSorting(): Promise<boolean> {
   return semver.gte(project.version, '3.0.0')
 }
 
-const switchedDocuments = new Set<string>()
-
-async function switchDocumentLanguageIfNeeded(document: TextDocument): Promise<void> {
-  // Consider documents that are already in `tailwindcss` language mode as
-  // having been switched automatically. This ensures that a user can still
-  // manually switch this document to `css` and have it stay that way.
-  if (document.languageId === 'tailwindcss') {
-    switchedDocuments.add(document.uri.toString())
-    return
-  }
-
-  if (document.languageId !== 'css') return
-
-  // When a document is manually switched back to the `css` language we do not
-  // want to switch it back to `tailwindcss` because the user has explicitly
-  // chosen to use the `css` language mode.
-  if (switchedDocuments.has(document.uri.toString())) return
-
-  let project = await projectForDocument(document)
-  if (!project) return
-
-  // CSS files in a known project should be switched to `tailwindcss`
-  // when they are opened
-  languages.setTextDocumentLanguage(document, 'tailwindcss')
-  switchedDocuments.add(document.uri.toString())
-}
-
 async function updateActiveTextEditorContext(): Promise<void> {
   commands.executeCommand(
     'setContext',
     'tailwindCSS.activeTextEditorSupportsClassSorting',
     await activeTextEditorSupportsClassSorting(),
   )
-
-  await Promise.all(Workspace.textDocuments.map(switchDocumentLanguageIfNeeded))
 }
 
 function resetActiveTextEditorContext(): void {
@@ -207,8 +173,6 @@ function resetActiveTextEditorContext(): void {
 }
 
 export async function activate(context: ExtensionContext) {
-  switchedDocuments.clear()
-
   let outputChannel = Window.createOutputChannel(CLIENT_NAME)
   context.subscriptions.push(outputChannel)
   context.subscriptions.push(
@@ -664,8 +628,6 @@ export async function activate(context: ExtensionContext) {
   }
 
   async function didOpenTextDocument(document: TextDocument): Promise<void> {
-    await switchDocumentLanguageIfNeeded(document)
-
     if (document.languageId === 'tailwindcss') {
       servers.css.boot(context, outputChannel)
     }


### PR DESCRIPTION
There's some issues with the approach and it's unexpected behavior for some users. Rolling this back until we have a better solution. Potentially one that's configurable.

Fixes #1111