### PR TITLE
Reload v4 design system when dependencies change

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -331,12 +331,7 @@ export class TW {
         for (let [, project] of this.projects) {
           if (!project.state.v4) continue
 
-          let reloadableFiles = [
-            project.projectConfig.configPath,
-            ...project.projectConfig.config.entries.map((entry) => entry.path),
-          ]
-
-          if (!changeAffectsFile(normalizedFilename, reloadableFiles)) continue
+          if (!changeAffectsFile(normalizedFilename, project.dependencies())) continue
 
           needsSoftRestart = true
           break changeLoop

--- a/packages/tailwindcss-language-server/src/utils.ts
+++ b/packages/tailwindcss-language-server/src/utils.ts
@@ -84,7 +84,7 @@ export function normalizeDriveLetter(filepath: string) {
   return filepath.replace(WIN_DRIVE_LETTER, (_, letter) => letter.toUpperCase() + ':')
 }
 
-export function changeAffectsFile(change: string, files: string[]): boolean {
+export function changeAffectsFile(change: string, files: Iterable<string>): boolean {
   for (let file of files) {
     if (change === file || dirContains(change, file)) {
       return true

--- a/packages/tailwindcss-language-service/src/util/v4/design-system.ts
+++ b/packages/tailwindcss-language-service/src/util/v4/design-system.ts
@@ -43,6 +43,7 @@ export interface DesignSystem {
 }
 
 export interface DesignSystem {
+  dependencies(): Set<string>
   compile(classes: string[]): postcss.Root[]
   toCss(nodes: postcss.Root | postcss.Node[]): string
 }


### PR DESCRIPTION
I noticed that editing imported CSS files, plugins, and configs in v4 the config wasn't reloading. This PR fixes that by making sure we reload when any of them change.
