### PR TITLE
Fix resolving tsconfig paths on Windows

### DIFF
--- a/packages/tailwindcss-language-server/src/resolver/tsconfig.ts
+++ b/packages/tailwindcss-language-server/src/resolver/tsconfig.ts
@@ -8,7 +8,7 @@
 import * as path from 'node:path'
 import * as tsconfig from 'tsconfig-paths'
 import * as tsconfck from 'tsconfck'
-import { normalizePath } from '../utils'
+import { normalizeDriveLetter, normalizePath } from '../utils'
 import { DefaultMap } from '../util/default-map'
 
 export interface TSConfigApi {
@@ -205,7 +205,7 @@ async function createMatchers(
   let assumeExists: tsconfig.FileExistsAsync = (_, callback) => callback(undefined, true)
 
   for (let result of configs) {
-    let parent = normalizePath(path.dirname(result.tsconfigFile))
+    let parent = normalizeDriveLetter(normalizePath(path.dirname(result.tsconfigFile)))
 
     let opts = result.tsconfig.compilerOptions ?? {}
 
@@ -257,7 +257,7 @@ async function createMatchers(
 }
 
 function* walkPaths(base: string) {
-  let projectDir = normalizePath(base)
+  let projectDir = normalizeDriveLetter(normalizePath(base))
 
   let prevProjectDir: string | undefined
   while (projectDir !== prevProjectDir) {

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Fix detection of TypeScript config paths on Windows ([#1130](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1130))
 
 ## 0.14.0
 


### PR DESCRIPTION
Sometimes drive letters have different casing. In this case project discovery works fine but when base paths are passed from VSCode resolving doesn’t work.

I thought I'd tested this but apparently not.