### PR TITLE
fix(vscode-tailwindcss): fix activation events

### DIFF
--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -35,7 +35,8 @@
   },
   "icon": "media/icon.png",
   "activationEvents": [
-    "onStartupFinished"
+    "workspaceContains:**/*{tailwind}*.config*.{js,cjs,mjs,ts,cts,mts}",
+    "workspaceContains:node_modules/.bin/tailwindcss"
   ],
   "main": "dist/extension.js",
   "capabilities": {


### PR DESCRIPTION
Currently the extension is activated always, even in not js/ts workspaces...

With this PR, the extension is activated when  a tailwind config file is present in the workspace or when `tailwindcss` is inside `node_modules/bin` folder

Fix https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1132
