### PR TITLE
Fix `@import` hoisting warning

### DIFF
--- a/packages/tailwindcss-language-server/src/css/resolve-css-imports.ts
+++ b/packages/tailwindcss-language-server/src/css/resolve-css-imports.ts
@@ -30,13 +30,18 @@ export function resolveCssImports({
         if (!loose) return
 
         let hoist: postcss.AtRule[] = []
+        let seenOtherNodes = false
         let seenImportsAfterOtherNodes = false
 
         for (let node of root.nodes) {
           if (node.type === 'atrule' && (node.name === 'import' || node.name === 'charset')) {
             hoist.push(node)
+
+            if (seenOtherNodes) {
+              seenImportsAfterOtherNodes = true
+            }
           } else if (hoist.length > 0 && (node.type === 'atrule' || node.type === 'rule')) {
-            seenImportsAfterOtherNodes = true
+            seenOtherNodes = true
           }
         }
 

--- a/packages/tailwindcss-language-server/src/css/resolve-css-imports.ts
+++ b/packages/tailwindcss-language-server/src/css/resolve-css-imports.ts
@@ -40,7 +40,15 @@ export function resolveCssImports({
             if (seenOtherNodes) {
               seenImportsAfterOtherNodes = true
             }
-          } else if (hoist.length > 0 && (node.type === 'atrule' || node.type === 'rule')) {
+          } else if (node.type === 'atrule') {
+            if (node.name === 'layer') {
+              if (!node.nodes || node.nodes.length > 0) {
+                continue
+              }
+            }
+
+            seenOtherNodes = true
+          } else if (node.type === 'rule') {
             seenOtherNodes = true
           }
         }


### PR DESCRIPTION
We're displaying warnings about having to hoist `@import`s even on otherwise valid files. This fixes the over eager warning.

~~Still needs a test~~ I tested it manually. Seems fine.