### PR TITLE
Allow hover over `--theme(…)` function in `@media` rule without spaces

### DIFF
--- a/packages/tailwindcss-language-server/tests/hover/hover.test.js
+++ b/packages/tailwindcss-language-server/tests/hover/hover.test.js
@@ -272,6 +272,24 @@ withFixture('v4/basic', (c) => {
       end: { line: 2, character: 18 },
     },
   })
+
+  testHover('--theme() works inside @media queries', {
+    lang: 'tailwindcss',
+    text: `@media (width>=--theme(--breakpoint-xl)) { .foo { color: red; } }`,
+    position: { line: 0, character: 23 },
+
+    exact: true,
+    expected: {
+      contents: {
+        kind: 'markdown',
+        value: ['```plaintext', '80rem /* 1280px */', '```'].join('\n'),
+      },
+      range: {
+        start: { line: 0, character: 23 },
+        end: { line: 0, character: 38 },
+      },
+    },
+  })
 })
 
 withFixture('v4/css-loading-js', (c) => {

--- a/packages/tailwindcss-language-server/tests/hover/hover.test.js
+++ b/packages/tailwindcss-language-server/tests/hover/hover.test.js
@@ -154,6 +154,24 @@ withFixture('basic', (c) => {
       },
     },
   })
+
+  testHover('theme() works inside @media queries', {
+    lang: 'tailwindcss',
+    text: `@media (width>=theme(screens.xl)) { .foo { color: red; } }`,
+    position: { line: 0, character: 21 },
+
+    exact: true,
+    expected: {
+      contents: {
+        kind: 'markdown',
+        value: ['```plaintext', '1280px', '```'].join('\n'),
+      },
+      range: {
+        start: { line: 0, character: 21 },
+        end: { line: 0, character: 31 },
+      },
+    },
+  })
 })
 
 withFixture('v4/basic', (c) => {

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -350,7 +350,7 @@ export function findHelperFunctionsInRange(
 ): DocumentHelperFunction[] {
   const text = getTextWithoutComments(doc, 'css', range)
   let matches = findAll(
-    /(?<prefix>[\s:;/*(){}])(?<helper>config|theme|--theme)(?<innerPrefix>\(\s*)(?<path>[^)]*?)\s*\)/g,
+    /(?<prefix>[\W])(?<helper>config|theme|--theme)(?<innerPrefix>\(\s*)(?<path>[^)]*?)\s*\)/g,
     text,
   )
 

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Ensure hover information for `theme(…)` and other functions are shown when used in `@media` queries ([#1172](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1172))
 
 ## 0.14.3
 


### PR DESCRIPTION
This PR fixes an issue with the regex detecting the `--theme(…)` function. If used within a media query with no spaces, it was not properly detecting word boundaries as characters like `<` etc. would be delimit properly.

## Test plan

Added a unit test to ensure this does not regress.