### PR TITLE
Match custom class regex in Vue templates

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -269,10 +269,11 @@ export async function findClassListsInRange(
   range?: Range,
   mode?: 'html' | 'css' | 'jsx',
   includeCustom: boolean = true,
+  lang?: string,
 ): Promise<DocumentClassList[]> {
   let classLists: DocumentClassList[] = []
   if (mode === 'css') {
-    classLists = findClassListsInCssRange(state, doc, range)
+    classLists = findClassListsInCssRange(state, doc, range, lang)
   } else if (mode === 'html' || mode === 'jsx') {
     classLists = await findClassListsInHtmlRange(state, doc, mode, range)
   }
@@ -447,11 +448,11 @@ export async function findClassNameAtPosition(
     let groups = await Promise.all(
       boundaries.map(async ({ type, range, lang }) => {
         if (type === 'css') {
-          return findClassListsInCssRange(state, doc, range, lang)
+          return await findClassListsInRange(state, doc, range, 'css', true, lang)
         }
 
         if (type === 'html') {
-          return await findClassListsInHtmlRange(state, doc, 'html', range)
+          return await findClassListsInRange(state, doc, range, 'html')
         }
 
         if (type === 'js' || type === 'jsx') {

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix parsing of `@custom-variant` shorthand in Tailwind CSS language mode ([#1183](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1183))
 - Make sure custom regexes apply in Vue `<script>` blocks  ([#1177](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1177))
 - Fix suggestion of utilities with slashes in them in v4 ([#1182](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1182))
+- Match custom class regex in Vue templates ([#1194](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1194))
 
 ## 0.14.3
 


### PR DESCRIPTION
Fixes #1066

Looks like I unintentionally broke this in #930 quite a while ago