### PR TITLE
Support directory imports for `index.{ts,cts,mts}`

### DIFF
--- a/packages/tailwindcss-language-server/src/resolver/index.ts
+++ b/packages/tailwindcss-language-server/src/resolver/index.ts
@@ -143,7 +143,8 @@ export async function createResolver(opts: ResolverOptions): Promise<Resolver> {
 
   let esmResolver = ResolverFactory.createResolver({
     fileSystem,
-    extensions: ['.mts', '.mjs', '.ts', '.js'],
+    // .json is omitted since Node does not support await import('foo.json')
+    extensions: ['.mjs', '.js', '.node', '.mts', '.ts'],
     mainFields: ['module'],
     conditionNames: ['node', 'import'],
     pnpApi,
@@ -151,7 +152,7 @@ export async function createResolver(opts: ResolverOptions): Promise<Resolver> {
 
   let cjsResolver = ResolverFactory.createResolver({
     fileSystem,
-    extensions: ['.cts', '.cjs', '.ts', '.js'],
+    extensions: ['.cjs', '.js', '.json', '.node', '.cts', '.ts'],
     mainFields: ['main'],
     conditionNames: ['node', 'require'],
     pnpApi,

--- a/packages/tailwindcss-language-server/src/resolver/index.ts
+++ b/packages/tailwindcss-language-server/src/resolver/index.ts
@@ -143,7 +143,7 @@ export async function createResolver(opts: ResolverOptions): Promise<Resolver> {
 
   let esmResolver = ResolverFactory.createResolver({
     fileSystem,
-    extensions: ['.mjs', '.js'],
+    extensions: ['.mts', '.mjs', '.ts', '.js'],
     mainFields: ['module'],
     conditionNames: ['node', 'import'],
     pnpApi,
@@ -151,7 +151,7 @@ export async function createResolver(opts: ResolverOptions): Promise<Resolver> {
 
   let cjsResolver = ResolverFactory.createResolver({
     fileSystem,
-    extensions: ['.cjs', '.js'],
+    extensions: ['.cts', '.cjs', '.ts', '.js'],
     mainFields: ['main'],
     conditionNames: ['node', 'require'],
     pnpApi,

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Better handle really long class lists in attributes and custom regexes ([#1192](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1192))
 - Add support for Astro’s template literal attributes ([#1193](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1193))
 - Match custom class regex in Vue templates ([#1194](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1194))
+- Support directory imports in plugins for `index.{ts,cts,mts}` ([#1198](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1198))
 
 ## 0.14.3
 


### PR DESCRIPTION
Fixes #1196
