### PR TITLE
Fix odd v4 behavior with custom @-rules

### DIFF
--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -386,14 +386,6 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
     )
     .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_')
 
-    .replace(/--value\(\[(\s?)\*\]\)/g, (_match, space) => {
-      // In this case, space represents a single character space.
-      // From what I can tell spaces aren't intended, so I limited this to a single matcher.
-      // This is because Prettier likes to add a space before the `*`.
-      // FIXME: This is probably unintentional behavior. Consider fixing.
-      return `--value([${space}_])`
-    })
-
   return TextDocument.create(
     textDocument.uri,
     textDocument.languageId,

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -381,6 +381,14 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
     )
     .replace(/(?<=\b(?:theme|config)\([^)]*)[.[\]]/g, '_')
 
+    .replace(/--value\(\[(\s?)\*\]\)/g, (_match, space) => {
+      // In this case, space represents a single character space.
+      // From what I can tell spaces aren't intended, so I limited this to a single matcher.
+      // This is because Prettier likes to add a space before the `*`.
+      // FIXME: This is probably unintentional behavior. Consider fixing.
+      return `--value([${space}_])`
+    })
+
   return TextDocument.create(
     textDocument.uri,
     textDocument.languageId,

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -354,12 +354,10 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
     .replace(/@variants(\s+[^{]+){/g, replace())
     .replace(/@responsive(\s*){/g, replace())
     .replace(/@utility(\s+[^{]+){/g, replaceWithStyleRule())
-    /* This matcher appears to be redundant, and I'm not sure of its purpose.
-       I kept it in case it has an actual use. The one below matches the same @-rule.
-    .replace(/@custom-variant(\s+[^;]+);/g, (match: string) => {
+    .replace(/@custom-variant(\s+[^;{]+);/g, (match: string) => {
       let spaces = ' '.repeat(match.length - 11)
       return `@media(p)${spaces}{}`
-    }) */
+    })
     .replace(/@custom-variant(\s+[^{]+){/g, replaceWithStyleRule())
     .replace(/@variant(\s+[^{]+){/g, replaceWithStyleRule())
     .replace(/@layer(\s+[^{]{2,}){/g, replace(-3))

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -215,9 +215,16 @@ connection.onDocumentSymbol(({ textDocument }) =>
       if (symbol.name === `@media (${MEDIA_MARKER})`) {
         let doc = documents.get(symbol.location.uri)
         let text = doc.getText(symbol.location.range)
-        let match = text.trim().match(/^(@[^\s]+)([^{]+){/)
+        let match = text.trim().match(/^(@[^\s]+)(?:([^{]+)[{]|([^;{]+);)/)
         if (match) {
-          symbol.name = `${match[1]} ${match[2].trim()}`
+          symbol.name = `${match[1]} ${match[2]?.trim() ?? match[3]?.trim()}`
+        }
+      } else if (symbol.name === `.placeholder`) {
+        let doc = documents.get(symbol.location.uri)
+        let text = doc.getText(symbol.location.range)
+        let match = text.trim().match(/^(@[^\s]+)(?:([^{]+)[{]|([^;{]+);)/)
+        if (match) {
+          symbol.name = `${match[1]} ${match[2]?.trim() ?? match[3]?.trim()}`
         }
       }
       return symbol
@@ -337,7 +344,7 @@ function replace(delta = 0) {
 function replaceWithStyleRule(delta = 0) {
   return (_match: string, p1: string) => {
     let spaces = ' '.repeat(p1.length + delta)
-    return `.foo${spaces}{`
+    return `.placeholder${spaces}{`
   }
 }
 
@@ -356,7 +363,7 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
     .replace(/@utility(\s+[^{]+){/g, replaceWithStyleRule())
     .replace(/@custom-variant(\s+[^;{]+);/g, (match: string) => {
       let spaces = ' '.repeat(match.length - 11)
-      return `@media(p)${spaces}{}`
+      return `@media (${MEDIA_MARKER})${spaces}{}`
     })
     .replace(/@custom-variant(\s+[^{]+){/g, replaceWithStyleRule())
     .replace(/@variant(\s+[^{]+){/g, replaceWithStyleRule())

--- a/packages/tailwindcss-language-server/src/language/cssServer.ts
+++ b/packages/tailwindcss-language-server/src/language/cssServer.ts
@@ -354,10 +354,12 @@ function createVirtualCssDocument(textDocument: TextDocument): TextDocument {
     .replace(/@variants(\s+[^{]+){/g, replace())
     .replace(/@responsive(\s*){/g, replace())
     .replace(/@utility(\s+[^{]+){/g, replaceWithStyleRule())
+    /* This matcher appears to be redundant, and I'm not sure of its purpose.
+       I kept it in case it has an actual use. The one below matches the same @-rule.
     .replace(/@custom-variant(\s+[^;]+);/g, (match: string) => {
       let spaces = ' '.repeat(match.length - 11)
       return `@media(p)${spaces}{}`
-    })
+    }) */
     .replace(/@custom-variant(\s+[^{]+){/g, replaceWithStyleRule())
     .replace(/@variant(\s+[^{]+){/g, replaceWithStyleRule())
     .replace(/@layer(\s+[^{]{2,}){/g, replace(-3))

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -2473,10 +2473,5 @@ async function knownUtilityFunctionArguments(state: State, fn: UtilityFn): Promi
     description: "Support arbitrary URL functions, e.g. `{utility}-['url(…)']`",
   })
 
-  args.push({
-    name: '[*]',
-    description: 'Support arbitrary values, e.g. `{utility}-[abc]`',
-  })
-
   return args
 }

--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -2473,5 +2473,10 @@ async function knownUtilityFunctionArguments(state: State, fn: UtilityFn): Promi
     description: "Support arbitrary URL functions, e.g. `{utility}-['url(…)']`",
   })
 
+  args.push({
+    name: '[*]',
+    description: 'Support arbitrary values, e.g. `{utility}-[abc]`',
+  })
+
   return args
 }

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show source diagnostics when imports contain a layer ([#1204](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1204))
 - Only detect project roots in v4 when using certain CSS features ([#1205](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1205))
 - Update Tailwind CSS v4 version to v4.0.6 ([#1207](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1207))
+- Fix parsing of `@custom-variant` block syntax containg declarations and/or `@slot` ([#1212](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1212))
 
 ## 0.14.4
 

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Only detect project roots in v4 when using certain CSS features ([#1205](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1205))
 - Update Tailwind CSS v4 version to v4.0.6 ([#1207](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1207))
 - Fix parsing of `@custom-variant` block syntax containg declarations and/or `@slot` ([#1212](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1212))
+- Fix display of custom at-rules in symbol listing ([#1212](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1212))
 
 ## 0.14.4
 


### PR DESCRIPTION
Fixes #1211

I'm not sure if the `.replace` I removed actually had a purpose - it seemed useless to me.
I can (probably) easily bring it back if it does have a purpose, gonna have to see how to fix it in that case hten.

Also adds a QOL feature of now autosuggesting `[*]` in `--value(`.

See the issue for way more details on why some things are the way they are.