### PR TITLE
lsp: Declare capability for handling change notifications

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -936,6 +936,11 @@ export class TW {
         return {
           capabilities: {
             textDocumentSync: TextDocumentSyncKind.Full,
+            workspace: {
+              workspaceFolders: {
+                changeNotifications: true,
+              },
+            },
           },
         }
       }
@@ -952,6 +957,11 @@ export class TW {
           completionProvider: {
             resolveProvider: true,
             triggerCharacters: [...TRIGGER_CHARACTERS, ':'],
+          },
+          workspace: {
+            workspaceFolders: {
+              changeNotifications: true,
+            },
           },
         },
       }

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- LSP: Declare capability for handling workspace folder change notifications ([#1223](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1223))
 
 ## 0.14.6
 


### PR DESCRIPTION
Tailwind LSP server is already capable of handling change notifications, but it does not declare a capability in it's Server Capabilities. Thus, clients such as Zed do not send out this notification.