### PR TITLE
Fix syntax error when resetting multi-word theme key namespaces

### DIFF
--- a/packages/tailwindcss-language-server/src/language/rewriting.test.ts
+++ b/packages/tailwindcss-language-server/src/language/rewriting.test.ts
@@ -69,20 +69,28 @@ test('@theme', () => {
   let input = [
     //
     '@theme {',
-    '  color: red;',
+    '  --color: red;',
+    '  --font-*: initial;',
+    '  --font-weight-*: initial;',
     '}',
     '@theme inline reference static default {',
-    '  color: red;',
+    '  --color: red;',
+    '  --font-*: initial;',
+    '  --font-weight-*: initial;',
     '}',
   ]
 
   let output = [
     //
     '.placeholder {', // wrong
-    '  color: red;',
+    '  --color: red;',
+    '  --font-_: initial;',
+    '  --font-weight-_: initial;',
     '}',
     '.placeholder                                 {', // wrong
-    '  color: red;',
+    '  --color: red;',
+    '  --font-_: initial;',
+    '  --font-weight-_: initial;',
     '}',
   ]
 

--- a/packages/tailwindcss-language-server/src/language/rewriting.ts
+++ b/packages/tailwindcss-language-server/src/language/rewriting.ts
@@ -74,7 +74,7 @@ export function rewriteCss(css: string) {
   })
 
   // Replace `--some-var-*` with `--some-var-_`
-  css = css.replace(/--([a-zA-Z0-9]+)-[*]/g, '--$1_')
+  css = css.replace(/--([a-zA-Z0-9-]+)-[*]/g, '--$1-_')
 
   return css
 }

--- a/packages/tailwindcss-language-server/tests/css/css-server.test.ts
+++ b/packages/tailwindcss-language-server/tests/css/css-server.test.ts
@@ -219,6 +219,7 @@ defineTest({
         @theme {
           --color-primary: #333;
           --leading-*: initial;
+          --font-weight-*: initial;
         }
       `,
     })
@@ -235,7 +236,7 @@ defineTest({
           uri: '{workspace:default}/file-1.css',
           range: {
             start: { line: 1, character: 0 },
-            end: { line: 4, character: 1 },
+            end: { line: 5, character: 1 },
           },
         },
       },

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Fix syntax error when resetting multi-word theme key namespaces ([#1237](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1237))
 
 # 0.14.7
 


### PR DESCRIPTION
Fixes #1236

This PR fixes an issue where we'd show a syntax error for multi-word namespace resets like `--font-weight-*: initial;`:

```css
@theme {
  --font-*: initial; /* this one is fine */
  --font-weight-*: initial; /* this one shows a syntax error */
}
```

<img width="686" alt="Screenshot 2025-02-26 at 12 16 38" src="https://github.com/user-attachments/assets/60a9e9e9-931a-485b-9a23-4ea972b02396" />

Now both work as expected:

<img width="763" alt="Screenshot 2025-02-26 at 12 17 09" src="https://github.com/user-attachments/assets/4a245979-2b45-4931-b47a-6a5c0de42bf5" />
