### PR TITLE
Don’t throw when client is missing the `textDocument` capability

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -1024,10 +1024,10 @@ export class TW {
 
 function supportsDynamicRegistration(params: InitializeParams): boolean {
   return (
-    params.capabilities.textDocument.hover?.dynamicRegistration &&
-    params.capabilities.textDocument.colorProvider?.dynamicRegistration &&
-    params.capabilities.textDocument.codeAction?.dynamicRegistration &&
-    params.capabilities.textDocument.completion?.dynamicRegistration &&
-    params.capabilities.textDocument.documentLink?.dynamicRegistration
+    params.capabilities.textDocument?.hover?.dynamicRegistration &&
+    params.capabilities.textDocument?.colorProvider?.dynamicRegistration &&
+    params.capabilities.textDocument?.codeAction?.dynamicRegistration &&
+    params.capabilities.textDocument?.completion?.dynamicRegistration &&
+    params.capabilities.textDocument?.documentLink?.dynamicRegistration
   )
 }

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - v4: Support loading bundled versions of some first-party plugins ([#1240](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1240))
 - Cancel initial file search if it takes too long ([#1242](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1242))
+- LSP: Don’t throw when the client does not provide `textDocument` in capabilities ([#1252](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1252))
 
 # 0.14.8
 


### PR DESCRIPTION
Fixes #1251

This needs more research before merging because we probably need to skip registration of providers. And possibly not even attempt to initialize projects in this case? Not entirely sure.

- [ ] Needs tests