### PR TITLE
LSP: Refresh internal caches when settings are updated

### DIFF
--- a/packages/tailwindcss-language-server/src/projects.ts
+++ b/packages/tailwindcss-language-server/src/projects.ts
@@ -1181,11 +1181,9 @@ export async function createProjectService(
       if (state.enabled) {
         refreshDiagnostics()
       }
-      if (settings.editor?.colorDecorators) {
-        updateCapabilities()
-      } else {
-        connection.sendNotification('@/tailwindCSS/clearColors')
-      }
+
+      updateCapabilities()
+      connection.sendNotification('@/tailwindCSS/clearColors')
     },
     onFileEvents,
     async onHover(params: TextDocumentPositionParams): Promise<Hover> {

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -33,6 +33,7 @@ import {
   DocumentLinkRequest,
   TextDocumentSyncKind,
   CodeLensRequest,
+  DidChangeConfigurationNotification,
 } from 'vscode-languageserver/node'
 import { URI } from 'vscode-uri'
 import normalizePath from 'normalize-path'
@@ -799,6 +800,7 @@ export class TW {
 
   private updateCapabilities() {
     if (!supportsDynamicRegistration(this.initializeParams)) {
+      this.connection.client.register(DidChangeConfigurationNotification.type, undefined)
       return
     }
 
@@ -815,6 +817,7 @@ export class TW {
     capabilities.add(CodeActionRequest.type, { documentSelector: null })
     capabilities.add(CodeLensRequest.type, { documentSelector: null })
     capabilities.add(DocumentLinkRequest.type, { documentSelector: null })
+    capabilities.add(DidChangeConfigurationNotification.type, undefined)
 
     capabilities.add(CompletionRequest.type, {
       documentSelector: null,

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -812,6 +812,8 @@ export class TW {
 
     let capabilities = BulkRegistration.create()
 
+    // TODO: We should *not* be re-registering these capabilities
+    // IDEA: These should probably be static registrations up front
     capabilities.add(HoverRequest.type, { documentSelector: null })
     capabilities.add(DocumentColorRequest.type, { documentSelector: null })
     capabilities.add(CodeActionRequest.type, { documentSelector: null })
@@ -819,6 +821,7 @@ export class TW {
     capabilities.add(DocumentLinkRequest.type, { documentSelector: null })
     capabilities.add(DidChangeConfigurationNotification.type, undefined)
 
+    // TODO: Only re-register this if trigger characters change
     capabilities.add(CompletionRequest.type, {
       documentSelector: null,
       resolveProvider: true,

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -6,6 +6,7 @@
 - v4: Make sure completions show after variants using arbitrary and bare values ([#1263](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1263))
 - v4: Add support for upcoming `@source not` feature ([#1262](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1262))
 - v4: Add support for upcoming `@source inline(…)` feature ([#1262](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1262))
+- LSP: Refresh internal caches when settings are updated ([#1273](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1273))
 
 # 0.14.9
 


### PR DESCRIPTION
We use the pull model (`workspace/configuration`) to get settings for a document and we cache these internally so we don't repeat these calls multiple times for a given request. We're set up to listen for configuration refresh notifications and update the project settings when we get them.

Unfortunately, we didn't actually _register_ for these notifications, so we never got them. This meant that if you changed the settings for an already opened file or workspace folder, the language server would not react to these changes. This PR fixes this by registering for configuration change notifications and now open files with color decorators, completions, etc… should react to changes in the settings as needed.

If settings are updated and our langauge server doesn't react to or handle these changes, it is definitely a bug. Hopefully this will squash all of those particular ones but… we'll see. 😅
