### PR TITLE
Improve error message when a workspace folder is inaccessible

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -186,7 +186,7 @@ export class TW {
     let base = baseUri.fsPath
 
     try {
-      await fs.access(base)
+      await fs.access(base, fs.constants.F_OK | fs.constants.R_OK)
     } catch (err) {
       console.error(
         `Unable to access the workspace folder [${base}]. This may happen if the directory does not exist or the current user does not have the necessary permissions to access it.`,

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -175,7 +175,7 @@ export class TW {
   }
 
   private async _initFolder(baseUri: URI): Promise<void> {
-    // NOTE: We do this check because on Linux when using a LSP client that does
+    // NOTE: We do this check because on Linux when using an LSP client that does
     // not support watching files on behalf of the server, we'll use Parcel
     // Watcher (if possible). If we start the watcher with a non-existent or
     // inaccessible directory, it will throw an error with a very unhelpful

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -38,6 +38,7 @@ import {
 import { URI } from 'vscode-uri'
 import normalizePath from 'normalize-path'
 import * as path from 'node:path'
+import * as fs from 'node:fs/promises'
 import type * as chokidar from 'chokidar'
 import picomatch from 'picomatch'
 import * as parcel from './watcher/index.js'
@@ -174,6 +175,26 @@ export class TW {
   }
 
   private async _initFolder(baseUri: URI): Promise<void> {
+    // NOTE: We do this check because on Linux when using a LSP client that does
+    // not support watching files on behalf of the server, we'll use Parcel
+    // Watcher (if possible). If we start the watcher with a non-existent or
+    // inaccessible directory, it will throw an error with a very unhelpful
+    // message: "Bad file descriptor"
+    //
+    // The best thing we can do is an initial check for access to the directory
+    // and log a more helpful error message if it fails.
+    let base = baseUri.fsPath
+
+    try {
+      await fs.access(base)
+    } catch (err) {
+      console.error(
+        `Unable to access the workspace folder [${base}]. This may happen if the directory does not exist or the current user does not have the necessary permissions to access it.`,
+      )
+      console.error(err)
+      return
+    }
+
     let initUserLanguages = this.initializeParams.initializationOptions?.userLanguages ?? {}
 
     if (Object.keys(initUserLanguages).length > 0) {
@@ -182,7 +203,6 @@ export class TW {
       )
     }
 
-    let base = baseUri.fsPath
     let workspaceFolders: Array<ProjectConfig> = []
     let globalSettings = await this.settingsCache.get()
     let ignore = globalSettings.tailwindCSS.files.exclude

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -7,6 +7,7 @@
 - v4: Add support for upcoming `@source not` feature ([#1262](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1262))
 - v4: Add support for upcoming `@source inline(…)` feature ([#1262](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1262))
 - LSP: Refresh internal caches when settings are updated ([#1273](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1273))
+- LSP: Improve error message when a workspace folder does not exist or is inaccesible to the current user ([#1276](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1276))
 
 # 0.14.9
 


### PR DESCRIPTION
On Linux when using a LSP client that does not support watching files on behalf of the server, we'll use Parcel Watcher (if possible). If we start the watcher with a non-existent or inaccessible directory, it will throw an error with a very unhelpful message: "Bad file descriptor".

The best thing we can do is an initial check for access to the directory and log a more helpful error message if it fails:

<img width="1013" alt="Screenshot 2025-03-20 at 12 33 29" src="https://github.com/user-attachments/assets/425c1fac-cd5e-492f-89bf-76d3a733670d" />

See https://github.com/tailwindlabs/tailwindcss-intellisense/issues/884#issuecomment-1927660975
