### PR TITLE
Ensure file exclusions always work on Windows

### DIFF
--- a/packages/tailwindcss-language-server/src/util/isExcluded.ts
+++ b/packages/tailwindcss-language-server/src/util/isExcluded.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import type { State } from '@tailwindcss/language-service/src/util/state'
 import { getFileFsPath } from './uri'
+import { normalizePath, normalizeDriveLetter } from '../utils'
 
 export default async function isExcluded(
   state: State,
@@ -11,8 +12,15 @@ export default async function isExcluded(
 ): Promise<boolean> {
   let settings = await state.editor.getConfiguration(document.uri)
 
+  file = normalizePath(file)
+  file = normalizeDriveLetter(file)
+
   for (let pattern of settings.tailwindCSS.files.exclude) {
-    if (picomatch(path.join(state.editor.folder, pattern))(file)) {
+    pattern = path.join(state.editor.folder, pattern)
+    pattern = normalizePath(pattern)
+    pattern = normalizeDriveLetter(pattern)
+
+    if (picomatch(pattern)(file)) {
       return true
     }
   }

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Prerelease
 
 - Fix content detection when using v4.0+ ([#1280](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1280))
+- Ensure file exclusions always work on Windows ([#1281](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1281))
 
 # 0.14.11
 


### PR DESCRIPTION
Sometimes exclusions weren't processed correctly on Windows. This cause additional results to show up in file path completions in things like `@config`, `@plugim`, `@source`, etc…