### PR TITLE
Guard against infinitely recursive theme key lookup

### DIFF
--- a/packages/tailwindcss-language-service/src/util/rewriting/index.test.ts
+++ b/packages/tailwindcss-language-service/src/util/rewriting/index.test.ts
@@ -79,9 +79,9 @@ test('replacing CSS variables with their fallbacks (when they have them)', () =>
   expect(replaceCssVarsWithFallbacks(state, 'var(--level-3)')).toBe('blue')
 
   // Circular replacements don't cause infinite loops
-  expect(replaceCssVarsWithFallbacks(state, 'var(--circular-1)')).toBe('var(--circular-3)')
-  expect(replaceCssVarsWithFallbacks(state, 'var(--circular-2)')).toBe('var(--circular-1)')
-  expect(replaceCssVarsWithFallbacks(state, 'var(--circular-3)')).toBe('var(--circular-2)')
+  expect(replaceCssVarsWithFallbacks(state, 'var(--circular-1)')).toBe('var(--circular-1)')
+  expect(replaceCssVarsWithFallbacks(state, 'var(--circular-2)')).toBe('var(--circular-2)')
+  expect(replaceCssVarsWithFallbacks(state, 'var(--circular-3)')).toBe('var(--circular-3)')
 })
 
 test('recursive theme replacements', () => {

--- a/packages/tailwindcss-language-service/src/util/rewriting/var-fallbacks.ts
+++ b/packages/tailwindcss-language-service/src/util/rewriting/var-fallbacks.ts
@@ -3,14 +3,25 @@ import { resolveVariableValue } from './lookup'
 import { replaceCssVars } from './replacements'
 
 export function replaceCssVarsWithFallbacks(state: State, str: string): string {
+  let seen = new Set<string>()
+
   return replaceCssVars(str, {
     replace({ name, fallback }) {
       // Replace with the value from the design system first. The design system
       // take precedences over other sources as that emulates the behavior of a
       // browser where the fallback is only used if the variable is defined.
       if (state.designSystem && name.startsWith('--')) {
+        // TODO: This isn't quite right as we might skip expanding a variable
+        // that should be expanded
+        if (seen.has(name)) return null
         let value = resolveVariableValue(state.designSystem, name)
-        if (value !== null) return value
+        if (value !== null) {
+          if (value.includes('var(')) {
+            seen.add(name)
+          }
+
+          return value
+        }
       }
 
       if (fallback) {

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Warn when using a blocklisted class in v4 ([#1310](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1310))
 - Support class function hovers in Svelte and HTML `<script>` blocks ([#1311](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1311))
+- Guard against recursive theme key lookup ([#1332](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1332))
 
 # 0.14.15
 


### PR DESCRIPTION
When constructing the design system we compute color swatches for all classes. This process involves:
- Computing the CSS for a utility
- Inlining any values from the theme, recursively
- Scanning for CSS color syntax that we can compute a swatch for

We guard against directly self-recursive replacements because of how the replacement itself functions. However, if you wrapped the variable in something then we would effectively recurse into the expression and try to replace the variable again. This caused the expansion to then be wrapped and then try again resulting in an infinite loop.

This fixes it by keeping track of seen variables during a replacement and if we've seen it _and_ the expansion contains a var(…) anywhere we'll only replace it once. This logic is not perfect as the thing that matters is that the replacement _itself_ results in a recursion but this is good enough for now.

Fixes #1329