### PR TITLE
Improve language server detection for workspace folders

### DIFF
--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Ignore Python virtual env directories by default ([#1336](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1336))
 - Ignore Yarn v2+ metadata & cache directories by default ([#1336](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1336))
 - Ignore some build caches by default ([#1336](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1336))
+- Boot langauage server quicker in multi-root workspaces ([#1334](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1334))
+- Don't start language server if we only see `@import` in preprocessor files ([#1334](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1334))
 
 # 0.14.16
 

--- a/packages/vscode-tailwindcss/src/analyze.ts
+++ b/packages/vscode-tailwindcss/src/analyze.ts
@@ -29,33 +29,53 @@ export async function anyWorkspaceFoldersNeedServer({ folders, token }: SearchOp
     if (typeof configFilePath === 'object' && Object.values(configFilePath).length > 0) return true
   }
 
-  let configs: Array<() => Thenable<Uri[]>> = []
-  let stylesheets: Array<() => Thenable<Uri[]>> = []
+  // If any search returns that it needs a workspace then the server needs to be started
+  // and the remainder of the searches will be cancelled
+  let searches = folders.map((folder) =>
+    workspaceFoldersNeedServer({ folder, token }).then((found) => {
+      if (found) return true
 
-  for (let folder of folders) {
-    let exclusions = getExcludePatterns(folder).flatMap((pattern) => braces.expand(pattern))
-    let exclude = `{${exclusions.join(',').replace(/{/g, '%7B').replace(/}/g, '%7D')}}`
+      // We use `throw` so we can use Promise.any(…)
+      throw new Error(DUMMY_ERROR_MESSAGE)
+    }),
+  )
 
-    configs.push(() =>
-      workspace.findFiles(
-        new RelativePattern(folder, `**/${CONFIG_GLOB}`),
-        exclude,
-        undefined,
-        token,
-      ),
-    )
+  const DUMMY_ERROR_MESSAGE = 'Workspace folder not needed'
 
-    stylesheets.push(() =>
-      workspace.findFiles(new RelativePattern(folder, `**/${CSS_GLOB}`), exclude, undefined, token),
-    )
+  try {
+    return await Promise.any(searches)
+  } catch (err) {
+    for (let anErr of (err as AggregateError).errors ?? []) {
+      if (typeof anErr === 'object' && err.message === DUMMY_ERROR_MESSAGE) {
+        continue
+      }
+
+      console.error(anErr)
+    }
+
+    return false
   }
+}
+
+export interface FolderSearchOptions {
+  folder: WorkspaceFolder
+  token: CancellationToken
+}
+
+async function workspaceFoldersNeedServer({ folder, token }: FolderSearchOptions) {
+  let exclusions = getExcludePatterns(folder).flatMap((pattern) => braces.expand(pattern))
+  let exclude = `{${exclusions.join(',').replace(/{/g, '%7B').replace(/}/g, '%7D')}}`
 
   // If we find a config file then we need the server
-  let configUrls = await Promise.all(configs.map((fn) => fn()))
-  for (let group of configUrls) {
-    if (group.length > 0) {
-      return true
-    }
+  let configs = await workspace.findFiles(
+    new RelativePattern(folder, `**/${CONFIG_GLOB}`),
+    exclude,
+    undefined,
+    token,
+  )
+
+  if (configs.length > 0) {
+    return true
   }
 
   // If we find a possibly-related stylesheet then we need the server
@@ -65,12 +85,16 @@ export async function anyWorkspaceFoldersNeedServer({ folders, token }: SearchOp
   // This is also, unfortunately, prone to starting the server unncessarily
   // in projects that don't use TailwindCSS so we do this one-by-one instead
   // of all at once to keep disk I/O low.
-  let stylesheetUrls = await Promise.all(stylesheets.map((fn) => fn()))
-  for (let group of stylesheetUrls) {
-    for (let file of group) {
-      if (await fileMayBeTailwindRelated(file)) {
-        return true
-      }
+  let stylesheets = await workspace.findFiles(
+    new RelativePattern(folder, `**/${CSS_GLOB}`),
+    exclude,
+    undefined,
+    token,
+  )
+
+  for (let file of stylesheets) {
+    if (await fileMayBeTailwindRelated(file)) {
+      return true
     }
   }
 }

--- a/packages/vscode-tailwindcss/src/api.ts
+++ b/packages/vscode-tailwindcss/src/api.ts
@@ -11,11 +11,13 @@ export async function createApi({ context, outputChannel }: ApiOptions) {
 
   async function workspaceNeedsLanguageServer() {
     if (folderAnalysis) return folderAnalysis
+    let found = false
 
     let source: CancellationTokenSource | null = new CancellationTokenSource()
     source.token.onCancellationRequested(() => {
       source?.dispose()
       source = null
+      if (found) return
 
       outputChannel.appendLine(
         'Server was not started. Search for Tailwind CSS-related files was taking too long.',
@@ -32,7 +34,8 @@ export async function createApi({ context, outputChannel }: ApiOptions) {
     })
 
     let result = await folderAnalysis
-    source?.dispose()
+    found = true
+    source?.cancel()
     return result
   }
 


### PR DESCRIPTION
This PR should enable quicker booting of the language server in large multi-root workspaces

1. Potentially improved detection time in multi-root workspaces

Now we'll start the server as soon as *any* search has requested that it be started. Any remaining searches will be cancelled instead of waiting for them to complete. The language server itself will still do a more exhaustive search to find projects in all registered workspace folders.

2. Ignore pre-processor files that don't contain `@config`

Tailwind CSS v4 required us to analyze the workspace for more stylesheets that may contain `@import` (because `@import "tailwindcss"` and similar), `@theme`, etc… but these are only supported in `.css` files and not `.styl`, `.sass`, `.scss`, `.less`, etc…

We were already doing this because v3 looked for `@config` but that is valid in _any_ stylesheet type. Now we restrict `@import`, `@theme`, etc matching to `.css` files and we'll be less likely to start the server if we don't need to.
