### PR TITLE
Update default file exclusions

### DIFF
--- a/packages/tailwindcss-language-server/tests/env/ignored.test.ts
+++ b/packages/tailwindcss-language-server/tests/env/ignored.test.ts
@@ -1,0 +1,111 @@
+import { expect } from 'vitest'
+import { css, defineTest } from '../../src/testing'
+import { createClient } from '../utils/client'
+import dedent from 'dedent'
+
+let ignored = css`
+  @import 'tailwindcss';
+  @theme {
+    --color-primary: #c0ffee;
+  }
+`
+
+let found = css`
+  @import 'tailwindcss';
+  @theme {
+    --color-primary: rebeccapurple;
+  }
+`
+
+defineTest({
+  name: 'various build folders and caches are ignored by default',
+  fs: {
+    // All of these should be ignored
+    'aaa/.git/app.css': ignored,
+    'aaa/.hg/app.css': ignored,
+    'aaa/.svn/app.css': ignored,
+    'aaa/node_modules/app.css': ignored,
+    'aaa/.yarn/app.css': ignored,
+    'aaa/.venv/app.css': ignored,
+    'aaa/venv/app.css': ignored,
+    'aaa/.next/app.css': ignored,
+    'aaa/.parcel-cache/app.css': ignored,
+    'aaa/.svelte-kit/app.css': ignored,
+    'aaa/.turbo/app.css': ignored,
+    'aaa/__pycache__/app.css': ignored,
+
+    // But this one should not be
+    'zzz/app.css': found,
+  },
+
+  prepare: async ({ root }) => ({ client: await createClient({ root }) }),
+  handle: async ({ client }) => {
+    let doc = await client.open({
+      lang: 'html',
+      text: '<div class="bg-primary">',
+    })
+
+    // <div class="bg-primary">
+    //             ^
+    let hover = await doc.hover({ line: 0, character: 13 })
+    expect(hover).toEqual({
+      contents: {
+        language: 'css',
+        value: dedent`
+          .bg-primary {
+            background-color: var(--color-primary) /* rebeccapurple = #663399 */;
+          }
+        `,
+      },
+      range: {
+        start: { line: 0, character: 12 },
+        end: { line: 0, character: 22 },
+      },
+    })
+  },
+})
+
+defineTest({
+  name: 'ignores can be overridden',
+  fs: {
+    'aaa/app.css': ignored,
+    'bbb/.git/app.css': found,
+  },
+
+  prepare: async ({ root }) => ({
+    client: await createClient({
+      root,
+      settings: {
+        tailwindCSS: {
+          files: {
+            exclude: ['**/aaa/**'],
+          },
+        },
+      },
+    }),
+  }),
+  handle: async ({ client }) => {
+    let doc = await client.open({
+      lang: 'html',
+      text: '<div class="bg-primary">',
+    })
+
+    // <div class="bg-primary">
+    //             ^
+    let hover = await doc.hover({ line: 0, character: 13 })
+    expect(hover).toEqual({
+      contents: {
+        language: 'css',
+        value: dedent`
+          .bg-primary {
+            background-color: var(--color-primary) /* rebeccapurple = #663399 */;
+          }
+        `,
+      },
+      range: {
+        start: { line: 0, character: 12 },
+        end: { line: 0, character: 22 },
+      },
+    })
+  },
+})

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -218,6 +218,9 @@ export function getDefaultTailwindSettings(): Settings {
           // NPM
           '**/node_modules/**',
 
+          // Yarn v2+ metadata & caches
+          '**/.yarn/**',
+
           // Python Virtual Environments
           '**/.venv/**',
           '**/venv/**',

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -217,6 +217,10 @@ export function getDefaultTailwindSettings(): Settings {
 
           // NPM
           '**/node_modules/**',
+
+          // Python Virtual Environments
+          '**/.venv/**',
+          '**/venv/**',
         ],
       },
       experimental: {

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -224,6 +224,13 @@ export function getDefaultTailwindSettings(): Settings {
           // Python Virtual Environments
           '**/.venv/**',
           '**/venv/**',
+
+          // Build caches
+          '**/.next/**',
+          '**/.parcel-cache/**',
+          '**/.svelte-kit/**',
+          '**/.turbo/**',
+          '**/__pycache__/**',
         ],
       },
       experimental: {

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -208,7 +208,17 @@ export function getDefaultTailwindSettings(): Settings {
       },
       showPixelEquivalents: true,
       includeLanguages: {},
-      files: { exclude: ['**/.git/**', '**/node_modules/**', '**/.hg/**', '**/.svn/**'] },
+      files: {
+        exclude: [
+          // Version Control
+          '**/.git/**',
+          '**/.hg/**',
+          '**/.svn/**',
+
+          // NPM
+          '**/node_modules/**',
+        ],
+      },
       experimental: {
         classRegex: [],
         configFile: null,

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -210,6 +210,15 @@ export function getDefaultTailwindSettings(): Settings {
       includeLanguages: {},
       files: {
         exclude: [
+          // These paths need to be universally ignorable. This means that we
+          // should only consider hidden folders with a commonly understood
+          // meaning unless there is a very good reason to do otherwise.
+          //
+          // This means that things like `build`, `target`, `cache`, etc… are
+          // not appropriate to include even though _in many cases_ they might
+          // be ignorable. The names are too general and ignoring them could
+          // cause us to ignore actual project files.
+
           // Version Control
           '**/.git/**',
           '**/.hg/**',

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Prerelease
 
 - Improve dynamic capability registration in the language server ([#1327](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1327))
+- Ignore Python virtual env directories by default ([#1336](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1336))
+- Ignore Yarn v2+ metadata & cache directories by default ([#1336](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1336))
+- Ignore some build caches by default ([#1336](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1336))
 
 # 0.14.16
 


### PR DESCRIPTION
IntelliSense, by default, ignores files for:
- Version control (`.git`, `.hg`, `.svn`)
- NPM (`node_modules`)

I'm adding three more groups to this:
- Python virtual environment folders (`.venv`, `venv`)
- Yarn v2+ metadata & caches (`.yarn`)
- *some* build caches (`.next`, `.turbo`, `.parcel-cache`, `__pycache__`)

Discovered that we should update these when triaging #1312 (that one was specifically about python virtual envs)