### PR TITLE
Add Node 24 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 23]
+        node: [18, 20, 22, 24]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
technically this replaces v23 with v24 but odd numbered node releases don't ever become LTS