### PR TITLE
Handle balanced parens when searching for helper functions

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.test.ts
+++ b/packages/tailwindcss-language-service/src/util/find.test.ts
@@ -904,6 +904,16 @@ test('Can find helper functions in CSS', async ({ expect }) => {
       .a { color: theme(foo / 0.5, default); }
       .a { color: theme("foo" / 0.5); }
       .a { color: theme("foo" / 0.5, default); }
+
+      /* nested invocations */
+      .a { color: from-config(theme(foo)); }
+      .a { color: from-config(theme(foo, default)); }
+      .a { color: from-config(theme("foo")); }
+      .a { color: from-config(theme("foo", default)); }
+      .a { color: from-config(theme(foo / 0.5)); }
+      .a { color: from-config(theme(foo / 0.5, default)); }
+      .a { color: from-config(theme("foo" / 0.5)); }
+      .a { color: from-config(theme("foo" / 0.5, default)); }
     `,
   })
 
@@ -949,6 +959,88 @@ test('Can find helper functions in CSS', async ({ expect }) => {
       helper: 'theme',
       path: 'foo',
       ranges: { full: range(8, 24, 8, 44), path: range(8, 25, 8, 28) },
+    },
+
+    // Nested
+    {
+      helper: 'config',
+      path: 'theme(foo)',
+      ranges: { full: range(11, 30, 11, 40), path: range(11, 30, 11, 40) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(11, 36, 11, 39), path: range(11, 36, 11, 39) },
+    },
+    {
+      helper: 'config',
+      path: 'theme(foo, default)',
+      ranges: { full: range(12, 30, 12, 49), path: range(12, 30, 12, 49) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(12, 36, 12, 48), path: range(12, 36, 12, 39) },
+    },
+    {
+      helper: 'config',
+      path: 'theme("foo")',
+      ranges: { full: range(13, 30, 13, 42), path: range(13, 30, 13, 42) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(13, 36, 13, 41), path: range(13, 37, 13, 40) },
+    },
+    {
+      helper: 'config',
+      path: 'theme("foo", default)',
+      ranges: { full: range(14, 30, 14, 51), path: range(14, 30, 14, 51) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(14, 36, 14, 50), path: range(14, 37, 14, 40) },
+    },
+    {
+      helper: 'config',
+      path: 'theme(foo / 0.5)',
+      ranges: { full: range(15, 30, 15, 46), path: range(15, 30, 15, 46) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(15, 36, 15, 45), path: range(15, 36, 15, 39) },
+    },
+    {
+      helper: 'config',
+      path: 'theme(foo / 0.5, default)',
+      ranges: { full: range(16, 30, 16, 55), path: range(16, 30, 16, 55) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(16, 36, 16, 54), path: range(16, 36, 16, 39) },
+    },
+    {
+      helper: 'config',
+      path: 'theme("foo" / 0.5)',
+      ranges: { full: range(17, 30, 17, 48), path: range(17, 30, 17, 48) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(17, 36, 17, 47), path: range(17, 37, 17, 40) },
+    },
+    {
+      helper: 'config',
+      path: 'theme("foo" / 0.5, default)',
+      ranges: { full: range(18, 30, 18, 57), path: range(18, 30, 18, 57) },
+    },
+    {
+      helper: 'theme',
+      path: 'foo',
+      ranges: { full: range(18, 36, 18, 56), path: range(18, 37, 18, 40) },
     },
   ])
 })

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Calculate swatches for HSL colors with angular units ([#1360](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1360))
 - Fix error when using VSCode < 1.78 ([#1353](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1353))
 - Don’t skip suggesting empty variant implementations ([#1352](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1352))
+- Handle helper function lookups in nested parens ([#1354](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1354))
 
 # 0.14.16
 


### PR DESCRIPTION
Fixes #1285

The regex would cause things like this to not work properly:
```
.foo {
  color: my-config(theme('fontFamily.sans'))
}
```

You'd get an error message like this:
```
'theme('fontFamily.sans' does not exist in your theme config.(invalidConfigPath)
```

Which means:
1. It saw `config` instead of `my-config`
2. It didn't handle nested parens correctly
3. the nested `theme` function wasn't found

This PR fixes all three of these