### PR TITLE
Improve CSS syntax highlighting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Run syntax tests
+        run: |
+          cd packages/tailwindcss-language-syntax &&
+          pnpm run build &&
+          pnpm run test
+
+      - name: Run service tests
+        run: |
+          cd packages/tailwindcss-language-service &&
+          pnpm run build &&
+          pnpm run test
+
       - name: Run tests
         run: |
           cd packages/tailwindcss-language-server &&

--- a/packages/tailwindcss-language-service/scripts/build.mjs
+++ b/packages/tailwindcss-language-service/scripts/build.mjs
@@ -3,8 +3,9 @@ import { spawnSync } from 'node:child_process'
 import esbuild from 'esbuild'
 import minimist from 'minimist'
 import { nodeExternalsPlugin } from 'esbuild-node-externals'
+import { fileURLToPath } from 'node:url'
 
-const __dirname = new URL('.', import.meta.url).pathname
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const args = minimist(process.argv.slice(2), {
   boolean: ['watch', 'minify'],
@@ -30,7 +31,13 @@ let build = await esbuild.context({
           // Call the tsc command to generate the types
           spawnSync(
             'tsc',
-            ['-p', path.resolve(__dirname, './tsconfig.build.json'), '--emitDeclarationOnly', '--outDir', path.resolve(__dirname, '../dist')],
+            [
+              '-p',
+              path.resolve(__dirname, './tsconfig.build.json'),
+              '--emitDeclarationOnly',
+              '--outDir',
+              path.resolve(__dirname, '../dist'),
+            ],
             {
               stdio: 'inherit',
             },

--- a/packages/tailwindcss-language-syntax/package.json
+++ b/packages/tailwindcss-language-syntax/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tailwindcss/language-syntax",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "vitest",
+    "build": " "
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.33",
+    "dedent": "^1.5.3",
+    "vitest": "^3.1.4",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.2.0"
+  }
+}

--- a/packages/tailwindcss-language-syntax/syntaxes/css.json
+++ b/packages/tailwindcss-language-syntax/syntaxes/css.json
@@ -1,0 +1,1871 @@
+{
+  "__tailwind_notes__": [
+    "This was copied from VSCode and is used for testing purposes",
+    "https://github.com/microsoft/vscode/blob/2e59a779912bc1b7b2505ae52aff3a7648c24857/extensions/css/syntaxes/css.tmLanguage.json",
+    "It is covered by the MIT license:",
+    "https://github.com/microsoft/vscode/blob/2e59a779912bc1b7b2505ae52aff3a7648c24857/LICENSE.txt"
+  ],
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/microsoft/vscode-css/blob/master/grammars/css.cson",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "version": "https://github.com/microsoft/vscode-css/commit/a927fe2f73927bf5c25d0b0c4dd0e63d69fd8887",
+  "name": "CSS",
+  "scopeName": "source.css",
+  "patterns": [
+    {
+      "include": "#comment-block"
+    },
+    {
+      "include": "#escapes"
+    },
+    {
+      "include": "#combinators"
+    },
+    {
+      "include": "#selector"
+    },
+    {
+      "include": "#at-rules"
+    },
+    {
+      "include": "#rule-list"
+    }
+  ],
+  "repository": {
+    "at-rules": {
+      "patterns": [
+        {
+          "begin": "\\A(?:\\xEF\\xBB\\xBF)?(?i:(?=\\s*@charset\\b))",
+          "end": ";|(?=$)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.rule.css"
+            }
+          },
+          "name": "meta.at-rule.charset.css",
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "name": "invalid.illegal.not-lowercase.charset.css"
+                },
+                "2": {
+                  "name": "invalid.illegal.leading-whitespace.charset.css"
+                },
+                "3": {
+                  "name": "invalid.illegal.no-whitespace.charset.css"
+                },
+                "4": {
+                  "name": "invalid.illegal.whitespace.charset.css"
+                },
+                "5": {
+                  "name": "invalid.illegal.not-double-quoted.charset.css"
+                },
+                "6": {
+                  "name": "invalid.illegal.unclosed-string.charset.css"
+                },
+                "7": {
+                  "name": "invalid.illegal.unexpected-characters.charset.css"
+                }
+              },
+              "match": "(?x)        # Possible errors:\n\\G\n((?!@charset)@\\w+)   # Not lowercase (@charset is case-sensitive)\n|\n\\G(\\s+)             # Preceding whitespace\n|\n(@charset\\S[^;]*)    # No whitespace after @charset\n|\n(?<=@charset)         # Before quoted charset name\n(\\x20{2,}|\\t+)      # More than one space used, or a tab\n|\n(?<=@charset\\x20)    # Beginning of charset name\n([^\";]+)              # Not double-quoted\n|\n(\"[^\"]+$)             # Unclosed quote\n|\n(?<=\")                # After charset name\n([^;]+)               # Unexpected junk instead of semicolon"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.control.at-rule.charset.css"
+                },
+                "2": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "match": "((@)charset)(?=\\s)"
+            },
+            {
+              "begin": "\"",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.begin.css"
+                }
+              },
+              "end": "\"|$",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.end.css"
+                }
+              },
+              "name": "string.quoted.double.css",
+              "patterns": [
+                {
+                  "begin": "(?:\\G|^)(?=(?:[^\"])+$)",
+                  "end": "$",
+                  "name": "invalid.illegal.unclosed.string.css"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?i)((@)import)(?:\\s+|$|(?=['\"]|/\\*))",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.at-rule.import.css"
+            },
+            "2": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.rule.css"
+            }
+          },
+          "name": "meta.at-rule.import.css",
+          "patterns": [
+            {
+              "begin": "\\G\\s*(?=/\\*)",
+              "end": "(?<=\\*/)\\s*",
+              "patterns": [
+                {
+                  "include": "#comment-block"
+                }
+              ]
+            },
+            {
+              "include": "#string"
+            },
+            {
+              "include": "#url"
+            },
+            {
+              "include": "#media-query-list"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)((@)font-face)(?=\\s*|{|/\\*|$)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.at-rule.font-face.css"
+            },
+            "2": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "end": "(?!\\G)",
+          "name": "meta.at-rule.font-face.css",
+          "patterns": [
+            {
+              "include": "#comment-block"
+            },
+            {
+              "include": "#escapes"
+            },
+            {
+              "include": "#rule-list"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(@)page(?=[\\s:{]|/\\*|$)",
+          "captures": {
+            "0": {
+              "name": "keyword.control.at-rule.page.css"
+            },
+            "1": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "end": "(?=\\s*($|[:{;]))",
+          "name": "meta.at-rule.page.css",
+          "patterns": [
+            {
+              "include": "#rule-list"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?=@media(\\s|\\(|/\\*|$))",
+          "end": "(?<=})(?!\\G)",
+          "patterns": [
+            {
+              "begin": "(?i)\\G(@)media",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.at-rule.media.css"
+                },
+                "1": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "end": "(?=\\s*[{;])",
+              "name": "meta.at-rule.media.header.css",
+              "patterns": [
+                {
+                  "include": "#media-query-list"
+                }
+              ]
+            },
+            {
+              "begin": "{",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.media.begin.bracket.curly.css"
+                }
+              },
+              "end": "}",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.media.end.bracket.curly.css"
+                }
+              },
+              "name": "meta.at-rule.media.body.css",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?=@counter-style([\\s'\"{;]|/\\*|$))",
+          "end": "(?<=})(?!\\G)",
+          "patterns": [
+            {
+              "begin": "(?i)\\G(@)counter-style",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.at-rule.counter-style.css"
+                },
+                "1": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "end": "(?=\\s*{)",
+              "name": "meta.at-rule.counter-style.header.css",
+              "patterns": [
+                {
+                  "include": "#comment-block"
+                },
+                {
+                  "include": "#escapes"
+                },
+                {
+                  "captures": {
+                    "0": {
+                      "patterns": [
+                        {
+                          "include": "#escapes"
+                        }
+                      ]
+                    }
+                  },
+                  "match": "(?x)\n(?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter\n(?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier\n  |\\\\(?:[0-9a-fA-F]{1,6}|.)\n)*",
+                  "name": "variable.parameter.style-name.css"
+                }
+              ]
+            },
+            {
+              "begin": "{",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.property-list.begin.bracket.curly.css"
+                }
+              },
+              "end": "}",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.property-list.end.bracket.curly.css"
+                }
+              },
+              "name": "meta.at-rule.counter-style.body.css",
+              "patterns": [
+                {
+                  "include": "#comment-block"
+                },
+                {
+                  "include": "#escapes"
+                },
+                {
+                  "include": "#rule-list-innards"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?=@document([\\s'\"{;]|/\\*|$))",
+          "end": "(?<=})(?!\\G)",
+          "patterns": [
+            {
+              "begin": "(?i)\\G(@)document",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.at-rule.document.css"
+                },
+                "1": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "end": "(?=\\s*[{;])",
+              "name": "meta.at-rule.document.header.css",
+              "patterns": [
+                {
+                  "begin": "(?i)(?<![\\w-])(url-prefix|domain|regexp)(\\()",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "support.function.document-rule.css"
+                    },
+                    "2": {
+                      "name": "punctuation.section.function.begin.bracket.round.css"
+                    }
+                  },
+                  "end": "\\)",
+                  "endCaptures": {
+                    "0": {
+                      "name": "punctuation.section.function.end.bracket.round.css"
+                    }
+                  },
+                  "name": "meta.function.document-rule.css",
+                  "patterns": [
+                    {
+                      "include": "#string"
+                    },
+                    {
+                      "include": "#comment-block"
+                    },
+                    {
+                      "include": "#escapes"
+                    },
+                    {
+                      "match": "[^'\")\\s]+",
+                      "name": "variable.parameter.document-rule.css"
+                    }
+                  ]
+                },
+                {
+                  "include": "#url"
+                },
+                {
+                  "include": "#commas"
+                },
+                {
+                  "include": "#comment-block"
+                },
+                {
+                  "include": "#escapes"
+                }
+              ]
+            },
+            {
+              "begin": "{",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.document.begin.bracket.curly.css"
+                }
+              },
+              "end": "}",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.document.end.bracket.curly.css"
+                }
+              },
+              "name": "meta.at-rule.document.body.css",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?=@(?:-(?:webkit|moz|o|ms)-)?keyframes([\\s'\"{;]|/\\*|$))",
+          "end": "(?<=})(?!\\G)",
+          "patterns": [
+            {
+              "begin": "(?i)\\G(@)(?:-(?:webkit|moz|o|ms)-)?keyframes",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.at-rule.keyframes.css"
+                },
+                "1": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "end": "(?=\\s*{)",
+              "name": "meta.at-rule.keyframes.header.css",
+              "patterns": [
+                {
+                  "include": "#comment-block"
+                },
+                {
+                  "include": "#escapes"
+                },
+                {
+                  "captures": {
+                    "0": {
+                      "patterns": [
+                        {
+                          "include": "#escapes"
+                        }
+                      ]
+                    }
+                  },
+                  "match": "(?x)\n(?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter\n(?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier\n  |\\\\(?:[0-9a-fA-F]{1,6}|.)\n)*",
+                  "name": "variable.parameter.keyframe-list.css"
+                }
+              ]
+            },
+            {
+              "begin": "{",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.keyframes.begin.bracket.curly.css"
+                }
+              },
+              "end": "}",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.keyframes.end.bracket.curly.css"
+                }
+              },
+              "name": "meta.at-rule.keyframes.body.css",
+              "patterns": [
+                {
+                  "include": "#comment-block"
+                },
+                {
+                  "include": "#escapes"
+                },
+                {
+                  "captures": {
+                    "1": {
+                      "name": "entity.other.keyframe-offset.css"
+                    },
+                    "2": {
+                      "name": "entity.other.keyframe-offset.percentage.css"
+                    }
+                  },
+                  "match": "(?xi)\n(?<![\\w-]) (from|to) (?![\\w-])         # Keywords for 0% | 100%\n|\n([-+]?(?:\\d+(?:\\.\\d+)?|\\.\\d+)%)     # Percentile value"
+                },
+                {
+                  "include": "#rule-list"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?=@supports(\\s|\\(|/\\*|$))",
+          "end": "(?<=})(?!\\G)|(?=;)",
+          "patterns": [
+            {
+              "begin": "(?i)\\G(@)supports",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.at-rule.supports.css"
+                },
+                "1": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "end": "(?=\\s*[{;])",
+              "name": "meta.at-rule.supports.header.css",
+              "patterns": [
+                {
+                  "include": "#feature-query-operators"
+                },
+                {
+                  "include": "#feature-query"
+                },
+                {
+                  "include": "#comment-block"
+                },
+                {
+                  "include": "#escapes"
+                }
+              ]
+            },
+            {
+              "begin": "{",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.supports.begin.bracket.curly.css"
+                }
+              },
+              "end": "}",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.supports.end.bracket.curly.css"
+                }
+              },
+              "name": "meta.at-rule.supports.body.css",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?i)((@)(-(ms|o)-)?viewport)(?=[\\s'\"{;]|/\\*|$)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.at-rule.viewport.css"
+            },
+            "2": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "end": "(?=\\s*[@{;])",
+          "name": "meta.at-rule.viewport.css",
+          "patterns": [
+            {
+              "include": "#comment-block"
+            },
+            {
+              "include": "#escapes"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)((@)font-feature-values)(?=[\\s'\"{;]|/\\*|$)\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.at-rule.font-feature-values.css"
+            },
+            "2": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "contentName": "variable.parameter.font-name.css",
+          "end": "(?=\\s*[@{;])",
+          "name": "meta.at-rule.font-features.css",
+          "patterns": [
+            {
+              "include": "#comment-block"
+            },
+            {
+              "include": "#escapes"
+            }
+          ]
+        },
+        {
+          "include": "#font-features"
+        },
+        {
+          "begin": "(?i)((@)namespace)(?=[\\s'\";]|/\\*|$)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.at-rule.namespace.css"
+            },
+            "2": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "end": ";|(?=[@{])",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.rule.css"
+            }
+          },
+          "name": "meta.at-rule.namespace.css",
+          "patterns": [
+            {
+              "include": "#url"
+            },
+            {
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#comment-block"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "entity.name.function.namespace-prefix.css",
+                  "patterns": [
+                    {
+                      "include": "#escapes"
+                    }
+                  ]
+                }
+              },
+              "match": "(?xi)\n(?:\\G|^|(?<=\\s))\n(?=\n  (?<=\\s|^)                             # Starts with whitespace\n  (?:[-a-zA-Z_]|[^\\x00-\\x7F])          # Then a valid identifier character\n  |\n  \\s*                                   # Possible adjoining whitespace\n  /\\*(?:[^*]|\\*[^/])*\\*/              # Injected comment\n)\n(.*?)                                    # Grouped to embed #comment-block\n(\n  (?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter\n  (?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier\n    |\\\\(?:[0-9a-fA-F]{1,6}|.)\n  )*\n)"
+            },
+            {
+              "include": "#comment-block"
+            },
+            {
+              "include": "#escapes"
+            },
+            {
+              "include": "#string"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?=@[\\w-]+[^;]+;s*$)",
+          "end": "(?<=;)(?!\\G)",
+          "patterns": [
+            {
+              "begin": "(?i)\\G(@)[\\w-]+",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.at-rule.css"
+                },
+                "1": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "end": ";",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.terminator.rule.css"
+                }
+              },
+              "name": "meta.at-rule.header.css"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?=@[\\w-]+(\\s|\\(|{|/\\*|$))",
+          "end": "(?<=})(?!\\G)",
+          "patterns": [
+            {
+              "begin": "(?i)\\G(@)[\\w-]+",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.at-rule.css"
+                },
+                "1": {
+                  "name": "punctuation.definition.keyword.css"
+                }
+              },
+              "end": "(?=\\s*[{;])",
+              "name": "meta.at-rule.header.css"
+            },
+            {
+              "begin": "{",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.begin.bracket.curly.css"
+                }
+              },
+              "end": "}",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.end.bracket.curly.css"
+                }
+              },
+              "name": "meta.at-rule.body.css",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "color-keywords": {
+      "patterns": [
+        {
+          "match": "(?i)(?<![\\w-])(aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white|yellow)(?![\\w-])",
+          "name": "support.constant.color.w3c-standard-color-name.css"
+        },
+        {
+          "match": "(?xi) (?<![\\w-])\n(aliceblue|antiquewhite|aquamarine|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood\n|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan\n|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange\n|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise\n|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen\n|gainsboro|ghostwhite|gold|goldenrod|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki\n|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow\n|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray\n|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|magenta|mediumaquamarine|mediumblue\n|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise\n|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olivedrab|orangered\n|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum\n|powderblue|rebeccapurple|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell\n|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato\n|transparent|turquoise|violet|wheat|whitesmoke|yellowgreen)\n(?![\\w-])",
+          "name": "support.constant.color.w3c-extended-color-name.css"
+        },
+        {
+          "match": "(?i)(?<![\\w-])currentColor(?![\\w-])",
+          "name": "support.constant.color.current.css"
+        },
+        {
+          "match": "(?xi) (?<![\\w-])\n(ActiveBorder|ActiveCaption|AppWorkspace|Background|ButtonFace|ButtonHighlight|ButtonShadow\n|ButtonText|CaptionText|GrayText|Highlight|HighlightText|InactiveBorder|InactiveCaption\n|InactiveCaptionText|InfoBackground|InfoText|Menu|MenuText|Scrollbar|ThreeDDarkShadow\n|ThreeDFace|ThreeDHighlight|ThreeDLightShadow|ThreeDShadow|Window|WindowFrame|WindowText)\n(?![\\w-])",
+          "name": "invalid.deprecated.color.system.css"
+        }
+      ]
+    },
+    "combinators": {
+      "patterns": [
+        {
+          "match": "/deep/|>>>",
+          "name": "invalid.deprecated.combinator.css"
+        },
+        {
+          "match": ">>|>|\\+|~",
+          "name": "keyword.operator.combinator.css"
+        }
+      ]
+    },
+    "commas": {
+      "match": ",",
+      "name": "punctuation.separator.list.comma.css"
+    },
+    "comment-block": {
+      "begin": "/\\*",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.begin.css"
+        }
+      },
+      "end": "\\*/",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.end.css"
+        }
+      },
+      "name": "comment.block.css"
+    },
+    "escapes": {
+      "patterns": [
+        {
+          "match": "\\\\[0-9a-fA-F]{1,6}",
+          "name": "constant.character.escape.codepoint.css"
+        },
+        {
+          "begin": "\\\\$\\s*",
+          "end": "^(?<!\\G)",
+          "name": "constant.character.escape.newline.css"
+        },
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.css"
+        }
+      ]
+    },
+    "feature-query": {
+      "begin": "\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.condition.begin.bracket.round.css"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.condition.end.bracket.round.css"
+        }
+      },
+      "name": "meta.feature-query.css",
+      "patterns": [
+        {
+          "include": "#feature-query-operators"
+        },
+        {
+          "include": "#feature-query"
+        }
+      ]
+    },
+    "feature-query-operators": {
+      "patterns": [
+        {
+          "match": "(?i)(?<=[\\s()]|^|\\*/)(and|not|or)(?=[\\s()]|/\\*|$)",
+          "name": "keyword.operator.logical.feature.$1.css"
+        },
+        {
+          "include": "#rule-list-innards"
+        }
+      ]
+    },
+    "font-features": {
+      "begin": "(?xi)\n((@)(annotation|character-variant|ornaments|styleset|stylistic|swash))\n(?=[\\s@'\"{;]|/\\*|$)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.at-rule.${3:/downcase}.css"
+        },
+        "2": {
+          "name": "punctuation.definition.keyword.css"
+        }
+      },
+      "end": "(?<=})",
+      "name": "meta.at-rule.${3:/downcase}.css",
+      "patterns": [
+        {
+          "begin": "{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.property-list.begin.bracket.curly.css"
+            }
+          },
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.property-list.end.bracket.curly.css"
+            }
+          },
+          "name": "meta.property-list.font-feature.css",
+          "patterns": [
+            {
+              "captures": {
+                "0": {
+                  "patterns": [
+                    {
+                      "include": "#escapes"
+                    }
+                  ]
+                }
+              },
+              "match": "(?x)\n(?: [-a-zA-Z_]    | [^\\x00-\\x7F] )   # First letter\n(?: [-a-zA-Z0-9_] | [^\\x00-\\x7F]     # Remainder of identifier\n  | \\\\(?:[0-9a-fA-F]{1,6}|.)\n)*",
+              "name": "variable.font-feature.css"
+            },
+            {
+              "include": "#rule-list-innards"
+            }
+          ]
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "begin": "(?i)(?<![\\w-])(calc)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.calc.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.calc.css",
+          "patterns": [
+            {
+              "match": "[*/]|(?<=\\s|^)[-+](?=\\s|$)",
+              "name": "keyword.operator.arithmetic.css"
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?<![\\w-])(rgba?|rgb|hsla?|hsl|hwb|lab|oklab|lch|oklch|color)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.misc.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.color.css",
+          "patterns": [
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "begin": "(?xi) (?<![\\w-])\n(\n  (?:-webkit-|-moz-|-o-)?    # Accept prefixed/historical variants\n  (?:repeating-)?            # \"Repeating\"-type gradient\n  (?:linear|radial|conic)    # Shape\n  -gradient\n)\n(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.gradient.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.gradient.css",
+          "patterns": [
+            {
+              "match": "(?i)(?<![\\w-])(from|to|at|in|hue)(?![\\w-])",
+              "name": "keyword.operator.gradient.css"
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?<![\\w-])(-webkit-gradient)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "invalid.deprecated.gradient.function.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.gradient.invalid.deprecated.gradient.css",
+          "patterns": [
+            {
+              "begin": "(?i)(?<![\\w-])(from|to|color-stop)(\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "invalid.deprecated.function.css"
+                },
+                "2": {
+                  "name": "punctuation.section.function.begin.bracket.round.css"
+                }
+              },
+              "end": "\\)",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.function.end.bracket.round.css"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#property-values"
+                }
+              ]
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "begin": "(?xi) (?<![\\w-])\n(annotation|attr|blur|brightness|character-variant|clamp|contrast|counters?\n|cross-fade|drop-shadow|element|fit-content|format|grayscale|hue-rotate|color-mix\n|image-set|invert|local|max|min|minmax|opacity|ornaments|repeat|saturate|sepia\n|styleset|stylistic|swash|symbols\n|cos|sin|tan|acos|asin|atan|atan2|hypot|sqrt|pow|log|exp|abs|sign)\n(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.misc.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.misc.css",
+          "patterns": [
+            {
+              "match": "(?i)(?<=[,\\s\"]|\\*/|^)\\d+x(?=[\\s,\"')]|/\\*|$)",
+              "name": "constant.numeric.other.density.css"
+            },
+            {
+              "include": "#property-values"
+            },
+            {
+              "match": "[^'\"),\\s]+",
+              "name": "variable.parameter.misc.css"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?<![\\w-])(circle|ellipse|inset|polygon|rect)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.shape.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.shape.css",
+          "patterns": [
+            {
+              "match": "(?i)(?<=\\s|^|\\*/)(at|round)(?=\\s|/\\*|$)",
+              "name": "keyword.operator.shape.css"
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(?<![\\w-])(cubic-bezier|steps)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.timing-function.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.timing-function.css",
+          "patterns": [
+            {
+              "match": "(?i)(?<![\\w-])(start|end)(?=\\s*\\)|$)",
+              "name": "support.constant.step-direction.css"
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "begin": "(?xi) (?<![\\w-])\n( (?:translate|scale|rotate)(?:[XYZ]|3D)?\n| matrix(?:3D)?\n| skew[XY]?\n| perspective\n)\n(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.transform.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "include": "#url"
+        },
+        {
+          "begin": "(?i)(?<![\\w-])(var)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.misc.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "name": "meta.function.variable.css",
+          "patterns": [
+            {
+              "name": "variable.argument.css",
+              "match": "(?x)\n--\n(?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter\n(?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier\n  |\\\\(?:[0-9a-fA-F]{1,6}|.)\n)*"
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        }
+      ]
+    },
+    "functional-pseudo-classes": {
+      "patterns": [
+        {
+          "begin": "(?i)((:)dir)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.other.attribute-name.pseudo-class.css"
+            },
+            "2": {
+              "name": "punctuation.definition.entity.css"
+            },
+            "3": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comment-block"
+            },
+            {
+              "include": "#escapes"
+            },
+            {
+              "match": "(?i)(?<![\\w-])(ltr|rtl)(?![\\w-])",
+              "name": "support.constant.text-direction.css"
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)((:)lang)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.other.attribute-name.pseudo-class.css"
+            },
+            "2": {
+              "name": "punctuation.definition.entity.css"
+            },
+            "3": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "match": "(?<=[(,\\s])[a-zA-Z]+(-[a-zA-Z0-9]*|\\\\(?:[0-9a-fA-F]{1,6}|.))*(?=[),\\s])",
+              "name": "support.constant.language-range.css"
+            },
+            {
+              "begin": "\"",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.begin.css"
+                }
+              },
+              "end": "\"",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.end.css"
+                }
+              },
+              "name": "string.quoted.double.css",
+              "patterns": [
+                {
+                  "include": "#escapes"
+                },
+                {
+                  "match": "(?<=[\"\\s])[a-zA-Z*]+(-[a-zA-Z0-9*]*)*(?=[\"\\s])",
+                  "name": "support.constant.language-range.css"
+                }
+              ]
+            },
+            {
+              "begin": "'",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.begin.css"
+                }
+              },
+              "end": "'",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.end.css"
+                }
+              },
+              "name": "string.quoted.single.css",
+              "patterns": [
+                {
+                  "include": "#escapes"
+                },
+                {
+                  "match": "(?<=['\\s])[a-zA-Z*]+(-[a-zA-Z0-9*]*)*(?=['\\s])",
+                  "name": "support.constant.language-range.css"
+                }
+              ]
+            },
+            {
+              "include": "#commas"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)((:)(?:not|has|matches|where|is))(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.other.attribute-name.pseudo-class.css"
+            },
+            "2": {
+              "name": "punctuation.definition.entity.css"
+            },
+            "3": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#selector-innards"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)((:)nth-(?:last-)?(?:child|of-type))(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.other.attribute-name.pseudo-class.css"
+            },
+            "2": {
+              "name": "punctuation.definition.entity.css"
+            },
+            "3": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "match": "(?i)[+-]?(\\d+n?|n)(\\s*[+-]\\s*\\d+)?",
+              "name": "constant.numeric.css"
+            },
+            {
+              "match": "(?i)even|odd",
+              "name": "support.constant.parity.css"
+            }
+          ]
+        }
+      ]
+    },
+    "media-features": {
+      "captures": {
+        "1": {
+          "name": "support.type.property-name.media.css"
+        },
+        "2": {
+          "name": "support.type.property-name.media.css"
+        },
+        "3": {
+          "name": "support.type.vendored.property-name.media.css"
+        }
+      },
+      "match": "(?xi)\n(?<=^|\\s|\\(|\\*/)           # Preceded by whitespace, bracket or comment\n(?:\n  # Standardised features\n  (\n    (?:min-|max-)?            # Range features\n    (?: height\n      | width\n      | aspect-ratio\n      | color\n      | color-index\n      | monochrome\n      | resolution\n    )\n    | grid                    # Discrete features\n    | scan\n    | orientation\n    | display-mode\n    | hover\n  )\n  |\n  # Deprecated features\n  (\n    (?:min-|max-)?            # Deprecated in Media Queries 4\n    device-\n    (?: height\n      | width\n      | aspect-ratio\n    )\n  )\n  |\n  # Vendor extensions\n  (\n    (?:\n      # Spec-compliant syntax\n      [-_]\n      (?: webkit              # Webkit/Blink\n        | apple|khtml         # Webkit aliases\n        | epub                # ePub3\n        | moz                 # Gecko\n        | ms                  # Microsoft\n        | o                   # Presto (pre-Opera 15)\n        | xv|ah|rim|atsc|     # Less common vendors\n          hp|tc|wap|ro\n      )\n      |\n      # Non-standard prefixes\n      (?: mso                 # Microsoft Office\n        | prince              # YesLogic\n      )\n    )\n    -\n    [\\w-]+                   # Feature name\n    (?=                       # Terminates correctly\n      \\s*                    # Possible whitespace\n      (?:                     # Possible injected comment\n        /\\*\n        (?:[^*]|\\*[^/])*\n        \\*/\n      )?\n      \\s*\n      [:)]                    # Ends with a colon or closed bracket\n    )\n  )\n)\n(?=\\s|$|[><:=]|\\)|/\\*)     # Terminates cleanly"
+    },
+    "media-feature-keywords": {
+      "match": "(?xi)\n(?<=^|\\s|:|\\*/)\n(?: portrait                  # Orientation\n  | landscape\n  | progressive               # Scan types\n  | interlace\n  | fullscreen                # Display modes\n  | standalone\n  | minimal-ui\n  | browser\n  | hover\n)\n(?=\\s|\\)|$)",
+      "name": "support.constant.property-value.css"
+    },
+    "media-query": {
+      "begin": "\\G",
+      "end": "(?=\\s*[{;])",
+      "patterns": [
+        {
+          "include": "#comment-block"
+        },
+        {
+          "include": "#escapes"
+        },
+        {
+          "include": "#media-types"
+        },
+        {
+          "match": "(?i)(?<=\\s|^|,|\\*/)(only|not)(?=\\s|{|/\\*|$)",
+          "name": "keyword.operator.logical.$1.media.css"
+        },
+        {
+          "match": "(?i)(?<=\\s|^|\\*/|\\))and(?=\\s|/\\*|$)",
+          "name": "keyword.operator.logical.and.media.css"
+        },
+        {
+          "match": ",(?:(?:\\s*,)+|(?=\\s*[;){]))",
+          "name": "invalid.illegal.comma.css"
+        },
+        {
+          "include": "#commas"
+        },
+        {
+          "begin": "\\(",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.parameters.begin.bracket.round.css"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.parameters.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#media-features"
+            },
+            {
+              "include": "#media-feature-keywords"
+            },
+            {
+              "match": ":",
+              "name": "punctuation.separator.key-value.css"
+            },
+            {
+              "match": ">=|<=|=|<|>",
+              "name": "keyword.operator.comparison.css"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "constant.numeric.css"
+                },
+                "2": {
+                  "name": "keyword.operator.arithmetic.css"
+                },
+                "3": {
+                  "name": "constant.numeric.css"
+                }
+              },
+              "match": "(\\d+)\\s*(/)\\s*(\\d+)",
+              "name": "meta.ratio.css"
+            },
+            {
+              "include": "#numeric-values"
+            },
+            {
+              "include": "#comment-block"
+            }
+          ]
+        }
+      ]
+    },
+    "media-query-list": {
+      "begin": "(?=\\s*[^{;])",
+      "end": "(?=\\s*[{;])",
+      "patterns": [
+        {
+          "include": "#media-query"
+        }
+      ]
+    },
+    "media-types": {
+      "captures": {
+        "1": {
+          "name": "support.constant.media.css"
+        },
+        "2": {
+          "name": "invalid.deprecated.constant.media.css"
+        }
+      },
+      "match": "(?xi)\n(?<=^|\\s|,|\\*/)\n(?:\n  # Valid media types\n  (all|print|screen|speech)\n  |\n  # Deprecated in Media Queries 4: http://dev.w3.org/csswg/mediaqueries/#media-types\n  (aural|braille|embossed|handheld|projection|tty|tv)\n)\n(?=$|[{,\\s;]|/\\*)"
+    },
+    "numeric-values": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.constant.css"
+            }
+          },
+          "match": "(#)(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b",
+          "name": "constant.other.color.rgb-value.hex.css"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.other.unit.percentage.css"
+            },
+            "2": {
+              "name": "keyword.other.unit.${2:/downcase}.css"
+            }
+          },
+          "match": "(?xi) (?<![\\w-])\n[-+]?                               # Sign indicator\n\n(?:                                 # Numerals\n    [0-9]+ (?:\\.[0-9]+)?           # Integer/float with leading digits\n  | \\.[0-9]+                       # Float without leading digits\n)\n\n(?:                                 # Scientific notation\n  (?<=[0-9])                        # Exponent must follow a digit\n  E                                 # Exponent indicator\n  [-+]?                             # Possible sign indicator\n  [0-9]+                            # Exponent value\n)?\n\n(?:                                 # Possible unit for data-type:\n  (%)                               # - Percentage\n  | ( deg|grad|rad|turn             # - Angle\n    | Hz|kHz                        # - Frequency\n    | ch|cm|em|ex|fr|in|mm|mozmm|   # - Length\n      pc|pt|px|q|rem|rch|rex|rlh|\n      ic|ric|rcap|vh|vw|vb|vi|svh|\n      svw|svb|svi|dvh|dvw|dvb|dvi|\n      lvh|lvw|lvb|lvi|vmax|vmin|\n      cqw|cqi|cqh|cqb|cqmin|cqmax\n    | dpi|dpcm|dppx                 # - Resolution\n    | s|ms                          # - Time\n    )\n  \\b                               # Boundary checking intentionally lax to\n)?                                  # facilitate embedding in CSS-like grammars",
+          "name": "constant.numeric.css"
+        }
+      ]
+    },
+    "property-keywords": {
+      "patterns": [
+        {
+          "match": "(?xi) (?<![\\w-])\n(above|absolute|active|add|additive|after-edge|alias|all|all-petite-caps|all-scroll|all-small-caps|alpha|alphabetic|alternate|alternate-reverse\n|always|antialiased|auto|auto-fill|auto-fit|auto-pos|available|avoid|avoid-column|avoid-page|avoid-region|backwards|balance|baseline|before-edge|below|bevel\n|bidi-override|blink|block|block-axis|block-start|block-end|bold|bolder|border|border-box|both|bottom|bottom-outside|break-all|break-word|bullets\n|butt|capitalize|caption|cell|center|central|char|circle|clip|clone|close-quote|closest-corner|closest-side|col-resize|collapse|color|color-burn\n|color-dodge|column|column-reverse|common-ligatures|compact|condensed|contain|content|content-box|contents|context-menu|contextual|copy|cover\n|crisp-edges|crispEdges|crosshair|cyclic|dark|darken|dashed|decimal|default|dense|diagonal-fractions|difference|digits|disabled|disc|discretionary-ligatures\n|distribute|distribute-all-lines|distribute-letter|distribute-space|dot|dotted|double|double-circle|downleft|downright|e-resize|each-line|ease|ease-in\n|ease-in-out|ease-out|economy|ellipse|ellipsis|embed|end|evenodd|ew-resize|exact|exclude|exclusion|expanded|extends|extra-condensed|extra-expanded\n|fallback|farthest-corner|farthest-side|fill|fill-available|fill-box|filled|fit-content|fixed|flat|flex|flex-end|flex-start|flip|flow-root|forwards|freeze\n|from-image|full-width|geometricPrecision|georgian|grab|grabbing|grayscale|grid|groove|hand|hanging|hard-light|help|hidden|hide\n|historical-forms|historical-ligatures|horizontal|horizontal-tb|hue|icon|ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space\n|ideographic|inactive|infinite|inherit|initial|inline|inline-axis|inline-block|inline-end|inline-flex|inline-grid|inline-list-item|inline-start\n|inline-table|inset|inside|inter-character|inter-ideograph|inter-word|intersect|invert|isolate|isolate-override|italic|jis04|jis78|jis83\n|jis90|justify|justify-all|kannada|keep-all|landscape|large|larger|left|light|lighten|lighter|line|line-edge|line-through|linear|linearRGB\n|lining-nums|list-item|local|loose|lowercase|lr|lr-tb|ltr|luminance|luminosity|main-size|mandatory|manipulation|manual|margin-box|match-parent\n|match-source|mathematical|max-content|medium|menu|message-box|middle|min-content|miter|mixed|move|multiply|n-resize|narrower|ne-resize\n|nearest-neighbor|nesw-resize|newspaper|no-change|no-clip|no-close-quote|no-common-ligatures|no-contextual|no-discretionary-ligatures\n|no-drop|no-historical-ligatures|no-open-quote|no-repeat|none|nonzero|normal|not-allowed|nowrap|ns-resize|numbers|numeric|nw-resize|nwse-resize\n|oblique|oldstyle-nums|open|open-quote|optimizeLegibility|optimizeQuality|optimizeSpeed|optional|ordinal|outset|outside|over|overlay|overline|padding\n|padding-box|page|painted|pan-down|pan-left|pan-right|pan-up|pan-x|pan-y|paused|petite-caps|pixelated|plaintext|pointer|portrait|pre|pre-line\n|pre-wrap|preserve-3d|progress|progressive|proportional-nums|proportional-width|proximity|radial|recto|region|relative|remove|repeat|repeat-[xy]\n|reset-size|reverse|revert|ridge|right|rl|rl-tb|round|row|row-resize|row-reverse|row-severse|rtl|ruby|ruby-base|ruby-base-container|ruby-text\n|ruby-text-container|run-in|running|s-resize|saturation|scale-down|screen|scroll|scroll-position|se-resize|semi-condensed|semi-expanded|separate\n|sesame|show|sideways|sideways-left|sideways-lr|sideways-right|sideways-rl|simplified|slashed-zero|slice|small|small-caps|small-caption|smaller\n|smooth|soft-light|solid|space|space-around|space-between|space-evenly|spell-out|square|sRGB|stacked-fractions|start|static|status-bar|swap\n|step-end|step-start|sticky|stretch|strict|stroke|stroke-box|style|sub|subgrid|subpixel-antialiased|subtract|super|sw-resize|symbolic|table\n|table-caption|table-cell|table-column|table-column-group|table-footer-group|table-header-group|table-row|table-row-group|tabular-nums|tb|tb-rl\n|text|text-after-edge|text-before-edge|text-bottom|text-top|thick|thin|titling-caps|top|top-outside|touch|traditional|transparent|triangle\n|ultra-condensed|ultra-expanded|under|underline|unicase|unset|upleft|uppercase|upright|use-glyph-orientation|use-script|verso|vertical\n|vertical-ideographic|vertical-lr|vertical-rl|vertical-text|view-box|visible|visibleFill|visiblePainted|visibleStroke|w-resize|wait|wavy\n|weight|whitespace|wider|words|wrap|wrap-reverse|x|x-large|x-small|xx-large|xx-small|y|zero|zoom-in|zoom-out)\n(?![\\w-])",
+          "name": "support.constant.property-value.css"
+        },
+        {
+          "match": "(?xi) (?<![\\w-])\n(arabic-indic|armenian|bengali|cambodian|circle|cjk-decimal|cjk-earthly-branch|cjk-heavenly-stem|cjk-ideographic\n|decimal|decimal-leading-zero|devanagari|disc|disclosure-closed|disclosure-open|ethiopic-halehame-am\n|ethiopic-halehame-ti-e[rt]|ethiopic-numeric|georgian|gujarati|gurmukhi|hangul|hangul-consonant|hebrew\n|hiragana|hiragana-iroha|japanese-formal|japanese-informal|kannada|katakana|katakana-iroha|khmer\n|korean-hangul-formal|korean-hanja-formal|korean-hanja-informal|lao|lower-alpha|lower-armenian|lower-greek\n|lower-latin|lower-roman|malayalam|mongolian|myanmar|oriya|persian|simp-chinese-formal|simp-chinese-informal\n|square|tamil|telugu|thai|tibetan|trad-chinese-formal|trad-chinese-informal|upper-alpha|upper-armenian\n|upper-latin|upper-roman|urdu)\n(?![\\w-])",
+          "name": "support.constant.property-value.list-style-type.css"
+        },
+        {
+          "match": "(?<![\\w-])(?i:-(?:ah|apple|atsc|epub|hp|khtml|moz|ms|o|rim|ro|tc|wap|webkit|xv)|(?:mso|prince))-[a-zA-Z-]+",
+          "name": "support.constant.vendored.property-value.css"
+        },
+        {
+          "match": "(?<![\\w-])(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system-ui|system|tahoma|times|trebuchet|ui-monospace|ui-rounded|ui-sans-serif|ui-serif|utopia|verdana|webdings|sans-serif|serif|monospace)(?![\\w-])",
+          "name": "support.constant.font-name.css"
+        }
+      ]
+    },
+    "property-names": {
+      "patterns": [
+        {
+          "match": "(?xi) (?<![\\w-])\n(?:\n  # Standard CSS\n  accent-color|additive-symbols|align-content|align-items|align-self|all|animation|animation-delay|animation-direction|animation-duration\n  | animation-fill-mode|animation-iteration-count|animation-name|animation-play-state|animation-timing-function|aspect-ratio|backdrop-filter\n  | backface-visibility|background|background-attachment|background-blend-mode|background-clip|background-color|background-image\n  | background-origin|background-position|background-position-[xy]|background-repeat|background-size|bleed|block-size|border\n  | border-block-end|border-block-end-color|border-block-end-style|border-block-end-width|border-block-start|border-block-start-color\n  | border-block-start-style|border-block-start-width|border-bottom|border-bottom-color|border-bottom-left-radius|border-bottom-right-radius\n  | border-bottom-style|border-bottom-width|border-collapse|border-color|border-end-end-radius|border-end-start-radius|border-image\n  | border-image-outset|border-image-repeat|border-image-slice|border-image-source|border-image-width|border-inline-end\n  | border-inline-end-color|border-inline-end-style|border-inline-end-width|border-inline-start|border-inline-start-color\n  | border-inline-start-style|border-inline-start-width|border-left|border-left-color|border-left-style|border-left-width\n  | border-radius|border-right|border-right-color|border-right-style|border-right-width|border-spacing|border-start-end-radius\n  | border-start-start-radius|border-style|border-top|border-top-color|border-top-left-radius|border-top-right-radius|border-top-style\n  | border-top-width|border-width|bottom|box-decoration-break|box-shadow|box-sizing|break-after|break-before|break-inside|caption-side\n  | caret-color|clear|clip|clip-path|clip-rule|color|color-adjust|color-interpolation-filters|color-scheme|column-count|column-fill|column-gap\n  | column-rule|column-rule-color|column-rule-style|column-rule-width|column-span|column-width|columns|contain|container|container-name|container-type|content|counter-increment\n  | counter-reset|cursor|direction|display|empty-cells|enable-background|fallback|fill|fill-opacity|fill-rule|filter|flex|flex-basis\n  | flex-direction|flex-flow|flex-grow|flex-shrink|flex-wrap|float|flood-color|flood-opacity|font|font-display|font-family\n  | font-feature-settings|font-kerning|font-language-override|font-optical-sizing|font-size|font-size-adjust|font-stretch\n  | font-style|font-synthesis|font-variant|font-variant-alternates|font-variant-caps|font-variant-east-asian|font-variant-ligatures\n  | font-variant-numeric|font-variant-position|font-variation-settings|font-weight|gap|glyph-orientation-horizontal|glyph-orientation-vertical\n  | grid|grid-area|grid-auto-columns|grid-auto-flow|grid-auto-rows|grid-column|grid-column-end|grid-column-gap|grid-column-start\n  | grid-gap|grid-row|grid-row-end|grid-row-gap|grid-row-start|grid-template|grid-template-areas|grid-template-columns|grid-template-rows\n  | hanging-punctuation|height|hyphens|image-orientation|image-rendering|image-resolution|ime-mode|initial-letter|initial-letter-align\n  | inline-size|inset|inset-block|inset-block-end|inset-block-start|inset-inline|inset-inline-end|inset-inline-start|isolation\n  | justify-content|justify-items|justify-self|kerning|left|letter-spacing|lighting-color|line-break|line-clamp|line-height|list-style\n  | list-style-image|list-style-position|list-style-type|margin|margin-block|margin-block-end|margin-block-start|margin-bottom|margin-inline|margin-inline-end|margin-inline-start\n  | margin-left|margin-right|margin-top|marker-end|marker-mid|marker-start|marks|mask|mask-border|mask-border-mode|mask-border-outset\n  | mask-border-repeat|mask-border-slice|mask-border-source|mask-border-width|mask-clip|mask-composite|mask-image|mask-mode\n  | mask-origin|mask-position|mask-repeat|mask-size|mask-type|max-block-size|max-height|max-inline-size|max-lines|max-width\n  | max-zoom|min-block-size|min-height|min-inline-size|min-width|min-zoom|mix-blend-mode|negative|object-fit|object-position\n  | offset|offset-anchor|offset-distance|offset-path|offset-position|offset-rotation|opacity|order|orientation|orphans\n  | outline|outline-color|outline-offset|outline-style|outline-width|overflow|overflow-anchor|overflow-block|overflow-inline\n  | overflow-wrap|overflow-[xy]|overscroll-behavior|overscroll-behavior-block|overscroll-behavior-inline|overscroll-behavior-[xy]\n  | pad|padding|padding-block|padding-block-end|padding-block-start|padding-bottom|padding-inline|padding-inline-end|padding-inline-start|padding-left\n  | padding-right|padding-top|page-break-after|page-break-before|page-break-inside|paint-order|perspective|perspective-origin\n  | place-content|place-items|place-self|pointer-events|position|prefix|quotes|range|resize|right|rotate|row-gap|ruby-align\n  | ruby-merge|ruby-position|scale|scroll-behavior|scroll-margin|scroll-margin-block|scroll-margin-block-end|scroll-margin-block-start\n  | scroll-margin-bottom|scroll-margin-inline|scroll-margin-inline-end|scroll-margin-inline-start|scroll-margin-left|scroll-margin-right\n  | scroll-margin-top|scroll-padding|scroll-padding-block|scroll-padding-block-end|scroll-padding-block-start|scroll-padding-bottom\n  | scroll-padding-inline|scroll-padding-inline-end|scroll-padding-inline-start|scroll-padding-left|scroll-padding-right\n  | scroll-padding-top|scroll-snap-align|scroll-snap-coordinate|scroll-snap-destination|scroll-snap-stop|scroll-snap-type\n  | scrollbar-color|scrollbar-gutter|scrollbar-width|shape-image-threshold|shape-margin|shape-outside|shape-rendering|size\n  | speak-as|src|stop-color|stop-opacity|stroke|stroke-dasharray|stroke-dashoffset|stroke-linecap|stroke-linejoin|stroke-miterlimit\n  | stroke-opacity|stroke-width|suffix|symbols|system|tab-size|table-layout|text-align|text-align-last|text-anchor|text-combine-upright\n  | text-decoration|text-decoration-color|text-decoration-line|text-decoration-skip|text-decoration-skip-ink|text-decoration-style|text-decoration-thickness\n  | text-emphasis|text-emphasis-color|text-emphasis-position|text-emphasis-style|text-indent|text-justify|text-orientation\n  | text-overflow|text-rendering|text-shadow|text-size-adjust|text-transform|text-underline-offset|text-underline-position|top|touch-action|transform\n  | transform-box|transform-origin|transform-style|transition|transition-delay|transition-duration|transition-property|transition-timing-function\n  | translate|unicode-bidi|unicode-range|user-select|user-zoom|vertical-align|visibility|white-space|widows|width|will-change\n  | word-break|word-spacing|word-wrap|writing-mode|z-index|zoom\n\n  # SVG attributes\n  | alignment-baseline|baseline-shift|clip-rule|color-interpolation|color-interpolation-filters|color-profile\n  | color-rendering|cx|cy|dominant-baseline|enable-background|fill|fill-opacity|fill-rule|flood-color|flood-opacity\n  | glyph-orientation-horizontal|glyph-orientation-vertical|height|kerning|lighting-color|marker-end|marker-mid\n  | marker-start|r|rx|ry|shape-rendering|stop-color|stop-opacity|stroke|stroke-dasharray|stroke-dashoffset|stroke-linecap\n  | stroke-linejoin|stroke-miterlimit|stroke-opacity|stroke-width|text-anchor|width|x|y\n\n  # Not listed on MDN; presumably deprecated\n  | adjust|after|align|align-last|alignment|alignment-adjust|appearance|attachment|azimuth|background-break\n  | balance|baseline|before|bidi|binding|bookmark|bookmark-label|bookmark-level|bookmark-target|border-length\n  | bottom-color|bottom-left-radius|bottom-right-radius|bottom-style|bottom-width|box|box-align|box-direction\n  | box-flex|box-flex-group|box-lines|box-ordinal-group|box-orient|box-pack|break|character|collapse|column\n  | column-break-after|column-break-before|count|counter|crop|cue|cue-after|cue-before|decoration|decoration-break\n  | delay|display-model|display-role|down|drop|drop-initial-after-adjust|drop-initial-after-align|drop-initial-before-adjust\n  | drop-initial-before-align|drop-initial-size|drop-initial-value|duration|elevation|emphasis|family|fit|fit-position\n  | flex-group|float-offset|gap|grid-columns|grid-rows|hanging-punctuation|header|hyphenate|hyphenate-after|hyphenate-before\n  | hyphenate-character|hyphenate-lines|hyphenate-resource|icon|image|increment|indent|index|initial-after-adjust\n  | initial-after-align|initial-before-adjust|initial-before-align|initial-size|initial-value|inline-box-align|iteration-count\n  | justify|label|left-color|left-style|left-width|length|level|line|line-stacking|line-stacking-ruby|line-stacking-shift\n  | line-stacking-strategy|lines|list|mark|mark-after|mark-before|marks|marquee|marquee-direction|marquee-play-count|marquee-speed\n  | marquee-style|max|min|model|move-to|name|nav|nav-down|nav-index|nav-left|nav-right|nav-up|new|numeral|offset|ordinal-group\n  | orient|origin|overflow-style|overhang|pack|page|page-policy|pause|pause-after|pause-before|phonemes|pitch|pitch-range\n  | play-count|play-during|play-state|point|presentation|presentation-level|profile|property|punctuation|punctuation-trim\n  | radius|rate|rendering-intent|repeat|replace|reset|resolution|resource|respond-to|rest|rest-after|rest-before|richness\n  | right-color|right-style|right-width|role|rotation|rotation-point|rows|ruby|ruby-overhang|ruby-span|rule|rule-color\n  | rule-style|rule-width|shadow|size|size-adjust|sizing|space|space-collapse|spacing|span|speak|speak-header|speak-numeral\n  | speak-punctuation|speech|speech-rate|speed|stacking|stacking-ruby|stacking-shift|stacking-strategy|stress|stretch\n  | string-set|style|style-image|style-position|style-type|target|target-name|target-new|target-position|text|text-height\n  | text-justify|text-outline|text-replace|text-wrap|timing-function|top-color|top-left-radius|top-right-radius|top-style\n  | top-width|trim|unicode|up|user-select|variant|voice|voice-balance|voice-duration|voice-family|voice-pitch|voice-pitch-range\n  | voice-rate|voice-stress|voice-volume|volume|weight|white|white-space-collapse|word|wrap\n)\n(?![\\w-])",
+          "name": "support.type.property-name.css"
+        },
+        {
+          "match": "(?<![\\w-])(?i:-(?:ah|apple|atsc|epub|hp|khtml|moz|ms|o|rim|ro|tc|wap|webkit|xv)|(?:mso|prince))-[a-zA-Z-]+",
+          "name": "support.type.vendored.property-name.css"
+        }
+      ]
+    },
+    "property-values": {
+      "patterns": [
+        {
+          "include": "#commas"
+        },
+        {
+          "include": "#comment-block"
+        },
+        {
+          "include": "#escapes"
+        },
+        {
+          "include": "#functions"
+        },
+        {
+          "include": "#property-keywords"
+        },
+        {
+          "include": "#unicode-range"
+        },
+        {
+          "include": "#numeric-values"
+        },
+        {
+          "include": "#color-keywords"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "match": "!\\s*important(?![\\w-])",
+          "name": "keyword.other.important.css"
+        }
+      ]
+    },
+    "pseudo-classes": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.entity.css"
+        },
+        "2": {
+          "name": "invalid.illegal.colon.css"
+        }
+      },
+      "match": "(?xi)\n(:)(:*)\n(?: active|any-link|checked|default|disabled|empty|enabled|first\n  | (?:first|last|only)-(?:child|of-type)|focus|focus-visible|focus-within|fullscreen|host|hover\n  | in-range|indeterminate|invalid|left|link|optional|out-of-range\n  | read-only|read-write|required|right|root|scope|target|unresolved\n  | valid|visited\n)(?![\\w-]|\\s*[;}])",
+      "name": "entity.other.attribute-name.pseudo-class.css"
+    },
+    "pseudo-elements": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.entity.css"
+        },
+        "2": {
+          "name": "punctuation.definition.entity.css"
+        }
+      },
+      "match": "(?xi)\n(?:\n  (::?)                       # Elements using both : and :: notation\n  (?: after\n    | before\n    | first-letter\n    | first-line\n    | (?:-(?:ah|apple|atsc|epub|hp|khtml|moz\n            |ms|o|rim|ro|tc|wap|webkit|xv)\n        | (?:mso|prince))\n      -[a-z-]+\n  )\n  |\n  (::)                        # Double-colon only\n  (?: backdrop\n    | content\n    | grammar-error\n    | marker\n    | placeholder\n    | selection\n    | shadow\n    | spelling-error\n  )\n)\n(?![\\w-]|\\s*[;}])",
+      "name": "entity.other.attribute-name.pseudo-element.css"
+    },
+    "rule-list": {
+      "begin": "{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.property-list.begin.bracket.curly.css"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.property-list.end.bracket.curly.css"
+        }
+      },
+      "name": "meta.property-list.css",
+      "patterns": [
+        {
+          "include": "#rule-list-innards"
+        }
+      ]
+    },
+    "rule-list-innards": {
+      "patterns": [
+        {
+          "include": "#comment-block"
+        },
+        {
+          "include": "#escapes"
+        },
+        {
+          "include": "#font-features"
+        },
+        {
+          "match": "(?x) (?<![\\w-])\n--\n(?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter\n(?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier\n  |\\\\(?:[0-9a-fA-F]{1,6}|.)\n)*",
+          "name": "variable.css"
+        },
+        {
+          "begin": "(?<![-a-zA-Z])(?=[-a-zA-Z])",
+          "end": "$|(?![-a-zA-Z])",
+          "name": "meta.property-name.css",
+          "patterns": [
+            {
+              "include": "#property-names"
+            }
+          ]
+        },
+        {
+          "begin": "(:)\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.separator.key-value.css"
+            }
+          },
+          "end": "\\s*(;)|\\s*(?=}|\\))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.rule.css"
+            }
+          },
+          "contentName": "meta.property-value.css",
+          "patterns": [
+            {
+              "include": "#comment-block"
+            },
+            {
+              "include": "#property-values"
+            }
+          ]
+        },
+        {
+          "match": ";",
+          "name": "punctuation.terminator.rule.css"
+        }
+      ]
+    },
+    "selector": {
+      "begin": "(?x)\n(?=\n  (?:\\|)?                    # Possible anonymous namespace prefix\n  (?:\n    [-\\[:.*\\#a-zA-Z_]       # Valid selector character\n    |\n    [^\\x00-\\x7F]            # Which can include non-ASCII symbols\n    |\n    \\\\                      # Or an escape sequence\n    (?:[0-9a-fA-F]{1,6}|.)\n  )\n)",
+      "end": "(?=\\s*[/@{)])",
+      "name": "meta.selector.css",
+      "patterns": [
+        {
+          "include": "#selector-innards"
+        }
+      ]
+    },
+    "selector-innards": {
+      "patterns": [
+        {
+          "include": "#comment-block"
+        },
+        {
+          "include": "#commas"
+        },
+        {
+          "include": "#escapes"
+        },
+        {
+          "include": "#combinators"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "entity.other.namespace-prefix.css"
+            },
+            "2": {
+              "name": "punctuation.separator.css"
+            }
+          },
+          "match": "(?x)\n(?:^|(?<=[\\s,(};]))         # Follows whitespace, comma, semicolon, or bracket\n(?!\n  [-\\w*]+\n  \\|\n  (?!\n      [-\\[:.*\\#a-zA-Z_]    # Make sure there's a selector to match\n    | [^\\x00-\\x7F]\n  )\n)\n(\n  (?: [-a-zA-Z_]    | [^\\x00-\\x7F] )   # First letter\n  (?: [-a-zA-Z0-9_] | [^\\x00-\\x7F]     # Remainder of identifier\n    | \\\\(?:[0-9a-fA-F]{1,6}|.)\n  )*\n  |\n  \\*     # Universal namespace\n)?\n(\\|)     # Namespace separator"
+        },
+        {
+          "include": "#tag-names"
+        },
+        {
+          "match": "\\*",
+          "name": "entity.name.tag.wildcard.css"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.css"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#escapes"
+                }
+              ]
+            }
+          },
+          "match": "(?x) (?<![@\\w-])\n([.\\#])\n# Invalid identifier\n(\n  (?:\n    # Starts with ASCII digits, with possible hyphen preceding it\n    -?[0-9]\n    |\n    # Consists of a hyphen only\n    -                                      # Terminated by either:\n    (?= $                                  # - End-of-line\n      | [\\s,.\\#)\\[:{>+~|]               # - Followed by another selector\n      | /\\*                               # - Followed by a block comment\n    )\n    |\n    # Name contains unescaped ASCII symbol\n    (?:                                    # Check for acceptable preceding characters\n        [-a-zA-Z_0-9]|[^\\x00-\\x7F]       # - Valid selector character\n      | \\\\(?:[0-9a-fA-F]{1,6}|.)         # - Escape sequence\n    )*\n    (?:                                    # Invalid punctuation\n      [!\"'%&(*;<?@^`|\\]}]                 # - NOTE: We exempt `)` from the list of checked\n      |                                    #   symbols to avoid matching `:not(.invalid)`\n      / (?!\\*)                            # - Avoid invalidating the start of a comment\n    )+\n  )\n  # Mark remainder of selector invalid\n  (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]         # - Otherwise valid identifier characters\n    | \\\\(?:[0-9a-fA-F]{1,6}|.)           # - Escape sequence\n  )*\n)",
+          "name": "invalid.illegal.bad-identifier.css"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.css"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#escapes"
+                }
+              ]
+            }
+          },
+          "match": "(?x)\n(\\.)                                  # Valid class-name\n(\n  (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters\n    | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence\n  )+\n)                                      # Followed by either:\n(?= $                                  # - End of the line\n  | [\\s,.\\#)\\[:{>+~|]               # - Another selector\n  | /\\*                               # - A block comment\n)",
+          "name": "entity.other.attribute-name.class.css"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.css"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#escapes"
+                }
+              ]
+            }
+          },
+          "match": "(?x)\n(\\#)\n(\n  -?\n  (?![0-9])\n  (?:[-a-zA-Z0-9_]|[^\\x00-\\x7F]|\\\\(?:[0-9a-fA-F]{1,6}|.))+\n)\n(?=$|[\\s,.\\#)\\[:{>+~|]|/\\*)",
+          "name": "entity.other.attribute-name.id.css"
+        },
+        {
+          "begin": "\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.entity.begin.bracket.square.css"
+            }
+          },
+          "end": "\\]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.entity.end.bracket.square.css"
+            }
+          },
+          "name": "meta.attribute-selector.css",
+          "patterns": [
+            {
+              "include": "#comment-block"
+            },
+            {
+              "include": "#string"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "storage.modifier.ignore-case.css"
+                }
+              },
+              "match": "(?<=[\"'\\s]|^|\\*/)\\s*([iI])\\s*(?=[\\s\\]]|/\\*|$)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "string.unquoted.attribute-value.css",
+                  "patterns": [
+                    {
+                      "include": "#escapes"
+                    }
+                  ]
+                }
+              },
+              "match": "(?x)(?<==)\\s*((?!/\\*)(?:[^\\\\\"'\\s\\]]|\\\\.)+)"
+            },
+            {
+              "include": "#escapes"
+            },
+            {
+              "match": "[~|^$*]?=",
+              "name": "keyword.operator.pattern.css"
+            },
+            {
+              "match": "\\|",
+              "name": "punctuation.separator.css"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "entity.other.namespace-prefix.css",
+                  "patterns": [
+                    {
+                      "include": "#escapes"
+                    }
+                  ]
+                }
+              },
+              "match": "(?x)\n# Qualified namespace prefix\n( -?(?!\\d)(?:[\\w-]|[^\\x00-\\x7F]|\\\\(?:[0-9a-fA-F]{1,6}|.))+\n| \\*\n)\n# Lookahead to ensure there's a valid identifier ahead\n(?=\n  \\| (?!\\s|=|$|\\])\n  (?: -?(?!\\d)\n   |   [\\\\\\w-]\n   |   [^\\x00-\\x7F]\n   )\n)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "entity.other.attribute-name.css",
+                  "patterns": [
+                    {
+                      "include": "#escapes"
+                    }
+                  ]
+                }
+              },
+              "match": "(?x)\n(-?(?!\\d)(?>[\\w-]|[^\\x00-\\x7F]|\\\\(?:[0-9a-fA-F]{1,6}|.))+)\n\\s*\n(?=[~|^\\]$*=]|/\\*)"
+            }
+          ]
+        },
+        {
+          "include": "#pseudo-classes"
+        },
+        {
+          "include": "#pseudo-elements"
+        },
+        {
+          "include": "#functional-pseudo-classes"
+        },
+        {
+          "match": "(?x) (?<![@\\w-])\n(?=            # Custom element names must:\n  [a-z]        # - start with a lowercase ASCII letter,\n  \\w* -       # - contain at least one dash\n)\n(?:\n  (?![A-Z])    # No uppercase ASCII letters are allowed\n  [\\w-]       # Allow any other word character or dash\n)+\n(?![(\\w-])",
+          "name": "entity.name.tag.custom.css"
+        }
+      ]
+    },
+    "string": {
+      "patterns": [
+        {
+          "begin": "\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.css"
+            }
+          },
+          "end": "\"|(?<!\\\\)(?=$|\\n)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.css"
+            }
+          },
+          "name": "string.quoted.double.css",
+          "patterns": [
+            {
+              "begin": "(?:\\G|^)(?=(?:[^\\\\\"]|\\\\.)+$)",
+              "end": "$",
+              "name": "invalid.illegal.unclosed.string.css",
+              "patterns": [
+                {
+                  "include": "#escapes"
+                }
+              ]
+            },
+            {
+              "include": "#escapes"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.css"
+            }
+          },
+          "end": "'|(?<!\\\\)(?=$|\\n)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.css"
+            }
+          },
+          "name": "string.quoted.single.css",
+          "patterns": [
+            {
+              "begin": "(?:\\G|^)(?=(?:[^\\\\']|\\\\.)+$)",
+              "end": "$",
+              "name": "invalid.illegal.unclosed.string.css",
+              "patterns": [
+                {
+                  "include": "#escapes"
+                }
+              ]
+            },
+            {
+              "include": "#escapes"
+            }
+          ]
+        }
+      ]
+    },
+    "tag-names": {
+      "match": "(?xi) (?<![\\w:-])\n(?:\n    # HTML\n    a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|bgsound\n  | big|blink|blockquote|body|br|button|canvas|caption|center|cite|code|col|colgroup|command\n  | content|data|datalist|dd|del|details|dfn|dialog|dir|div|dl|dt|element|em|embed|fieldset\n  | figcaption|figure|font|footer|form|frame|frameset|h[1-6]|head|header|hgroup|hr|html|i\n  | iframe|image|img|input|ins|isindex|kbd|keygen|label|legend|li|link|listing|main|map|mark\n  | marquee|math|menu|menuitem|meta|meter|multicol|nav|nextid|nobr|noembed|noframes|noscript\n  | object|ol|optgroup|option|output|p|param|picture|plaintext|pre|progress|q|rb|rp|rt|rtc\n  | ruby|s|samp|script|section|select|shadow|slot|small|source|spacer|span|strike|strong\n  | style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr\n  | track|tt|u|ul|var|video|wbr|xmp\n\n  # SVG\n  | altGlyph|altGlyphDef|altGlyphItem|animate|animateColor|animateMotion|animateTransform\n  | circle|clipPath|color-profile|cursor|defs|desc|discard|ellipse|feBlend|feColorMatrix\n  | feComponentTransfer|feComposite|feConvolveMatrix|feDiffuseLighting|feDisplacementMap\n  | feDistantLight|feDropShadow|feFlood|feFuncA|feFuncB|feFuncG|feFuncR|feGaussianBlur\n  | feImage|feMerge|feMergeNode|feMorphology|feOffset|fePointLight|feSpecularLighting\n  | feSpotLight|feTile|feTurbulence|filter|font-face|font-face-format|font-face-name\n  | font-face-src|font-face-uri|foreignObject|g|glyph|glyphRef|hatch|hatchpath|hkern\n  | line|linearGradient|marker|mask|mesh|meshgradient|meshpatch|meshrow|metadata\n  | missing-glyph|mpath|path|pattern|polygon|polyline|radialGradient|rect|set|solidcolor\n  | stop|svg|switch|symbol|text|textPath|tref|tspan|use|view|vkern\n\n  # MathML\n  | annotation|annotation-xml|maction|maligngroup|malignmark|math|menclose|merror|mfenced\n  | mfrac|mglyph|mi|mlabeledtr|mlongdiv|mmultiscripts|mn|mo|mover|mpadded|mphantom|mroot\n  | mrow|ms|mscarries|mscarry|msgroup|msline|mspace|msqrt|msrow|mstack|mstyle|msub|msubsup\n  | msup|mtable|mtd|mtext|mtr|munder|munderover|semantics\n)\n(?=[+~>\\s,.\\#|){:\\[]|/\\*|$)",
+      "name": "entity.name.tag.css"
+    },
+    "unicode-range": {
+      "captures": {
+        "0": {
+          "name": "constant.other.unicode-range.css"
+        },
+        "1": {
+          "name": "punctuation.separator.dash.unicode-range.css"
+        }
+      },
+      "match": "(?<![\\w-])[Uu]\\+[0-9A-Fa-f?]{1,6}(?:(-)[0-9A-Fa-f]{1,6})?(?![\\w-])"
+    },
+    "url": {
+      "begin": "(?i)(?<![\\w@-])(url)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.url.css"
+        },
+        "2": {
+          "name": "punctuation.section.function.begin.bracket.round.css"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.function.end.bracket.round.css"
+        }
+      },
+      "name": "meta.function.url.css",
+      "patterns": [
+        {
+          "match": "[^'\")\\s]+",
+          "name": "variable.parameter.url.css"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#comment-block"
+        },
+        {
+          "include": "#escapes"
+        }
+      ]
+    }
+  }
+}

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -488,37 +488,40 @@ exports[`@plugin with options 1`] = `
         ^^^^^^^^^       3: string.quoted.double.css
         ^               1: punctuation.definition.string.begin.css
                 ^       1: punctuation.definition.string.end.css
-                  ^     1: meta.at-rule.plugin.body.tailwind punctuation.section.plugin.begin.bracket.curly.tailwind
+                  ^     1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
 
   color: red;
-^^^^^^^^^^^^^           6: source.css.tailwind meta.at-rule.plugin.body.tailwind
+^^^^^^^^^^^^^           6: source.css.tailwind meta.property-list.css
   ^^^^^                 1: meta.property-name.css support.type.property-name.css
        ^                1: punctuation.separator.key-value.css
          ^^^            1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
             ^           1: punctuation.terminator.rule.css
 
 }
-^                       1: source.css.tailwind meta.at-rule.plugin.body.tailwind punctuation.section.plugin.end.bracket.curly.tailwind
+^                       1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
 
 
 ^                       1: source.css.tailwind
 
 html,
-^^^^^^                  1: source.css.tailwind
+^^^^^                   2: source.css.tailwind meta.selector.css
+^^^^                    1: entity.name.tag.css
+    ^                   1: punctuation.separator.list.comma.css
 
 body {
-^^^^^^                  2: source.css.tailwind
-     ^                  1: meta.at-rule.plugin.body.tailwind punctuation.section.plugin.begin.bracket.curly.tailwind
+^^^^^^                  3: source.css.tailwind
+^^^^                    1: meta.selector.css entity.name.tag.css
+     ^                  1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
 
   color: red;
-^^^^^^^^^^^^^           6: source.css.tailwind meta.at-rule.plugin.body.tailwind
+^^^^^^^^^^^^^           6: source.css.tailwind meta.property-list.css
   ^^^^^                 1: meta.property-name.css support.type.property-name.css
        ^                1: punctuation.separator.key-value.css
          ^^^            1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
             ^           1: punctuation.terminator.rule.css
 
 }
-^                       1: source.css.tailwind meta.at-rule.plugin.body.tailwind punctuation.section.plugin.end.bracket.curly.tailwind
+^                       1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
 "
 `;
 

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -239,7 +239,7 @@ exports[`@import 1`] = `
                                                 ^          1: punctuation.terminator.rule.css
 
 @import './test.css' theme(default invalid reference);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    16: source.css.tailwind meta.at-rule.import.css
 ^^^^^^^                                                    2: keyword.control.at-rule.import.css
 ^                                                          1: punctuation.definition.keyword.css
         ^^^^^^^^^^^^                                       3: string.quoted.single.css
@@ -247,8 +247,8 @@ exports[`@import 1`] = `
                    ^                                       1: punctuation.definition.string.end.css
                      ^^^^^                                 1: support.function.theme.css
                           ^                                1: punctuation.section.function.begin.bracket.round.css
-                           ^^^^^^^^                        2: variable.other.css
-                                   ^^^^^^^^^^^^^^^^^       1: invalid.illegal.invalid-source.css
+                           ^^^^^^^^       ^^^^^^^^^^       4: variable.other.css
+                                   ^^^^^^^                 1: invalid.illegal.invalid-source.css
                                                     ^      1: punctuation.section.function.end.bracket.round.css
                                                      ^     1: punctuation.terminator.rule.css
 
@@ -393,7 +393,7 @@ exports[`@import 1`] = `
                                                    ^       1: punctuation.terminator.rule.css
 
 @reference './test.css' theme(default invalid reference);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 16: source.css.tailwind meta.at-rule.import.css
 ^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
 ^                                                          1: punctuation.definition.keyword.css
            ^^^^^^^^^^^^                                    3: string.quoted.single.css
@@ -401,8 +401,8 @@ exports[`@import 1`] = `
                       ^                                    1: punctuation.definition.string.end.css
                         ^^^^^                              1: support.function.theme.css
                              ^                             1: punctuation.section.function.begin.bracket.round.css
-                              ^^^^^^^^                     2: variable.other.css
-                                      ^^^^^^^^^^^^^^^^^    1: invalid.illegal.invalid-source.css
+                              ^^^^^^^^       ^^^^^^^^^^    4: variable.other.css
+                                      ^^^^^^^              1: invalid.illegal.invalid-source.css
                                                        ^   1: punctuation.section.function.end.bracket.round.css
                                                         ^  1: punctuation.terminator.rule.css
 "

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -25,20 +25,30 @@ exports[`@config statement 1`] = `
 exports[`@custom-variant 1`] = `
 "
 @custom-variant dark (&:is(.dark, .dark *));
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  4: source.css.tailwind meta.at-rule.header.css
-^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 21: source.css.tailwind
+^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.variant.tailwind
 ^                                             1: punctuation.definition.keyword.css
-                                           ^  1: punctuation.terminator.rule.css
+                ^^^^                          1: variable.parameter.variant.tailwind
+                     ^^^^^^^^^^^^^^^^^^^^^^  15: meta.selector.tailwind
+                     ^                        1: punctuation.section.variant.begin.bracket.paren.tailwind
+                       ^^^                    2: entity.other.attribute-name.pseudo-class.css
+                       ^   ^      ^           3: punctuation.definition.entity.css
+                          ^                   1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^  ^^^^^       4: entity.other.attribute-name.class.css
+                                ^             1: punctuation.separator.list.comma.css
+                                        ^     1: entity.name.tag.wildcard.css
+                                         ^    1: punctuation.section.function.end.bracket.round.css
+                                          ^   1: punctuation.section.variant.end.bracket.paren.tailwind
 
 @custom-variant dark {
-^^^^^^^^^^^^^^^^^^^^^^                        5: source.css.tailwind
-^^^^^^^^^^^^^^^^^^^^                          3: meta.at-rule.header.css
-^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.css
+^^^^^^^^^^^^^^^^^^^^^^                        6: source.css.tailwind
+^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.variant.tailwind
 ^                                             1: punctuation.definition.keyword.css
-                     ^                        1: meta.at-rule.body.css punctuation.section.begin.bracket.curly.css
+                ^^^^                          1: variable.parameter.variant.tailwind
+                     ^                        1: meta.at-rule.variant.body.tailwind punctuation.section.variant.begin.bracket.curly.tailwind
 
   &:is(.dark, .dark *) {
-^^^^^^^^^^^^^^^^^^^^^^^^                     15: source.css.tailwind meta.at-rule.body.css
+^^^^^^^^^^^^^^^^^^^^^^^^                     15: source.css.tailwind meta.at-rule.variant.body.tailwind
    ^^^^^^^^^^^^^^^^^^^                       12: meta.selector.css
    ^^^                                        2: entity.other.attribute-name.pseudo-class.css
    ^   ^      ^                               3: punctuation.definition.entity.css
@@ -50,52 +60,52 @@ exports[`@custom-variant 1`] = `
                        ^                      1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
 
     @slot;
-^^^^^^^^^^                                    3: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+^^^^^^^^^^                                    3: source.css.tailwind meta.at-rule.variant.body.tailwind meta.property-list.css
      ^^^^                                     1: meta.property-name.css
          ^                                    1: punctuation.terminator.rule.css
 
   }
-^^^                                           2: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+^^^                                           2: source.css.tailwind meta.at-rule.variant.body.tailwind meta.property-list.css
   ^                                           1: punctuation.section.property-list.end.bracket.curly.css
 
 }
-^                                             1: source.css.tailwind meta.at-rule.body.css punctuation.section.end.bracket.curly.css
+^                                             1: source.css.tailwind meta.at-rule.variant.body.tailwind punctuation.section.variant.end.bracket.curly.tailwind
 
 @custom-variant around {
-^^^^^^^^^^^^^^^^^^^^^^^^                      5: source.css.tailwind
-^^^^^^^^^^^^^^^^^^^^^^                        3: meta.at-rule.header.css
-^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.css
+^^^^^^^^^^^^^^^^^^^^^^^^                      6: source.css.tailwind
+^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.variant.tailwind
 ^                                             1: punctuation.definition.keyword.css
-                       ^                      1: meta.at-rule.body.css punctuation.section.begin.bracket.curly.css
+                ^^^^^^                        1: variable.parameter.variant.tailwind
+                       ^                      1: meta.at-rule.variant.body.tailwind punctuation.section.variant.begin.bracket.curly.tailwind
 
   color: '';
-^^^^^^^^^^^^^                                 2: source.css.tailwind meta.at-rule.body.css
+^^^^^^^^^^^^^                                 2: source.css.tailwind meta.at-rule.variant.body.tailwind
   ^^^^^^^^^^^                                 1: meta.selector.css
 
   &::before,
-^^^^^^^^^^^^                                  4: source.css.tailwind meta.at-rule.body.css meta.selector.css
+^^^^^^^^^^^^                                  4: source.css.tailwind meta.at-rule.variant.body.tailwind meta.selector.css
    ^^^^^^^^                                   2: entity.other.attribute-name.pseudo-element.css
    ^^                                         1: punctuation.definition.entity.css
            ^                                  1: punctuation.separator.list.comma.css
 
   &::after {
-^^^^^^^^^^^^                                  5: source.css.tailwind meta.at-rule.body.css
+^^^^^^^^^^^^                                  5: source.css.tailwind meta.at-rule.variant.body.tailwind
 ^^^^^^^^^^                                    3: meta.selector.css
    ^^^^^^^                                    2: entity.other.attribute-name.pseudo-element.css
    ^^                                         1: punctuation.definition.entity.css
            ^                                  1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
 
     @slot;
-^^^^^^^^^^                                    3: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+^^^^^^^^^^                                    3: source.css.tailwind meta.at-rule.variant.body.tailwind meta.property-list.css
      ^^^^                                     1: meta.property-name.css
          ^                                    1: punctuation.terminator.rule.css
 
   }
-^^^                                           2: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+^^^                                           2: source.css.tailwind meta.at-rule.variant.body.tailwind meta.property-list.css
   ^                                           1: punctuation.section.property-list.end.bracket.curly.css
 
 }
-^                                             1: source.css.tailwind meta.at-rule.body.css punctuation.section.end.bracket.curly.css
+^                                             1: source.css.tailwind meta.at-rule.variant.body.tailwind punctuation.section.variant.end.bracket.curly.tailwind
 "
 `;
 

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -567,27 +567,30 @@ exports[`@source 1`] = `
                                 ^                            1: punctuation.terminator.rule.css
 
 @source not "./dir";
-^^^^^^^^^^^^^^^^^^^^                                         8: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^                                         9: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^                                                  1: support.constant.not.css
             ^^^^^^^                                          3: string.quoted.double.css
             ^                                                1: punctuation.definition.string.begin.css
                   ^                                          1: punctuation.definition.string.end.css
                    ^                                         1: punctuation.terminator.rule.css
 
 @source not "./file.ts";
-^^^^^^^^^^^^^^^^^^^^^^^^                                     8: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^                                     9: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^                                                  1: support.constant.not.css
             ^^^^^^^^^^^                                      3: string.quoted.double.css
             ^                                                1: punctuation.definition.string.begin.css
                       ^                                      1: punctuation.definition.string.end.css
                        ^                                     1: punctuation.terminator.rule.css
 
 @source not "./dir/**/file-{a,b}.ts";
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                        8: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                        9: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^                                                  1: support.constant.not.css
             ^^^^^^^^^^^^^^^^^^^^^^^^                         3: string.quoted.double.css
             ^                                                1: punctuation.definition.string.begin.css
                                    ^                         1: punctuation.definition.string.end.css
@@ -615,18 +618,20 @@ exports[`@source 1`] = `
                                                       ^      1: punctuation.terminator.rule.css
 
 @source not inline("flex");
-^^^^^^^^^^^^^^^^^^^^^^^^^^^                                  9: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^                                 10: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^                                                  1: support.constant.not.css
                    ^^^^^^                                    3: string.quoted.double.css
                    ^                                         1: punctuation.definition.string.begin.css
                         ^                                    1: punctuation.definition.string.end.css
                           ^                                  1: punctuation.terminator.rule.css
 
 @source not inline("flex bg-red-{50,{100..900..100},950}");
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  9: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 10: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^                                                  1: support.constant.not.css
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    3: string.quoted.double.css
                    ^                                         1: punctuation.definition.string.begin.css
                                                         ^    1: punctuation.definition.string.end.css

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -698,65 +698,72 @@ exports[`@theme 1`] = `
 ^^^^^^^^                               4: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-       ^                               1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+      ^                                1: variable.other.css
+       ^                               1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
-^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
-  ^^^^^^^                              1: variable.css
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.at-rule.theme.body.tailwind
+  ^^^^^^^                              1: meta.property-name.css
          ^                             1: punctuation.separator.key-value.css
            ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
               ^                        1: punctuation.terminator.rule.css
 
 }
-^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+^                                      1: source.css.tailwind meta.at-rule.theme.body.tailwind punctuation.section.theme.end.bracket.curly.tailwind
 
 @theme static {
-^^^^^^^^^^^^^^^                        4: source.css.tailwind
+^^^^^^^^^^^^^^^                        6: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-              ^                        1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+      ^^^^^^^^                         3: variable.other.css
+              ^                        1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
-^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
-  ^^^^^^^                              1: variable.css
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.at-rule.theme.body.tailwind
+  ^^^^^^^                              1: meta.property-name.css
          ^                             1: punctuation.separator.key-value.css
            ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
               ^                        1: punctuation.terminator.rule.css
 
 }
-^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+^                                      1: source.css.tailwind meta.at-rule.theme.body.tailwind punctuation.section.theme.end.bracket.curly.tailwind
 
 @theme inline deprecated {
-^^^^^^^^^^^^^^^^^^^^^^^^^^             4: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^             8: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-                         ^             1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+      ^^^^^^^^^^^^^^^^^^^              5: variable.other.css
+                         ^             1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
-^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
-  ^^^^^^^                              1: variable.css
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.at-rule.theme.body.tailwind
+  ^^^^^^^                              1: meta.property-name.css
          ^                             1: punctuation.separator.key-value.css
            ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
               ^                        1: punctuation.terminator.rule.css
 
 }
-^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+^                                      1: source.css.tailwind meta.at-rule.theme.body.tailwind punctuation.section.theme.end.bracket.curly.tailwind
 
 @theme prefix(tw) inline {
-^^^^^^^^^^^^^^^^^^^^^^^^^^             4: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^            11: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-                         ^             1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+       ^^^^^^                          1: support.function.prefix.css
+             ^                         1: punctuation.section.function.begin.bracket.round.css
+              ^^ ^^^^^^^^              4: variable.other.css
+                ^                      1: punctuation.section.function.end.bracket.round.css
+                         ^             1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
-^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
-  ^^^^^^^                              1: variable.css
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.at-rule.theme.body.tailwind
+  ^^^^^^^                              1: meta.property-name.css
          ^                             1: punctuation.separator.key-value.css
            ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
               ^                        1: punctuation.terminator.rule.css
 
 }
-^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+^                                      1: source.css.tailwind meta.at-rule.theme.body.tailwind punctuation.section.theme.end.bracket.curly.tailwind
 
 
 ^                                      1: source.css.tailwind
@@ -765,25 +772,26 @@ exports[`@theme 1`] = `
 ^^^^^^^^                               4: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-       ^                               1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+      ^                                1: variable.other.css
+       ^                               1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --spacing: initial;
-^^^^^^^^^^^^^^^^^^^^^                  6: source.css.tailwind meta.property-list.css
-  ^^^^^^^^^                            1: variable.css
+^^^^^^^^^^^^^^^^^^^^^                  6: source.css.tailwind meta.at-rule.theme.body.tailwind
+  ^^^^^^^^^                            1: meta.property-name.css
            ^                           1: punctuation.separator.key-value.css
              ^^^^^^^                   1: meta.property-value.css support.constant.property-value.css
                     ^                  1: punctuation.terminator.rule.css
 
   --color-*: initial;
-^^^^^^^^^^^^^^^^^^^^^                  7: source.css.tailwind meta.property-list.css
-  ^^^^^^^^                             1: variable.css
+^^^^^^^^^^^^^^^^^^^^^                  7: source.css.tailwind meta.at-rule.theme.body.tailwind
+  ^^^^^^^^                             1: meta.property-name.css
            ^                           1: punctuation.separator.key-value.css
              ^^^^^^^                   1: meta.property-value.css support.constant.property-value.css
                     ^                  1: punctuation.terminator.rule.css
 
   --animate-pulse: 1s pulse infinite;
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  9: source.css.tailwind meta.property-list.css
-  ^^^^^^^^^^^^^^^                      1: variable.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  9: source.css.tailwind meta.at-rule.theme.body.tailwind
+  ^^^^^^^^^^^^^^^                      1: meta.property-name.css
                  ^                     1: punctuation.separator.key-value.css
                    ^^^^^^^^^^^^^^^^^   4: meta.property-value.css
                    ^^                  2: constant.numeric.css
@@ -792,28 +800,28 @@ exports[`@theme 1`] = `
                                     ^  1: punctuation.terminator.rule.css
 
 
-^                                      1: source.css.tailwind meta.property-list.css
+^                                      1: source.css.tailwind meta.at-rule.theme.body.tailwind
 
   @keyframes pulse {
-^^^^^^^^^^^^^^^^^^^^^                  5: source.css.tailwind meta.property-list.css
+^^^^^^^^^^^^^^^^^^^^^                  5: source.css.tailwind meta.at-rule.theme.body.tailwind
    ^^^^^^^^^ ^^^^^                     2: meta.property-name.css
 
     0%,
-^^^^^^^^                               1: source.css.tailwind meta.property-list.css
+^^^^^^^^                               1: source.css.tailwind meta.at-rule.theme.body.tailwind
 
     100% {
-^^^^^^^^^^^                            1: source.css.tailwind meta.property-list.css
+^^^^^^^^^^^                            1: source.css.tailwind meta.at-rule.theme.body.tailwind
 
       opacity: 0;
-^^^^^^^^^^^^^^^^^                      6: source.css.tailwind meta.property-list.css
+^^^^^^^^^^^^^^^^^                      6: source.css.tailwind meta.at-rule.theme.body.tailwind
       ^^^^^^^                          1: meta.property-name.css support.type.property-name.css
              ^                         1: punctuation.separator.key-value.css
                ^                       1: meta.property-value.css constant.numeric.css
                 ^                      1: punctuation.terminator.rule.css
 
     }
-^^^^^                                  2: source.css.tailwind meta.property-list.css
-    ^                                  1: punctuation.section.property-list.end.bracket.curly.css
+^^^^^                                  2: source.css.tailwind meta.at-rule.theme.body.tailwind
+    ^                                  1: punctuation.section.theme.end.bracket.curly.tailwind
 
     50% {
 ^^^^^^^^^                              2: source.css.tailwind

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -600,41 +600,53 @@ exports[`@source 1`] = `
 ^                                                            1: source.css.tailwind
 
 @source inline("flex");
-^^^^^^^^^^^^^^^^^^^^^^^                                      9: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^                                     10: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^^^^                                               1: support.function.inline.css
+              ^                                              1: punctuation.section.function.begin.bracket.round.css
                ^^^^^^                                        3: string.quoted.double.css
                ^                                             1: punctuation.definition.string.begin.css
                     ^                                        1: punctuation.definition.string.end.css
+                     ^                                       1: punctuation.section.function.end.bracket.round.css
                       ^                                      1: punctuation.terminator.rule.css
 
 @source inline("flex bg-red-{50,{100..900..100},950}");
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      9: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     10: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^^^^                                               1: support.function.inline.css
+              ^                                              1: punctuation.section.function.begin.bracket.round.css
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^        3: string.quoted.double.css
                ^                                             1: punctuation.definition.string.begin.css
                                                     ^        1: punctuation.definition.string.end.css
+                                                     ^       1: punctuation.section.function.end.bracket.round.css
                                                       ^      1: punctuation.terminator.rule.css
 
 @source not inline("flex");
-^^^^^^^^^^^^^^^^^^^^^^^^^^^                                 10: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^                                 12: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
         ^^^                                                  1: support.constant.not.css
+            ^^^^^^                                           1: support.function.inline.css
+                  ^                                          1: punctuation.section.function.begin.bracket.round.css
                    ^^^^^^                                    3: string.quoted.double.css
                    ^                                         1: punctuation.definition.string.begin.css
                         ^                                    1: punctuation.definition.string.end.css
+                         ^                                   1: punctuation.section.function.end.bracket.round.css
                           ^                                  1: punctuation.terminator.rule.css
 
 @source not inline("flex bg-red-{50,{100..900..100},950}");
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 10: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 12: source.css.tailwind
 ^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
 ^                                                            1: punctuation.definition.keyword.tailwind
         ^^^                                                  1: support.constant.not.css
+            ^^^^^^                                           1: support.function.inline.css
+                  ^                                          1: punctuation.section.function.begin.bracket.round.css
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    3: string.quoted.double.css
                    ^                                         1: punctuation.definition.string.begin.css
                                                         ^    1: punctuation.definition.string.end.css
+                                                         ^   1: punctuation.section.function.end.bracket.round.css
                                                           ^  1: punctuation.terminator.rule.css
 "
 `;

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -205,7 +205,7 @@ exports[`@import 1`] = `
                    ^                                       1: punctuation.definition.string.end.css
                      ^^^^^                                 1: support.function.theme.css
                           ^                                1: punctuation.section.function.begin.bracket.round.css
-                           ^^^^^^                          1: variable.other.css
+                           ^^^^^^                          1: support.constant.theme-option.css
                                  ^                         1: punctuation.section.function.end.bracket.round.css
                                   ^                        1: punctuation.terminator.rule.css
 
@@ -218,7 +218,7 @@ exports[`@import 1`] = `
                    ^                                       1: punctuation.definition.string.end.css
                      ^^^^^                                 1: support.function.theme.css
                           ^                                1: punctuation.section.function.begin.bracket.round.css
-                           ^^^^^^^^^^^^^^^^^^^^^           5: variable.other.css
+                           ^^^^^^ ^^^^^^^ ^^^^^^           3: support.constant.theme-option.css
                                                 ^          1: punctuation.section.function.end.bracket.round.css
                                                  ^         1: punctuation.terminator.rule.css
 
@@ -231,7 +231,7 @@ exports[`@import 1`] = `
                    ^                                       1: punctuation.definition.string.end.css
                      ^^^^^                                 1: support.function.theme.css
                           ^                                1: punctuation.section.function.begin.bracket.round.css
-                           ^^^^^^^^^^^^^^^^^^^^            3: variable.other.css
+                           ^^^^^^^^^ ^^^^^^^^^^            2: support.constant.theme-option.css
                                                ^           1: punctuation.section.function.end.bracket.round.css
                                                 ^          1: punctuation.terminator.rule.css
 
@@ -245,8 +245,9 @@ exports[`@import 1`] = `
                      ^^^^^                                 1: support.function.theme.css
                           ^      ^                         2: punctuation.section.function.begin.bracket.round.css
                            ^^^^^^                          1: support.function.prefix.css
-                                  ^^ ^^^^^^^^^^            3: variable.other.css
+                                  ^^                       1: variable.other.css
                                     ^          ^           2: punctuation.section.function.end.bracket.round.css
+                                      ^^^^^^^^^            1: support.constant.theme-option.css
                                                 ^          1: punctuation.terminator.rule.css
 
 @import './test.css' theme(default invalid reference);
@@ -258,8 +259,8 @@ exports[`@import 1`] = `
                    ^                                       1: punctuation.definition.string.end.css
                      ^^^^^                                 1: support.function.theme.css
                           ^                                1: punctuation.section.function.begin.bracket.round.css
-                           ^^^^^^^^       ^^^^^^^^^^       4: variable.other.css
-                                   ^^^^^^^                 1: invalid.illegal.invalid-source.css
+                           ^^^^^^^         ^^^^^^^^^       2: support.constant.theme-option.css
+                                   ^^^^^^^                 1: invalid.illegal.theme-option.css
                                                     ^      1: punctuation.section.function.end.bracket.round.css
                                                      ^     1: punctuation.terminator.rule.css
 
@@ -360,7 +361,7 @@ exports[`@import 1`] = `
                       ^                                    1: punctuation.definition.string.end.css
                         ^^^^^                              1: support.function.theme.css
                              ^                             1: punctuation.section.function.begin.bracket.round.css
-                              ^^^^^^                       1: variable.other.css
+                              ^^^^^^                       1: support.constant.theme-option.css
                                     ^                      1: punctuation.section.function.end.bracket.round.css
                                      ^                     1: punctuation.terminator.rule.css
 
@@ -373,7 +374,7 @@ exports[`@import 1`] = `
                       ^                                    1: punctuation.definition.string.end.css
                         ^^^^^                              1: support.function.theme.css
                              ^                             1: punctuation.section.function.begin.bracket.round.css
-                              ^^^^^^^^^^^^^^^^^^^^^        5: variable.other.css
+                              ^^^^^^ ^^^^^^^ ^^^^^^        3: support.constant.theme-option.css
                                                    ^       1: punctuation.section.function.end.bracket.round.css
                                                     ^      1: punctuation.terminator.rule.css
 
@@ -386,7 +387,7 @@ exports[`@import 1`] = `
                       ^                                    1: punctuation.definition.string.end.css
                         ^^^^^                              1: support.function.theme.css
                              ^                             1: punctuation.section.function.begin.bracket.round.css
-                              ^^^^^^^^^^^^^^^^^^^^         3: variable.other.css
+                              ^^^^^^^^^ ^^^^^^^^^^         2: support.constant.theme-option.css
                                                   ^        1: punctuation.section.function.end.bracket.round.css
                                                    ^       1: punctuation.terminator.rule.css
 
@@ -400,8 +401,9 @@ exports[`@import 1`] = `
                         ^^^^^                              1: support.function.theme.css
                              ^      ^                      2: punctuation.section.function.begin.bracket.round.css
                               ^^^^^^                       1: support.function.prefix.css
-                                     ^^ ^^^^^^^^^^         3: variable.other.css
+                                     ^^                    1: variable.other.css
                                        ^          ^        2: punctuation.section.function.end.bracket.round.css
+                                         ^^^^^^^^^         1: support.constant.theme-option.css
                                                    ^       1: punctuation.terminator.rule.css
 
 @reference './test.css' theme(default invalid reference);
@@ -413,8 +415,8 @@ exports[`@import 1`] = `
                       ^                                    1: punctuation.definition.string.end.css
                         ^^^^^                              1: support.function.theme.css
                              ^                             1: punctuation.section.function.begin.bracket.round.css
-                              ^^^^^^^^       ^^^^^^^^^^    4: variable.other.css
-                                      ^^^^^^^              1: invalid.illegal.invalid-source.css
+                              ^^^^^^^         ^^^^^^^^^    2: support.constant.theme-option.css
+                                      ^^^^^^^              1: invalid.illegal.theme-option.css
                                                        ^   1: punctuation.section.function.end.bracket.round.css
                                                         ^  1: punctuation.terminator.rule.css
 "
@@ -727,7 +729,6 @@ exports[`@theme 1`] = `
 ^^^^^^^^                               4: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-      ^                                1: variable.other.css
        ^                               1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
@@ -744,7 +745,7 @@ exports[`@theme 1`] = `
 ^^^^^^^^^^^^^^^                        6: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-      ^^^^^^^^                         3: variable.other.css
+       ^^^^^^                          1: support.constant.theme-option.css
               ^                        1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
@@ -761,7 +762,7 @@ exports[`@theme 1`] = `
 ^^^^^^^^^^^^^^^^^^^^^^^^^^             8: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-      ^^^^^^^^^^^^^^^^^^^              5: variable.other.css
+       ^^^^^^ ^^^^^^^^^^               2: support.constant.theme-option.css
                          ^             1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
@@ -780,8 +781,9 @@ exports[`@theme 1`] = `
 ^                                      1: punctuation.definition.keyword.css
        ^^^^^^                          1: support.function.prefix.css
              ^                         1: punctuation.section.function.begin.bracket.round.css
-              ^^ ^^^^^^^^              4: variable.other.css
+              ^^                       1: variable.other.css
                 ^                      1: punctuation.section.function.end.bracket.round.css
+                  ^^^^^^               1: support.constant.theme-option.css
                          ^             1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --color: red;
@@ -801,7 +803,6 @@ exports[`@theme 1`] = `
 ^^^^^^^^                               4: source.css.tailwind
 ^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
 ^                                      1: punctuation.definition.keyword.css
-      ^                                1: variable.other.css
        ^                               1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind
 
   --spacing: initial;

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -1,0 +1,1114 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`@config statement 1`] = `
+"
+@config "./foo";
+^^^^^^^^^^^^^^^^  7: source.css.tailwind
+^^^^^^^           2: keyword.control.at-rule.config.tailwind
+^                 1: punctuation.definition.keyword.tailwind
+        ^^^^^^^   3: string.quoted.double.css
+        ^         1: punctuation.definition.string.begin.css
+              ^   1: punctuation.definition.string.end.css
+               ^  1: punctuation.terminator.rule.css
+
+@config "./bar";
+^^^^^^^^^^^^^^^^  7: source.css.tailwind
+^^^^^^^           2: keyword.control.at-rule.config.tailwind
+^                 1: punctuation.definition.keyword.tailwind
+        ^^^^^^^   3: string.quoted.double.css
+        ^         1: punctuation.definition.string.begin.css
+              ^   1: punctuation.definition.string.end.css
+               ^  1: punctuation.terminator.rule.css
+"
+`;
+
+exports[`@custom-variant 1`] = `
+"
+@custom-variant dark (&:is(.dark, .dark *));
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  4: source.css.tailwind meta.at-rule.header.css
+^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.css
+^                                             1: punctuation.definition.keyword.css
+                                           ^  1: punctuation.terminator.rule.css
+
+@custom-variant dark {
+^^^^^^^^^^^^^^^^^^^^^^                        5: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^                          3: meta.at-rule.header.css
+^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.css
+^                                             1: punctuation.definition.keyword.css
+                     ^                        1: meta.at-rule.body.css punctuation.section.begin.bracket.curly.css
+
+  &:is(.dark, .dark *) {
+^^^^^^^^^^^^^^^^^^^^^^^^                     15: source.css.tailwind meta.at-rule.body.css
+   ^^^^^^^^^^^^^^^^^^^                       12: meta.selector.css
+   ^^^                                        2: entity.other.attribute-name.pseudo-class.css
+   ^   ^      ^                               3: punctuation.definition.entity.css
+      ^                                       1: punctuation.section.function.begin.bracket.round.css
+       ^^^^^  ^^^^^                           4: entity.other.attribute-name.class.css
+            ^                                 1: punctuation.separator.list.comma.css
+                    ^                         1: entity.name.tag.wildcard.css
+                     ^                        1: punctuation.section.function.end.bracket.round.css
+                       ^                      1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+    @slot;
+^^^^^^^^^^                                    3: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+     ^^^^                                     1: meta.property-name.css
+         ^                                    1: punctuation.terminator.rule.css
+
+  }
+^^^                                           2: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+  ^                                           1: punctuation.section.property-list.end.bracket.curly.css
+
+}
+^                                             1: source.css.tailwind meta.at-rule.body.css punctuation.section.end.bracket.curly.css
+
+@custom-variant around {
+^^^^^^^^^^^^^^^^^^^^^^^^                      5: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^                        3: meta.at-rule.header.css
+^^^^^^^^^^^^^^^                               2: keyword.control.at-rule.css
+^                                             1: punctuation.definition.keyword.css
+                       ^                      1: meta.at-rule.body.css punctuation.section.begin.bracket.curly.css
+
+  color: '';
+^^^^^^^^^^^^^                                 2: source.css.tailwind meta.at-rule.body.css
+  ^^^^^^^^^^^                                 1: meta.selector.css
+
+  &::before,
+^^^^^^^^^^^^                                  4: source.css.tailwind meta.at-rule.body.css meta.selector.css
+   ^^^^^^^^                                   2: entity.other.attribute-name.pseudo-element.css
+   ^^                                         1: punctuation.definition.entity.css
+           ^                                  1: punctuation.separator.list.comma.css
+
+  &::after {
+^^^^^^^^^^^^                                  5: source.css.tailwind meta.at-rule.body.css
+^^^^^^^^^^                                    3: meta.selector.css
+   ^^^^^^^                                    2: entity.other.attribute-name.pseudo-element.css
+   ^^                                         1: punctuation.definition.entity.css
+           ^                                  1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+    @slot;
+^^^^^^^^^^                                    3: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+     ^^^^                                     1: meta.property-name.css
+         ^                                    1: punctuation.terminator.rule.css
+
+  }
+^^^                                           2: source.css.tailwind meta.at-rule.body.css meta.property-list.css
+  ^                                           1: punctuation.section.property-list.end.bracket.curly.css
+
+}
+^                                             1: source.css.tailwind meta.at-rule.body.css punctuation.section.end.bracket.curly.css
+"
+`;
+
+exports[`@import 1`] = `
+"
+@import './test.css';
+^^^^^^^^^^^^^^^^^^^^^                                      7: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                    ^                                      1: punctuation.terminator.rule.css
+
+
+^                                                          1: source.css.tailwind
+
+@import './test.css' prefix(tw);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          12: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^^                                1: support.function.prefix.css
+                           ^                               1: punctuation.section.function.begin.bracket.round.css
+                            ^^                             1: variable.other.css
+                              ^                            1: punctuation.section.function.end.bracket.round.css
+                               ^                           1: punctuation.terminator.rule.css
+
+@import './test.css' layer(utilities) prefix(tw);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         17: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^                                 1: support.function.layer.css
+                          ^                 ^              2: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^^^^                       1: support.constant.layer-name.css
+                                    ^          ^           2: punctuation.section.function.end.bracket.round.css
+                                      ^^^^^^               1: support.function.prefix.css
+                                             ^^            1: variable.other.css
+                                                ^          1: punctuation.terminator.rule.css
+
+
+^                                                          1: source.css.tailwind
+
+@import './test.css' source(none);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                        12: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^^                                1: support.function.source.css
+                           ^                               1: punctuation.section.function.begin.bracket.round.css
+                            ^^^^                           1: support.constant.none.css
+                                ^                          1: punctuation.section.function.end.bracket.round.css
+                                 ^                         1: punctuation.terminator.rule.css
+
+@import './test.css' source('./foo');
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                     14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^        ^^^^^^^                        6: string.quoted.single.css
+        ^                   ^                              2: punctuation.definition.string.begin.css
+                   ^              ^                        2: punctuation.definition.string.end.css
+                     ^^^^^^                                1: support.function.source.css
+                           ^                               1: punctuation.section.function.begin.bracket.round.css
+                                   ^                       1: punctuation.section.function.end.bracket.round.css
+                                    ^                      1: punctuation.terminator.rule.css
+
+@import './test.css' layer(utilities) source('./foo');
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    19: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                         ^^^^^^^       6: string.quoted.single.css
+        ^                                    ^             2: punctuation.definition.string.begin.css
+                   ^                               ^       2: punctuation.definition.string.end.css
+                     ^^^^^                                 1: support.function.layer.css
+                          ^                 ^              2: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^^^^                       1: support.constant.layer-name.css
+                                    ^               ^      2: punctuation.section.function.end.bracket.round.css
+                                      ^^^^^^               1: support.function.source.css
+                                                     ^     1: punctuation.terminator.rule.css
+
+
+^                                                          1: source.css.tailwind
+
+@import './test.css' theme(static);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                       12: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^                                 1: support.function.theme.css
+                          ^                                1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^                          1: variable.other.css
+                                 ^                         1: punctuation.section.function.end.bracket.round.css
+                                  ^                        1: punctuation.terminator.rule.css
+
+@import './test.css' theme(static default inline);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^        16: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^                                 1: support.function.theme.css
+                          ^                                1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^^^^^^^^^^^^^^^^           5: variable.other.css
+                                                ^          1: punctuation.section.function.end.bracket.round.css
+                                                 ^         1: punctuation.terminator.rule.css
+
+@import './test.css' theme(reference deprecated);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^                                 1: support.function.theme.css
+                          ^                                1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^^^^^^^^^^^^^^^            3: variable.other.css
+                                               ^           1: punctuation.section.function.end.bracket.round.css
+                                                ^          1: punctuation.terminator.rule.css
+
+@import './test.css' theme(prefix(tw) reference);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         13: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^                                 1: support.function.theme.css
+                          ^                                1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^^^^                       1: invalid.illegal.invalid-source.css
+                                    ^                      1: punctuation.section.function.end.bracket.round.css
+                                                ^          1: punctuation.terminator.rule.css
+
+@import './test.css' theme(default invalid reference);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                                                    2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^                                       3: string.quoted.single.css
+        ^                                                  1: punctuation.definition.string.begin.css
+                   ^                                       1: punctuation.definition.string.end.css
+                     ^^^^^                                 1: support.function.theme.css
+                          ^                                1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^^^                        2: variable.other.css
+                                   ^^^^^^^^^^^^^^^^^       1: invalid.illegal.invalid-source.css
+                                                    ^      1: punctuation.section.function.end.bracket.round.css
+                                                     ^     1: punctuation.terminator.rule.css
+
+
+^                                                          1: source.css.tailwind
+
+@reference './test.css';
+^^^^^^^^^^^^^^^^^^^^^^^^                                   7: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                       ^                                   1: punctuation.terminator.rule.css
+
+
+^                                                          1: source.css.tailwind
+
+@reference './test.css' prefix(tw);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                       12: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^^                             1: support.function.prefix.css
+                              ^                            1: punctuation.section.function.begin.bracket.round.css
+                               ^^                          1: variable.other.css
+                                 ^                         1: punctuation.section.function.end.bracket.round.css
+                                  ^                        1: punctuation.terminator.rule.css
+
+@reference './test.css' layer(utilities) prefix(tw);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      17: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^                              1: support.function.layer.css
+                             ^                 ^           2: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^^^^                    1: support.constant.layer-name.css
+                                       ^          ^        2: punctuation.section.function.end.bracket.round.css
+                                         ^^^^^^            1: support.function.prefix.css
+                                                ^^         1: variable.other.css
+                                                   ^       1: punctuation.terminator.rule.css
+
+
+^                                                          1: source.css.tailwind
+
+@reference './test.css' source(none);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                     12: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^^                             1: support.function.source.css
+                              ^                            1: punctuation.section.function.begin.bracket.round.css
+                               ^^^^                        1: support.constant.none.css
+                                   ^                       1: punctuation.section.function.end.bracket.round.css
+                                    ^                      1: punctuation.terminator.rule.css
+
+@reference './test.css' source('./foo');
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                  14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^        ^^^^^^^                     6: string.quoted.single.css
+           ^                   ^                           2: punctuation.definition.string.begin.css
+                      ^              ^                     2: punctuation.definition.string.end.css
+                        ^^^^^^                             1: support.function.source.css
+                              ^                            1: punctuation.section.function.begin.bracket.round.css
+                                      ^                    1: punctuation.section.function.end.bracket.round.css
+                                       ^                   1: punctuation.terminator.rule.css
+
+@reference './test.css' layer(utilities) source('./foo');
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 19: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                         ^^^^^^^    6: string.quoted.single.css
+           ^                                    ^          2: punctuation.definition.string.begin.css
+                      ^                               ^    2: punctuation.definition.string.end.css
+                        ^^^^^                              1: support.function.layer.css
+                             ^                 ^           2: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^^^^                    1: support.constant.layer-name.css
+                                       ^               ^   2: punctuation.section.function.end.bracket.round.css
+                                         ^^^^^^            1: support.function.source.css
+                                                        ^  1: punctuation.terminator.rule.css
+
+
+^                                                          1: source.css.tailwind
+
+@reference './test.css' theme(static);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                    12: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^                              1: support.function.theme.css
+                             ^                             1: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^                       1: variable.other.css
+                                    ^                      1: punctuation.section.function.end.bracket.round.css
+                                     ^                     1: punctuation.terminator.rule.css
+
+@reference './test.css' theme(static default inline);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     16: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^                              1: support.function.theme.css
+                             ^                             1: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^^^^^^^^^^^^^^^^        5: variable.other.css
+                                                   ^       1: punctuation.section.function.end.bracket.round.css
+                                                    ^      1: punctuation.terminator.rule.css
+
+@reference './test.css' theme(reference deprecated);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^                              1: support.function.theme.css
+                             ^                             1: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^^^^^^^^^^^^^^^         3: variable.other.css
+                                                  ^        1: punctuation.section.function.end.bracket.round.css
+                                                   ^       1: punctuation.terminator.rule.css
+
+@reference './test.css' theme(prefix(tw) reference);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      13: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^                              1: support.function.theme.css
+                             ^                             1: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^^^^                    1: invalid.illegal.invalid-source.css
+                                       ^                   1: punctuation.section.function.end.bracket.round.css
+                                                   ^       1: punctuation.terminator.rule.css
+
+@reference './test.css' theme(default invalid reference);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 14: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
+^                                                          1: punctuation.definition.keyword.css
+           ^^^^^^^^^^^^                                    3: string.quoted.single.css
+           ^                                               1: punctuation.definition.string.begin.css
+                      ^                                    1: punctuation.definition.string.end.css
+                        ^^^^^                              1: support.function.theme.css
+                             ^                             1: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^^^                     2: variable.other.css
+                                      ^^^^^^^^^^^^^^^^^    1: invalid.illegal.invalid-source.css
+                                                       ^   1: punctuation.section.function.end.bracket.round.css
+                                                        ^  1: punctuation.terminator.rule.css
+"
+`;
+
+exports[`@layer 1`] = `
+"
+@layer theme, base, components, utilities;
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 38: source.css.tailwind
+^^^^^^                                      2: keyword.control.at-rule.layer.tailwind
+^                                           1: punctuation.definition.keyword.css
+       ^^^^^  ^^^^  ^^^^^^^^^^  ^^^^^^^^^  28: variable.parameter.layer.tailwind
+            ^     ^           ^             3: punctuation.separator.list.comma.css
+                                         ^  1: punctuation.terminator.rule.css
+
+@layer utilities {
+^^^^^^^^^^^^^^^^^^                         14: source.css.tailwind
+^^^^^^                                      2: keyword.control.at-rule.layer.tailwind
+^                                           1: punctuation.definition.keyword.css
+       ^^^^^^^^^                            9: variable.parameter.layer.tailwind
+                 ^                          1: meta.at-rule.layer.body.tailwind punctuation.section.layer.begin.bracket.curly.tailwind
+
+  .custom {
+^^^^^^^^^^^                                 5: source.css.tailwind meta.at-rule.layer.body.tailwind
+  ^^^^^^^                                   2: meta.selector.css entity.other.attribute-name.class.css
+  ^                                         1: punctuation.definition.entity.css
+          ^                                 1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+    width: 12px;
+^^^^^^^^^^^^^^^^                            7: source.css.tailwind meta.at-rule.layer.body.tailwind meta.property-list.css
+    ^^^^^                                   1: meta.property-name.css support.type.property-name.css
+         ^                                  1: punctuation.separator.key-value.css
+           ^^^^                             2: meta.property-value.css constant.numeric.css
+             ^^                             1: keyword.other.unit.px.css
+               ^                            1: punctuation.terminator.rule.css
+
+  }
+^^^                                         2: source.css.tailwind meta.at-rule.layer.body.tailwind meta.property-list.css
+  ^                                         1: punctuation.section.property-list.end.bracket.curly.css
+
+}
+^                                           1: source.css.tailwind meta.at-rule.layer.body.tailwind punctuation.section.layer.end.bracket.curly.tailwind
+"
+`;
+
+exports[`@plugin statement 1`] = `
+"
+@plugin "./foo";
+^^^^^^^^^^^^^^^^  7: source.css.tailwind
+^^^^^^^           2: keyword.control.at-rule.plugin.tailwind
+^                 1: punctuation.definition.keyword.tailwind
+        ^^^^^^^   3: string.quoted.double.css
+        ^         1: punctuation.definition.string.begin.css
+              ^   1: punctuation.definition.string.end.css
+               ^  1: punctuation.terminator.rule.css
+
+@plugin "./bar";
+^^^^^^^^^^^^^^^^  7: source.css.tailwind
+^^^^^^^           2: keyword.control.at-rule.plugin.tailwind
+^                 1: punctuation.definition.keyword.tailwind
+        ^^^^^^^   3: string.quoted.double.css
+        ^         1: punctuation.definition.string.begin.css
+              ^   1: punctuation.definition.string.end.css
+               ^  1: punctuation.terminator.rule.css
+"
+`;
+
+exports[`@plugin with options 1`] = `
+"
+@import 'tailwindcss';
+^^^^^^^^^^^^^^^^^^^^^^  7: source.css.tailwind meta.at-rule.import.css
+^^^^^^^                 2: keyword.control.at-rule.import.css
+^                       1: punctuation.definition.keyword.css
+        ^^^^^^^^^^^^^   3: string.quoted.single.css
+        ^               1: punctuation.definition.string.begin.css
+                    ^   1: punctuation.definition.string.end.css
+                     ^  1: punctuation.terminator.rule.css
+
+@plugin "testing" {
+^^^^^^^^^^^^^^^^^^^     8: source.css.tailwind
+^^^^^^^                 2: keyword.control.at-rule.plugin.tailwind
+^                       1: punctuation.definition.keyword.tailwind
+        ^^^^^^^^^       3: string.quoted.double.css
+        ^               1: punctuation.definition.string.begin.css
+                ^       1: punctuation.definition.string.end.css
+                  ^     1: meta.at-rule.plugin.body.tailwind punctuation.section.plugin.begin.bracket.curly.tailwind
+
+  color: red;
+^^^^^^^^^^^^^           6: source.css.tailwind meta.at-rule.plugin.body.tailwind
+  ^^^^^                 1: meta.property-name.css support.type.property-name.css
+       ^                1: punctuation.separator.key-value.css
+         ^^^            1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+            ^           1: punctuation.terminator.rule.css
+
+}
+^                       1: source.css.tailwind meta.at-rule.plugin.body.tailwind punctuation.section.plugin.end.bracket.curly.tailwind
+
+
+^                       1: source.css.tailwind
+
+html,
+^^^^^^                  1: source.css.tailwind
+
+body {
+^^^^^^                  2: source.css.tailwind
+     ^                  1: meta.at-rule.plugin.body.tailwind punctuation.section.plugin.begin.bracket.curly.tailwind
+
+  color: red;
+^^^^^^^^^^^^^           6: source.css.tailwind meta.at-rule.plugin.body.tailwind
+  ^^^^^                 1: meta.property-name.css support.type.property-name.css
+       ^                1: punctuation.separator.key-value.css
+         ^^^            1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+            ^           1: punctuation.terminator.rule.css
+
+}
+^                       1: source.css.tailwind meta.at-rule.plugin.body.tailwind punctuation.section.plugin.end.bracket.curly.tailwind
+"
+`;
+
+exports[`@source 1`] = `
+"
+@source "./dir";
+^^^^^^^^^^^^^^^^                                             7: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^^^^^                                              3: string.quoted.double.css
+        ^                                                    1: punctuation.definition.string.begin.css
+              ^                                              1: punctuation.definition.string.end.css
+               ^                                             1: punctuation.terminator.rule.css
+
+@source "./file.ts";
+^^^^^^^^^^^^^^^^^^^^                                         7: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^^^^^^^^^                                          3: string.quoted.double.css
+        ^                                                    1: punctuation.definition.string.begin.css
+                  ^                                          1: punctuation.definition.string.end.css
+                   ^                                         1: punctuation.terminator.rule.css
+
+@source "./dir/**/file-{a,b}.ts";
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                            7: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+        ^^^^^^^^^^^^^^^^^^^^^^^^                             3: string.quoted.double.css
+        ^                                                    1: punctuation.definition.string.begin.css
+                               ^                             1: punctuation.definition.string.end.css
+                                ^                            1: punctuation.terminator.rule.css
+
+@source not "./dir";
+^^^^^^^^^^^^^^^^^^^^                                         8: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+            ^^^^^^^                                          3: string.quoted.double.css
+            ^                                                1: punctuation.definition.string.begin.css
+                  ^                                          1: punctuation.definition.string.end.css
+                   ^                                         1: punctuation.terminator.rule.css
+
+@source not "./file.ts";
+^^^^^^^^^^^^^^^^^^^^^^^^                                     8: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+            ^^^^^^^^^^^                                      3: string.quoted.double.css
+            ^                                                1: punctuation.definition.string.begin.css
+                      ^                                      1: punctuation.definition.string.end.css
+                       ^                                     1: punctuation.terminator.rule.css
+
+@source not "./dir/**/file-{a,b}.ts";
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                        8: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+            ^^^^^^^^^^^^^^^^^^^^^^^^                         3: string.quoted.double.css
+            ^                                                1: punctuation.definition.string.begin.css
+                                   ^                         1: punctuation.definition.string.end.css
+                                    ^                        1: punctuation.terminator.rule.css
+
+
+^                                                            1: source.css.tailwind
+
+@source inline("flex");
+^^^^^^^^^^^^^^^^^^^^^^^                                      9: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+               ^^^^^^                                        3: string.quoted.double.css
+               ^                                             1: punctuation.definition.string.begin.css
+                    ^                                        1: punctuation.definition.string.end.css
+                      ^                                      1: punctuation.terminator.rule.css
+
+@source inline("flex bg-red-{50,{100..900..100},950}");
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      9: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^        3: string.quoted.double.css
+               ^                                             1: punctuation.definition.string.begin.css
+                                                    ^        1: punctuation.definition.string.end.css
+                                                      ^      1: punctuation.terminator.rule.css
+
+@source not inline("flex");
+^^^^^^^^^^^^^^^^^^^^^^^^^^^                                  9: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+                   ^^^^^^                                    3: string.quoted.double.css
+                   ^                                         1: punctuation.definition.string.begin.css
+                        ^                                    1: punctuation.definition.string.end.css
+                          ^                                  1: punctuation.terminator.rule.css
+
+@source not inline("flex bg-red-{50,{100..900..100},950}");
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  9: source.css.tailwind
+^^^^^^^                                                      2: keyword.control.at-rule.source.tailwind
+^                                                            1: punctuation.definition.keyword.tailwind
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    3: string.quoted.double.css
+                   ^                                         1: punctuation.definition.string.begin.css
+                                                        ^    1: punctuation.definition.string.end.css
+                                                          ^  1: punctuation.terminator.rule.css
+"
+`;
+
+exports[`@tailwind 1`] = `
+"
+@tailwind base;
+^^^^^^^^^^^^^^^                        8: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^                         4: variable.parameter.tailwind.tailwind
+              ^                        1: punctuation.terminator.tailwind.tailwind
+
+@tailwind components;
+^^^^^^^^^^^^^^^^^^^^^                 14: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^^^^^^^                  10: variable.parameter.tailwind.tailwind
+                    ^                  1: punctuation.terminator.tailwind.tailwind
+
+@tailwind utilities;
+^^^^^^^^^^^^^^^^^^^^                  13: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^^^^^^                    9: variable.parameter.tailwind.tailwind
+                   ^                   1: punctuation.terminator.tailwind.tailwind
+
+@tailwind utilities source(none);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     18: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^^^^^^                    9: variable.parameter.tailwind.tailwind
+                    ^^^^^^             1: support.function.source.css
+                          ^            1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^        1: support.constant.none.css
+                               ^       1: punctuation.section.function.end.bracket.round.css
+                                ^      1: punctuation.terminator.tailwind.tailwind
+
+@tailwind utilities source("./**/*");
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 20: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^^^^^^                    9: variable.parameter.tailwind.tailwind
+                    ^^^^^^             1: support.function.source.css
+                          ^            1: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^^^    3: string.quoted.double.css
+                           ^           1: punctuation.definition.string.begin.css
+                                  ^    1: punctuation.definition.string.end.css
+                                   ^   1: punctuation.section.function.end.bracket.round.css
+                                    ^  1: punctuation.terminator.tailwind.tailwind
+
+@tailwind screens;
+^^^^^^^^^^^^^^^^^^                    11: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^^^^                      7: variable.parameter.tailwind.tailwind
+                 ^                     1: punctuation.terminator.tailwind.tailwind
+
+@tailwind variants;
+^^^^^^^^^^^^^^^^^^^                   12: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^^^^^                     8: variable.parameter.tailwind.tailwind
+                  ^                    1: punctuation.terminator.tailwind.tailwind
+
+@tailwind unknown;
+^^^^^^^^^^^^^^^^^^                    11: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
+^                                      1: punctuation.definition.keyword.css
+          ^^^^^^^                      7: variable.parameter.tailwind.tailwind
+                 ^                     1: punctuation.terminator.tailwind.tailwind
+"
+`;
+
+exports[`@theme 1`] = `
+"
+@theme {
+^^^^^^^^                               4: source.css.tailwind
+^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
+^                                      1: punctuation.definition.keyword.css
+       ^                               1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+  --color: red;
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
+  ^^^^^^^                              1: variable.css
+         ^                             1: punctuation.separator.key-value.css
+           ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+              ^                        1: punctuation.terminator.rule.css
+
+}
+^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+
+@theme static {
+^^^^^^^^^^^^^^^                        4: source.css.tailwind
+^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
+^                                      1: punctuation.definition.keyword.css
+              ^                        1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+  --color: red;
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
+  ^^^^^^^                              1: variable.css
+         ^                             1: punctuation.separator.key-value.css
+           ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+              ^                        1: punctuation.terminator.rule.css
+
+}
+^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+
+@theme inline deprecated {
+^^^^^^^^^^^^^^^^^^^^^^^^^^             4: source.css.tailwind
+^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
+^                                      1: punctuation.definition.keyword.css
+                         ^             1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+  --color: red;
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
+  ^^^^^^^                              1: variable.css
+         ^                             1: punctuation.separator.key-value.css
+           ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+              ^                        1: punctuation.terminator.rule.css
+
+}
+^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+
+@theme prefix(tw) inline {
+^^^^^^^^^^^^^^^^^^^^^^^^^^             4: source.css.tailwind
+^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
+^                                      1: punctuation.definition.keyword.css
+                         ^             1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+  --color: red;
+^^^^^^^^^^^^^^^                        6: source.css.tailwind meta.property-list.css
+  ^^^^^^^                              1: variable.css
+         ^                             1: punctuation.separator.key-value.css
+           ^^^                         1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+              ^                        1: punctuation.terminator.rule.css
+
+}
+^                                      1: source.css.tailwind meta.property-list.css punctuation.section.property-list.end.bracket.curly.css
+
+
+^                                      1: source.css.tailwind
+
+@theme {
+^^^^^^^^                               4: source.css.tailwind
+^^^^^^                                 2: keyword.control.at-rule.theme.tailwind
+^                                      1: punctuation.definition.keyword.css
+       ^                               1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+  --spacing: initial;
+^^^^^^^^^^^^^^^^^^^^^                  6: source.css.tailwind meta.property-list.css
+  ^^^^^^^^^                            1: variable.css
+           ^                           1: punctuation.separator.key-value.css
+             ^^^^^^^                   1: meta.property-value.css support.constant.property-value.css
+                    ^                  1: punctuation.terminator.rule.css
+
+  --color-*: initial;
+^^^^^^^^^^^^^^^^^^^^^                  7: source.css.tailwind meta.property-list.css
+  ^^^^^^^^                             1: variable.css
+           ^                           1: punctuation.separator.key-value.css
+             ^^^^^^^                   1: meta.property-value.css support.constant.property-value.css
+                    ^                  1: punctuation.terminator.rule.css
+
+  --animate-pulse: 1s pulse infinite;
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  9: source.css.tailwind meta.property-list.css
+  ^^^^^^^^^^^^^^^                      1: variable.css
+                 ^                     1: punctuation.separator.key-value.css
+                   ^^^^^^^^^^^^^^^^^   4: meta.property-value.css
+                   ^^                  2: constant.numeric.css
+                    ^                  1: keyword.other.unit.s.css
+                            ^^^^^^^^   1: support.constant.property-value.css
+                                    ^  1: punctuation.terminator.rule.css
+
+
+^                                      1: source.css.tailwind meta.property-list.css
+
+  @keyframes pulse {
+^^^^^^^^^^^^^^^^^^^^^                  5: source.css.tailwind meta.property-list.css
+   ^^^^^^^^^ ^^^^^                     2: meta.property-name.css
+
+    0%,
+^^^^^^^^                               1: source.css.tailwind meta.property-list.css
+
+    100% {
+^^^^^^^^^^^                            1: source.css.tailwind meta.property-list.css
+
+      opacity: 0;
+^^^^^^^^^^^^^^^^^                      6: source.css.tailwind meta.property-list.css
+      ^^^^^^^                          1: meta.property-name.css support.type.property-name.css
+             ^                         1: punctuation.separator.key-value.css
+               ^                       1: meta.property-value.css constant.numeric.css
+                ^                      1: punctuation.terminator.rule.css
+
+    }
+^^^^^                                  2: source.css.tailwind meta.property-list.css
+    ^                                  1: punctuation.section.property-list.end.bracket.curly.css
+
+    50% {
+^^^^^^^^^                              2: source.css.tailwind
+        ^                              1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+      opacity: 1;
+^^^^^^^^^^^^^^^^^                      6: source.css.tailwind meta.property-list.css
+      ^^^^^^^                          1: meta.property-name.css support.type.property-name.css
+             ^                         1: punctuation.separator.key-value.css
+               ^                       1: meta.property-value.css constant.numeric.css
+                ^                      1: punctuation.terminator.rule.css
+
+    }
+^^^^^                                  2: source.css.tailwind meta.property-list.css
+    ^                                  1: punctuation.section.property-list.end.bracket.curly.css
+
+  }
+^^^^                                   1: source.css.tailwind
+
+}
+^^                                     1: source.css.tailwind
+"
+`;
+
+exports[`@utility 1`] = `
+"
+@utility custom {
+^^^^^^^^^^^^^^^^^                      11: source.css.tailwind
+^^^^^^^^                                2: keyword.control.at-rule.utility.tailwind
+^                                       1: punctuation.definition.keyword.css
+         ^^^^^^                         6: variable.parameter.utility.tailwind
+                ^                       1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
+
+  width: 12px;
+^^^^^^^^^^^^^^^                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+}
+^                                       1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
+
+
+^                                       1: source.css.tailwind
+
+@utility functional-* {
+^^^^^^^^^^^^^^^^^^^^^^^                17: source.css.tailwind
+^^^^^^^^                                2: keyword.control.at-rule.utility.tailwind
+^                                       1: punctuation.definition.keyword.css
+         ^^^^^^^^^^^^                  12: variable.parameter.utility.tailwind
+                      ^                 1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
+
+  width: calc(--value(number) * 1px);
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+}
+^                                       1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
+"
+`;
+
+exports[`@variant 1`] = `
+"
+@variant dark {
+^^^^^^^^^^^^^^^     9: source.css.tailwind
+^^^^^^^^            2: keyword.control.at-rule.variant.tailwind
+^                   1: punctuation.definition.keyword.css
+         ^^^^       4: variable.parameter.variant.tailwind
+              ^     1: meta.at-rule.variant.body.tailwind punctuation.section.variant.begin.bracket.curly.tailwind
+
+  .foo {
+^^^^^^^^            5: source.css.tailwind meta.at-rule.variant.body.tailwind
+  ^^^^              2: meta.selector.css entity.other.attribute-name.class.css
+  ^                 1: punctuation.definition.entity.css
+       ^            1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+    color: white;
+^^^^^^^^^^^^^^^^^   6: source.css.tailwind meta.at-rule.variant.body.tailwind meta.property-list.css
+    ^^^^^           1: meta.property-name.css support.type.property-name.css
+         ^          1: punctuation.separator.key-value.css
+           ^^^^^    1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+                ^   1: punctuation.terminator.rule.css
+
+  }
+^^^                 2: source.css.tailwind meta.at-rule.variant.body.tailwind meta.property-list.css
+  ^                 1: punctuation.section.property-list.end.bracket.curly.css
+
+}
+^                   1: source.css.tailwind meta.at-rule.variant.body.tailwind punctuation.section.variant.end.bracket.curly.tailwind
+
+
+^                   1: source.css.tailwind
+
+.bar {
+^^^^^^              4: source.css.tailwind
+^^^^                2: meta.selector.css entity.other.attribute-name.class.css
+^                   1: punctuation.definition.entity.css
+     ^              1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+  @variant dark {
+^^^^^^^^^^^^^^^^^  10: source.css.tailwind meta.property-list.css
+  ^^^^^^^^          2: keyword.control.at-rule.variant.tailwind
+  ^                 1: punctuation.definition.keyword.css
+           ^^^^     4: variable.parameter.variant.tailwind
+                ^   1: meta.at-rule.variant.body.tailwind punctuation.section.variant.begin.bracket.curly.tailwind
+
+    color: white;
+^^^^^^^^^^^^^^^^^^  2: source.css.tailwind meta.property-list.css meta.at-rule.variant.body.tailwind
+    ^^^^^^^^^^^^^^  1: meta.selector.css
+
+  }
+^^^^                1: source.css.tailwind meta.property-list.css meta.at-rule.variant.body.tailwind meta.selector.css
+
+}
+^^                  1: source.css.tailwind meta.property-list.css meta.at-rule.variant.body.tailwind meta.selector.css
+"
+`;
+
+exports[`--value(…) 1`] = `
+"
+@utility functional-* {
+^^^^^^^^^^^^^^^^^^^^^^^                                   17: source.css.tailwind
+^^^^^^^^                                                   2: keyword.control.at-rule.utility.tailwind
+^                                                          1: punctuation.definition.keyword.css
+         ^^^^^^^^^^^^                                     12: variable.parameter.utility.tailwind
+                      ^                                    1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
+
+  width: --value(
+^^^^^^^^^^^^^^^^^^                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    --size,
+^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    'literal',
+^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    integer,
+^^^^^^^^^^^^^                                              1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    number,
+^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    percentage,
+^^^^^^^^^^^^^^^^                                           1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    ratio,
+^^^^^^^^^^^                                                1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [integer],
+^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [number],
+^^^^^^^^^^^^^^                                             1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [percentage],
+^^^^^^^^^^^^^^^^^^                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [ratio]
+^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+  );
+^^^^^                                                      1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+
+^                                                          1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+  height: --modifier(
+^^^^^^^^^^^^^^^^^^^^^^                                     1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    --size,
+^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    'literal',
+^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    integer,
+^^^^^^^^^^^^^                                              1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    number,
+^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    percentage,
+^^^^^^^^^^^^^^^^                                           1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    ratio,
+^^^^^^^^^^^                                                1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [integer],
+^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [number],
+^^^^^^^^^^^^^^                                             1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [percentage],
+^^^^^^^^^^^^^^^^^^                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+    [ratio]
+^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+  );
+^^^^^                                                      1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+
+^                                                          1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+  color: --alpha(--value([color]) / --modifier(number));
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  1: source.css.tailwind meta.at-rule.utility.body.tailwind
+
+}
+^                                                          1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
+"
+`;
+
+exports[`legacy: @responsive 1`] = `
+"
+@responsive {
+^^^^^^^^^^^^^    4: source.css.tailwind
+^^^^^^^^^^^      2: keyword.control.at-rule.responsive.tailwind
+^                1: punctuation.definition.keyword.css
+            ^    1: meta.at-rule.responsive.body.tailwind punctuation.section.responsive.begin.bracket.curly.tailwind
+
+  .foo {
+^^^^^^^^         5: source.css.tailwind meta.at-rule.responsive.body.tailwind
+  ^^^^           2: meta.selector.css entity.other.attribute-name.class.css
+  ^              1: punctuation.definition.entity.css
+       ^         1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+    color: red;
+^^^^^^^^^^^^^^^  6: source.css.tailwind meta.at-rule.responsive.body.tailwind meta.property-list.css
+    ^^^^^        1: meta.property-name.css support.type.property-name.css
+         ^       1: punctuation.separator.key-value.css
+           ^^^   1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+              ^  1: punctuation.terminator.rule.css
+
+  }
+^^^              2: source.css.tailwind meta.at-rule.responsive.body.tailwind meta.property-list.css
+  ^              1: punctuation.section.property-list.end.bracket.curly.css
+
+}
+^                1: source.css.tailwind meta.at-rule.responsive.body.tailwind punctuation.section.responsive.end.bracket.curly.tailwind
+"
+`;
+
+exports[`legacy: @screen 1`] = `
+"
+@screen sm {
+^^^^^^^^^^^^     7: source.css.tailwind
+^^^^^^^          2: keyword.control.at-rule.screen.tailwind
+^                1: punctuation.definition.keyword.css
+        ^^       2: variable.parameter.screen.tailwind
+           ^     1: meta.at-rule.screen.body.tailwind punctuation.section.screen.begin.bracket.curly.tailwind
+
+  .foo {
+^^^^^^^^         5: source.css.tailwind meta.at-rule.screen.body.tailwind
+  ^^^^           2: meta.selector.css entity.other.attribute-name.class.css
+  ^              1: punctuation.definition.entity.css
+       ^         1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+    color: red;
+^^^^^^^^^^^^^^^  6: source.css.tailwind meta.at-rule.screen.body.tailwind meta.property-list.css
+    ^^^^^        1: meta.property-name.css support.type.property-name.css
+         ^       1: punctuation.separator.key-value.css
+           ^^^   1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+              ^  1: punctuation.terminator.rule.css
+
+  }
+^^^              2: source.css.tailwind meta.at-rule.screen.body.tailwind meta.property-list.css
+  ^              1: punctuation.section.property-list.end.bracket.curly.css
+
+}
+^                1: source.css.tailwind meta.at-rule.screen.body.tailwind punctuation.section.screen.end.bracket.curly.tailwind
+"
+`;
+
+exports[`legacy: @variants 1`] = `
+"
+@variants hover, focus {
+^^^^^^^^^^^^^^^^^^^^^^^^ 17: source.css.tailwind
+^^^^^^^^^                 2: keyword.control.at-rule.variants.tailwind
+^                         1: punctuation.definition.keyword.css
+          ^^^^^  ^^^^^   10: variable.parameter.variants.tailwind
+               ^          1: punctuation.separator.list.comma.css
+                       ^  1: meta.at-rule.variants.body.tailwind punctuation.section.variants.begin.bracket.curly.tailwind
+
+  .foo {
+^^^^^^^^                  5: source.css.tailwind meta.at-rule.variants.body.tailwind
+  ^^^^                    2: meta.selector.css entity.other.attribute-name.class.css
+  ^                       1: punctuation.definition.entity.css
+       ^                  1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
+
+    color: red;
+^^^^^^^^^^^^^^^           6: source.css.tailwind meta.at-rule.variants.body.tailwind meta.property-list.css
+    ^^^^^                 1: meta.property-name.css support.type.property-name.css
+         ^                1: punctuation.separator.key-value.css
+           ^^^            1: meta.property-value.css support.constant.color.w3c-standard-color-name.css
+              ^           1: punctuation.terminator.rule.css
+
+  }
+^^^                       2: source.css.tailwind meta.at-rule.variants.body.tailwind meta.property-list.css
+  ^                       1: punctuation.section.property-list.end.bracket.curly.css
+
+}
+^                         1: source.css.tailwind meta.at-rule.variants.body.tailwind punctuation.section.variants.end.bracket.curly.tailwind
+"
+`;

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -907,14 +907,16 @@ exports[`@utility 1`] = `
                       ^                1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
 
   width: calc(--value(number) * 1px);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 13: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 17: source.css.tailwind meta.at-rule.utility.body.tailwind
   ^^^^^                                1: meta.property-name.css support.type.property-name.css
        ^                               1: punctuation.separator.key-value.css
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^    7: meta.property-value.css
-         ^^^^^^^^^^^^^^^^^^^^          4: meta.function.calc.css
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^  12: meta.property-value.css meta.function.calc.css
          ^^^^                          1: support.function.calc.css
-             ^                         1: punctuation.section.function.begin.bracket.round.css
-                            ^          1: punctuation.section.function.end.bracket.round.css
+             ^       ^                 2: punctuation.section.function.begin.bracket.round.css
+              ^^^^^^^                  1: support.function.value.tailwind
+                      ^^^^^^           1: support.constant.utility.data-type.css
+                            ^      ^   2: punctuation.section.function.end.bracket.round.css
+                              ^        1: keyword.operator.arithmetic.css
                                 ^^^    2: constant.numeric.css
                                  ^^    1: keyword.other.unit.px.css
                                     ^  1: punctuation.terminator.rule.css
@@ -984,95 +986,182 @@ exports[`@variant 1`] = `
 exports[`--value(…) 1`] = `
 "
 @utility functional-* {
-^^^^^^^^^^^^^^^^^^^^^^^                                   17: source.css.tailwind
-^^^^^^^^                                                   2: keyword.control.at-rule.utility.tailwind
-^                                                          1: punctuation.definition.keyword.css
-         ^^^^^^^^^^^^                                     12: variable.parameter.utility.tailwind
-                      ^                                    1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^                                   6: source.css.tailwind
+^^^^^^^^                                                  2: keyword.control.at-rule.utility.tailwind
+^                                                         1: punctuation.definition.keyword.css
+         ^^^^^^^^^^^^                                     1: variable.parameter.utility.tailwind
+                      ^                                   1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
 
   width: --value(
-^^^^^^^^^^^^^^^^^^                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^^^                                         6: source.css.tailwind meta.at-rule.utility.body.tailwind
+  ^^^^^                                                   1: meta.property-name.css support.type.property-name.css
+       ^                                                  1: punctuation.separator.key-value.css
+         ^^^^^^^^                                         2: meta.property-value.css
+         ^^^^^^^                                          1: support.function.value.tailwind
+                ^                                         1: punctuation.section.function.begin.bracket.round.css
 
     --size,
-^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^                                               3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^                                                1: variable.theme-namespace.css
+          ^                                               1: punctuation.separator.list.comma.css
 
     'literal',
-^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^                                            5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^^^^                                             3: string.quoted.single.css
+    ^                                                     1: punctuation.definition.string.begin.css
+            ^                                             1: punctuation.definition.string.end.css
+             ^                                            1: punctuation.separator.list.comma.css
 
     integer,
-^^^^^^^^^^^^^                                              1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^                                              3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^^                                               1: support.constant.utility.data-type.css
+           ^                                              1: punctuation.separator.list.comma.css
 
     number,
-^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^                                               3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^                                                1: support.constant.utility.data-type.css
+          ^                                               1: punctuation.separator.list.comma.css
 
     percentage,
-^^^^^^^^^^^^^^^^                                           1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^                                           3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^^^^^                                            1: support.constant.utility.data-type.css
+              ^                                           1: punctuation.separator.list.comma.css
 
     ratio,
-^^^^^^^^^^^                                                1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^                                                3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^                                                 1: support.constant.utility.data-type.css
+         ^                                                1: punctuation.separator.list.comma.css
 
     [integer],
-^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^                                            5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^^^                                              1: support.constant.utility.data-type.css
+            ^                                             1: punctuation.definition.arbitrary.end.bracket.square.css
+             ^                                            1: punctuation.separator.list.comma.css
 
     [number],
-^^^^^^^^^^^^^^                                             1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^                                             5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^^                                               1: support.constant.utility.data-type.css
+           ^                                              1: punctuation.definition.arbitrary.end.bracket.square.css
+            ^                                             1: punctuation.separator.list.comma.css
 
     [percentage],
-^^^^^^^^^^^^^^^^^^                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^^^                                         5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^^^^^^                                           1: support.constant.utility.data-type.css
+               ^                                          1: punctuation.definition.arbitrary.end.bracket.square.css
+                ^                                         1: punctuation.separator.list.comma.css
 
     [ratio]
-^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^                                               4: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^                                                1: support.constant.utility.data-type.css
+          ^                                               1: punctuation.definition.arbitrary.end.bracket.square.css
 
   );
-^^^^^                                                      1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^                                                      3: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^                                                       2: meta.property-value.css
+  ^                                                       1: punctuation.section.function.end.bracket.round.css
+   ^                                                      1: punctuation.terminator.rule.css
 
 
-^                                                          1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^                                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
 
   height: --modifier(
-^^^^^^^^^^^^^^^^^^^^^^                                     1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^^^^^^^                                     6: source.css.tailwind meta.at-rule.utility.body.tailwind
+  ^^^^^^                                                  1: meta.property-name.css support.type.property-name.css
+        ^                                                 1: punctuation.separator.key-value.css
+          ^^^^^^^^^^^                                     2: meta.property-value.css
+          ^^^^^^^^^^                                      1: support.function.modifier.tailwind
+                    ^                                     1: punctuation.section.function.begin.bracket.round.css
 
     --size,
-^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^                                               3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^                                                1: variable.theme-namespace.css
+          ^                                               1: punctuation.separator.list.comma.css
 
     'literal',
-^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^                                            5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^^^^                                             3: string.quoted.single.css
+    ^                                                     1: punctuation.definition.string.begin.css
+            ^                                             1: punctuation.definition.string.end.css
+             ^                                            1: punctuation.separator.list.comma.css
 
     integer,
-^^^^^^^^^^^^^                                              1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^                                              3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^^                                               1: support.constant.utility.data-type.css
+           ^                                              1: punctuation.separator.list.comma.css
 
     number,
-^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^                                               3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^                                                1: support.constant.utility.data-type.css
+          ^                                               1: punctuation.separator.list.comma.css
 
     percentage,
-^^^^^^^^^^^^^^^^                                           1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^                                           3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^^^^^^                                            1: support.constant.utility.data-type.css
+              ^                                           1: punctuation.separator.list.comma.css
 
     ratio,
-^^^^^^^^^^^                                                1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^                                                3: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^^^^^                                                 1: support.constant.utility.data-type.css
+         ^                                                1: punctuation.separator.list.comma.css
 
     [integer],
-^^^^^^^^^^^^^^^                                            1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^                                            5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^^^                                              1: support.constant.utility.data-type.css
+            ^                                             1: punctuation.definition.arbitrary.end.bracket.square.css
+             ^                                            1: punctuation.separator.list.comma.css
 
     [number],
-^^^^^^^^^^^^^^                                             1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^                                             5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^^                                               1: support.constant.utility.data-type.css
+           ^                                              1: punctuation.definition.arbitrary.end.bracket.square.css
+            ^                                             1: punctuation.separator.list.comma.css
 
     [percentage],
-^^^^^^^^^^^^^^^^^^                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^^^                                         5: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^^^^^^                                           1: support.constant.utility.data-type.css
+               ^                                          1: punctuation.definition.arbitrary.end.bracket.square.css
+                ^                                         1: punctuation.separator.list.comma.css
 
     [ratio]
-^^^^^^^^^^^^                                               1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^                                               4: source.css.tailwind meta.at-rule.utility.body.tailwind meta.property-value.css
+    ^                                                     1: punctuation.definition.arbitrary.begin.bracket.square.css
+     ^^^^^                                                1: support.constant.utility.data-type.css
+          ^                                               1: punctuation.definition.arbitrary.end.bracket.square.css
 
   );
-^^^^^                                                      1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^                                                      3: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^                                                       2: meta.property-value.css
+  ^                                                       1: punctuation.section.function.end.bracket.round.css
+   ^                                                      1: punctuation.terminator.rule.css
 
 
-^                                                          1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^                                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
 
   color: --alpha(--value([color]) / --modifier(number));
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 21: source.css.tailwind meta.at-rule.utility.body.tailwind
+  ^^^^^                                                   1: meta.property-name.css support.type.property-name.css
+       ^                                                  1: punctuation.separator.key-value.css
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  16: meta.property-value.css
+         ^^^^^^^                                          1: support.function.alpha.tailwind
+                ^       ^                     ^           3: punctuation.section.function.begin.bracket.round.css
+                 ^^^^^^^                                  1: support.function.value.tailwind
+                         ^                                1: punctuation.definition.arbitrary.begin.bracket.square.css
+                          ^^^^^                ^^^^^^     2: support.constant.utility.data-type.css
+                               ^                          1: punctuation.definition.arbitrary.end.bracket.square.css
+                                ^                    ^^   3: punctuation.section.function.end.bracket.round.css
+                                  ^                       1: variable.parameter.alpha.tailwind
+                                    ^^^^^^^^^^            1: support.function.modifier.tailwind
+                                                       ^  1: punctuation.terminator.rule.css
 
 }
-^                                                          1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
+^                                                         1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
 "
 `;
 

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -413,18 +413,18 @@ exports[`@import 1`] = `
 exports[`@layer 1`] = `
 "
 @layer theme, base, components, utilities;
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 38: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 14: source.css.tailwind
 ^^^^^^                                      2: keyword.control.at-rule.layer.tailwind
 ^                                           1: punctuation.definition.keyword.css
-       ^^^^^  ^^^^  ^^^^^^^^^^  ^^^^^^^^^  28: variable.parameter.layer.tailwind
+       ^^^^^  ^^^^  ^^^^^^^^^^  ^^^^^^^^^   4: variable.parameter.layer.tailwind
             ^     ^           ^             3: punctuation.separator.list.comma.css
                                          ^  1: punctuation.terminator.rule.css
 
 @layer utilities {
-^^^^^^^^^^^^^^^^^^                         14: source.css.tailwind
+^^^^^^^^^^^^^^^^^^                          6: source.css.tailwind
 ^^^^^^                                      2: keyword.control.at-rule.layer.tailwind
 ^                                           1: punctuation.definition.keyword.css
-       ^^^^^^^^^                            9: variable.parameter.layer.tailwind
+       ^^^^^^^^^                            1: variable.parameter.layer.tailwind
                  ^                          1: meta.at-rule.layer.body.tailwind punctuation.section.layer.begin.bracket.curly.tailwind
 
   .custom {
@@ -627,31 +627,31 @@ exports[`@source 1`] = `
 exports[`@tailwind 1`] = `
 "
 @tailwind base;
-^^^^^^^^^^^^^^^                        8: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^                        5: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^                         4: variable.parameter.tailwind.tailwind
+          ^^^^                         1: variable.parameter.tailwind.tailwind
               ^                        1: punctuation.terminator.tailwind.tailwind
 
 @tailwind components;
-^^^^^^^^^^^^^^^^^^^^^                 14: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^^^^^^^                  5: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^^^^^^^                  10: variable.parameter.tailwind.tailwind
+          ^^^^^^^^^^                   1: variable.parameter.tailwind.tailwind
                     ^                  1: punctuation.terminator.tailwind.tailwind
 
 @tailwind utilities;
-^^^^^^^^^^^^^^^^^^^^                  13: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^^^^^^                   5: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^^^^^^                    9: variable.parameter.tailwind.tailwind
+          ^^^^^^^^^                    1: variable.parameter.tailwind.tailwind
                    ^                   1: punctuation.terminator.tailwind.tailwind
 
 @tailwind utilities source(none);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     18: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     10: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^^^^^^                    9: variable.parameter.tailwind.tailwind
+          ^^^^^^^^^                    1: variable.parameter.tailwind.tailwind
                     ^^^^^^             1: support.function.source.css
                           ^            1: punctuation.section.function.begin.bracket.round.css
                            ^^^^        1: support.constant.none.css
@@ -659,10 +659,10 @@ exports[`@tailwind 1`] = `
                                 ^      1: punctuation.terminator.tailwind.tailwind
 
 @tailwind utilities source("./**/*");
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 20: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 12: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^^^^^^                    9: variable.parameter.tailwind.tailwind
+          ^^^^^^^^^                    1: variable.parameter.tailwind.tailwind
                     ^^^^^^             1: support.function.source.css
                           ^            1: punctuation.section.function.begin.bracket.round.css
                            ^^^^^^^^    3: string.quoted.double.css
@@ -672,24 +672,24 @@ exports[`@tailwind 1`] = `
                                     ^  1: punctuation.terminator.tailwind.tailwind
 
 @tailwind screens;
-^^^^^^^^^^^^^^^^^^                    11: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^^^^                     5: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^^^^                      7: variable.parameter.tailwind.tailwind
+          ^^^^^^^                      1: variable.parameter.tailwind.tailwind
                  ^                     1: punctuation.terminator.tailwind.tailwind
 
 @tailwind variants;
-^^^^^^^^^^^^^^^^^^^                   12: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^^^^^                    5: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^^^^^                     8: variable.parameter.tailwind.tailwind
+          ^^^^^^^^                     1: variable.parameter.tailwind.tailwind
                   ^                    1: punctuation.terminator.tailwind.tailwind
 
 @tailwind unknown;
-^^^^^^^^^^^^^^^^^^                    11: source.css.tailwind meta.at-rule.tailwind.css
+^^^^^^^^^^^^^^^^^^                     5: source.css.tailwind meta.at-rule.tailwind.css
 ^^^^^^^^^                              2: keyword.control.at-rule.tailwind.tailwind
 ^                                      1: punctuation.definition.keyword.css
-          ^^^^^^^                      7: variable.parameter.tailwind.tailwind
+          ^^^^^^^                      1: variable.parameter.tailwind.tailwind
                  ^                     1: punctuation.terminator.tailwind.tailwind
 "
 `;
@@ -851,10 +851,10 @@ exports[`@theme 1`] = `
 exports[`@utility 1`] = `
 "
 @utility custom {
-^^^^^^^^^^^^^^^^^                      11: source.css.tailwind
+^^^^^^^^^^^^^^^^^                       6: source.css.tailwind
 ^^^^^^^^                                2: keyword.control.at-rule.utility.tailwind
 ^                                       1: punctuation.definition.keyword.css
-         ^^^^^^                         6: variable.parameter.utility.tailwind
+         ^^^^^^                         1: variable.parameter.utility.tailwind
                 ^                       1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
 
   width: 12px;
@@ -867,10 +867,10 @@ exports[`@utility 1`] = `
 ^                                       1: source.css.tailwind
 
 @utility functional-* {
-^^^^^^^^^^^^^^^^^^^^^^^                17: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^                 6: source.css.tailwind
 ^^^^^^^^                                2: keyword.control.at-rule.utility.tailwind
 ^                                       1: punctuation.definition.keyword.css
-         ^^^^^^^^^^^^                  12: variable.parameter.utility.tailwind
+         ^^^^^^^^^^^^                   1: variable.parameter.utility.tailwind
                       ^                 1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
 
   width: calc(--value(number) * 1px);
@@ -884,10 +884,10 @@ exports[`@utility 1`] = `
 exports[`@variant 1`] = `
 "
 @variant dark {
-^^^^^^^^^^^^^^^     9: source.css.tailwind
+^^^^^^^^^^^^^^^     6: source.css.tailwind
 ^^^^^^^^            2: keyword.control.at-rule.variant.tailwind
 ^                   1: punctuation.definition.keyword.css
-         ^^^^       4: variable.parameter.variant.tailwind
+         ^^^^       1: variable.parameter.variant.tailwind
               ^     1: meta.at-rule.variant.body.tailwind punctuation.section.variant.begin.bracket.curly.tailwind
 
   .foo {
@@ -920,10 +920,10 @@ exports[`@variant 1`] = `
      ^              1: meta.property-list.css punctuation.section.property-list.begin.bracket.curly.css
 
   @variant dark {
-^^^^^^^^^^^^^^^^^  10: source.css.tailwind meta.property-list.css
+^^^^^^^^^^^^^^^^^   7: source.css.tailwind meta.property-list.css
   ^^^^^^^^          2: keyword.control.at-rule.variant.tailwind
   ^                 1: punctuation.definition.keyword.css
-           ^^^^     4: variable.parameter.variant.tailwind
+           ^^^^     1: variable.parameter.variant.tailwind
                 ^   1: meta.at-rule.variant.body.tailwind punctuation.section.variant.begin.bracket.curly.tailwind
 
     color: white;
@@ -1066,10 +1066,10 @@ exports[`legacy: @responsive 1`] = `
 exports[`legacy: @screen 1`] = `
 "
 @screen sm {
-^^^^^^^^^^^^     7: source.css.tailwind
+^^^^^^^^^^^^     6: source.css.tailwind
 ^^^^^^^          2: keyword.control.at-rule.screen.tailwind
 ^                1: punctuation.definition.keyword.css
-        ^^       2: variable.parameter.screen.tailwind
+        ^^       1: variable.parameter.screen.tailwind
            ^     1: meta.at-rule.screen.body.tailwind punctuation.section.screen.begin.bracket.curly.tailwind
 
   .foo {
@@ -1097,10 +1097,10 @@ exports[`legacy: @screen 1`] = `
 exports[`legacy: @variants 1`] = `
 "
 @variants hover, focus {
-^^^^^^^^^^^^^^^^^^^^^^^^ 17: source.css.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^  9: source.css.tailwind
 ^^^^^^^^^                 2: keyword.control.at-rule.variants.tailwind
 ^                         1: punctuation.definition.keyword.css
-          ^^^^^  ^^^^^   10: variable.parameter.variants.tailwind
+          ^^^^^  ^^^^^    2: variable.parameter.variants.tailwind
                ^          1: punctuation.separator.list.comma.css
                        ^  1: meta.at-rule.variants.body.tailwind punctuation.section.variants.begin.bracket.curly.tailwind
 

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -851,33 +851,48 @@ exports[`@theme 1`] = `
 exports[`@utility 1`] = `
 "
 @utility custom {
-^^^^^^^^^^^^^^^^^                       6: source.css.tailwind
-^^^^^^^^                                2: keyword.control.at-rule.utility.tailwind
-^                                       1: punctuation.definition.keyword.css
-         ^^^^^^                         1: variable.parameter.utility.tailwind
-                ^                       1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
+^^^^^^^^^^^^^^^^^                      6: source.css.tailwind
+^^^^^^^^                               2: keyword.control.at-rule.utility.tailwind
+^                                      1: punctuation.definition.keyword.css
+         ^^^^^^                        1: variable.parameter.utility.tailwind
+                ^                      1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
 
   width: 12px;
-^^^^^^^^^^^^^^^                         1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^                         7: source.css.tailwind meta.at-rule.utility.body.tailwind
+  ^^^^^                                1: meta.property-name.css support.type.property-name.css
+       ^                               1: punctuation.separator.key-value.css
+         ^^^^                          2: meta.property-value.css constant.numeric.css
+           ^^                          1: keyword.other.unit.px.css
+             ^                         1: punctuation.terminator.rule.css
 
 }
-^                                       1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
+^                                      1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
 
 
-^                                       1: source.css.tailwind
+^                                      1: source.css.tailwind
 
 @utility functional-* {
-^^^^^^^^^^^^^^^^^^^^^^^                 6: source.css.tailwind
-^^^^^^^^                                2: keyword.control.at-rule.utility.tailwind
-^                                       1: punctuation.definition.keyword.css
-         ^^^^^^^^^^^^                   1: variable.parameter.utility.tailwind
-                      ^                 1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^                6: source.css.tailwind
+^^^^^^^^                               2: keyword.control.at-rule.utility.tailwind
+^                                      1: punctuation.definition.keyword.css
+         ^^^^^^^^^^^^                  1: variable.parameter.utility.tailwind
+                      ^                1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
 
   width: calc(--value(number) * 1px);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  1: source.css.tailwind meta.at-rule.utility.body.tailwind
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 13: source.css.tailwind meta.at-rule.utility.body.tailwind
+  ^^^^^                                1: meta.property-name.css support.type.property-name.css
+       ^                               1: punctuation.separator.key-value.css
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^    7: meta.property-value.css
+         ^^^^^^^^^^^^^^^^^^^^          4: meta.function.calc.css
+         ^^^^                          1: support.function.calc.css
+             ^                         1: punctuation.section.function.begin.bracket.round.css
+                            ^          1: punctuation.section.function.end.bracket.round.css
+                                ^^^    2: constant.numeric.css
+                                 ^^    1: keyword.other.unit.px.css
+                                    ^  1: punctuation.terminator.rule.css
 
 }
-^                                       1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
+^                                      1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind
 "
 `;
 

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -132,7 +132,7 @@ exports[`@import 1`] = `
                    ^                                       1: punctuation.definition.string.end.css
                      ^^^^^^                                1: support.function.prefix.css
                            ^                               1: punctuation.section.function.begin.bracket.round.css
-                            ^^                             1: variable.other.css
+                            ^^                             1: variable.parameter.prefix.css
                               ^                            1: punctuation.section.function.end.bracket.round.css
                                ^                           1: punctuation.terminator.rule.css
 
@@ -148,7 +148,7 @@ exports[`@import 1`] = `
                            ^^^^^^^^^                       1: support.constant.layer-name.css
                                     ^          ^           2: punctuation.section.function.end.bracket.round.css
                                       ^^^^^^               1: support.function.prefix.css
-                                             ^^            1: variable.other.css
+                                             ^^            1: variable.parameter.prefix.css
                                                 ^          1: punctuation.terminator.rule.css
 
 
@@ -245,7 +245,7 @@ exports[`@import 1`] = `
                      ^^^^^                                 1: support.function.theme.css
                           ^      ^                         2: punctuation.section.function.begin.bracket.round.css
                            ^^^^^^                          1: support.function.prefix.css
-                                  ^^                       1: variable.other.css
+                                  ^^                       1: variable.parameter.prefix.css
                                     ^          ^           2: punctuation.section.function.end.bracket.round.css
                                       ^^^^^^^^^            1: support.constant.theme-option.css
                                                 ^          1: punctuation.terminator.rule.css
@@ -288,7 +288,7 @@ exports[`@import 1`] = `
                       ^                                    1: punctuation.definition.string.end.css
                         ^^^^^^                             1: support.function.prefix.css
                               ^                            1: punctuation.section.function.begin.bracket.round.css
-                               ^^                          1: variable.other.css
+                               ^^                          1: variable.parameter.prefix.css
                                  ^                         1: punctuation.section.function.end.bracket.round.css
                                   ^                        1: punctuation.terminator.rule.css
 
@@ -304,7 +304,7 @@ exports[`@import 1`] = `
                               ^^^^^^^^^                    1: support.constant.layer-name.css
                                        ^          ^        2: punctuation.section.function.end.bracket.round.css
                                          ^^^^^^            1: support.function.prefix.css
-                                                ^^         1: variable.other.css
+                                                ^^         1: variable.parameter.prefix.css
                                                    ^       1: punctuation.terminator.rule.css
 
 
@@ -401,7 +401,7 @@ exports[`@import 1`] = `
                         ^^^^^                              1: support.function.theme.css
                              ^      ^                      2: punctuation.section.function.begin.bracket.round.css
                               ^^^^^^                       1: support.function.prefix.css
-                                     ^^                    1: variable.other.css
+                                     ^^                    1: variable.parameter.prefix.css
                                        ^          ^        2: punctuation.section.function.end.bracket.round.css
                                          ^^^^^^^^^         1: support.constant.theme-option.css
                                                    ^       1: punctuation.terminator.rule.css
@@ -781,7 +781,7 @@ exports[`@theme 1`] = `
 ^                                      1: punctuation.definition.keyword.css
        ^^^^^^                          1: support.function.prefix.css
              ^                         1: punctuation.section.function.begin.bracket.round.css
-              ^^                       1: variable.other.css
+              ^^                       1: variable.parameter.prefix.css
                 ^                      1: punctuation.section.function.end.bracket.round.css
                   ^^^^^^               1: support.constant.theme-option.css
                          ^             1: meta.at-rule.theme.body.tailwind punctuation.section.theme.begin.bracket.curly.tailwind

--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -226,16 +226,17 @@ exports[`@import 1`] = `
                                                 ^          1: punctuation.terminator.rule.css
 
 @import './test.css' theme(prefix(tw) reference);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         13: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         17: source.css.tailwind meta.at-rule.import.css
 ^^^^^^^                                                    2: keyword.control.at-rule.import.css
 ^                                                          1: punctuation.definition.keyword.css
         ^^^^^^^^^^^^                                       3: string.quoted.single.css
         ^                                                  1: punctuation.definition.string.begin.css
                    ^                                       1: punctuation.definition.string.end.css
                      ^^^^^                                 1: support.function.theme.css
-                          ^                                1: punctuation.section.function.begin.bracket.round.css
-                           ^^^^^^^^^                       1: invalid.illegal.invalid-source.css
-                                    ^                      1: punctuation.section.function.end.bracket.round.css
+                          ^      ^                         2: punctuation.section.function.begin.bracket.round.css
+                           ^^^^^^                          1: support.function.prefix.css
+                                  ^^ ^^^^^^^^^^            3: variable.other.css
+                                    ^          ^           2: punctuation.section.function.end.bracket.round.css
                                                 ^          1: punctuation.terminator.rule.css
 
 @import './test.css' theme(default invalid reference);
@@ -380,16 +381,17 @@ exports[`@import 1`] = `
                                                    ^       1: punctuation.terminator.rule.css
 
 @reference './test.css' theme(prefix(tw) reference);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      13: source.css.tailwind meta.at-rule.import.css
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      17: source.css.tailwind meta.at-rule.import.css
 ^^^^^^^^^^                                                 2: keyword.control.at-rule.import.css
 ^                                                          1: punctuation.definition.keyword.css
            ^^^^^^^^^^^^                                    3: string.quoted.single.css
            ^                                               1: punctuation.definition.string.begin.css
                       ^                                    1: punctuation.definition.string.end.css
                         ^^^^^                              1: support.function.theme.css
-                             ^                             1: punctuation.section.function.begin.bracket.round.css
-                              ^^^^^^^^^                    1: invalid.illegal.invalid-source.css
-                                       ^                   1: punctuation.section.function.end.bracket.round.css
+                             ^      ^                      2: punctuation.section.function.begin.bracket.round.css
+                              ^^^^^^                       1: support.function.prefix.css
+                                     ^^ ^^^^^^^^^^         3: variable.other.css
+                                       ^          ^        2: punctuation.section.function.end.bracket.round.css
                                                    ^       1: punctuation.terminator.rule.css
 
 @reference './test.css' theme(default invalid reference);

--- a/packages/tailwindcss-language-syntax/tests/default-map.ts
+++ b/packages/tailwindcss-language-syntax/tests/default-map.ts
@@ -1,0 +1,20 @@
+/**
+ * A Map that can generate default values for keys that don't exist.
+ * Generated default values are added to the map to avoid recomputation.
+ */
+export class DefaultMap<T = string, V = any> extends Map<T, V> {
+  constructor(private factory: (key: T, self: DefaultMap<T, V>) => V) {
+    super()
+  }
+
+  get(key: T): V {
+    let value = super.get(key)
+
+    if (value === undefined) {
+      value = this.factory(key, this)
+      this.set(key, value)
+    }
+
+    return value
+  }
+}

--- a/packages/tailwindcss-language-syntax/tests/scopes.ts
+++ b/packages/tailwindcss-language-syntax/tests/scopes.ts
@@ -1,0 +1,41 @@
+export interface ScopeEntry {
+  content: Promise<{ default: object }>
+  inject: string[]
+}
+
+export const KNOWN_SCOPES: Record<string, ScopeEntry> = {
+  'source.css': {
+    content: import('../syntaxes/css.json'),
+    inject: [
+      'tailwindcss.at-rules.injection',
+      'tailwindcss.at-apply.injection',
+      'tailwindcss.theme-fn.injection',
+      'tailwindcss.screen-fn.injection',
+    ],
+  },
+
+  'source.css.tailwind': {
+    content: import('../../vscode-tailwindcss/syntaxes/source.css.tailwind.tmLanguage.json'),
+    inject: [],
+  },
+
+  'tailwindcss.at-apply.injection': {
+    content: import('../../vscode-tailwindcss/syntaxes/at-apply.tmLanguage.json'),
+    inject: [],
+  },
+
+  'tailwindcss.at-rules.injection': {
+    content: import('../../vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json'),
+    inject: [],
+  },
+
+  'tailwindcss.theme-fn.injection': {
+    content: import('../../vscode-tailwindcss/syntaxes/theme-fn.tmLanguage.json'),
+    inject: [],
+  },
+
+  'tailwindcss.screen-fn.injection': {
+    content: import('../../vscode-tailwindcss/syntaxes/screen-fn.tmLanguage.json'),
+    inject: [],
+  },
+}

--- a/packages/tailwindcss-language-syntax/tests/syntax.test.ts
+++ b/packages/tailwindcss-language-syntax/tests/syntax.test.ts
@@ -1,0 +1,282 @@
+import { test } from 'vitest'
+import dedent, { type Dedent } from 'dedent'
+import { loadGrammar } from './utils'
+
+const css: Dedent = dedent
+
+let grammar = await loadGrammar()
+
+test('@theme', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @theme {
+      --color: red;
+    }
+    @theme static {
+      --color: red;
+    }
+    @theme inline deprecated {
+      --color: red;
+    }
+    @theme prefix(tw) inline {
+      --color: red;
+    }
+
+    @theme {
+      --spacing: initial;
+      --color-*: initial;
+      --animate-pulse: 1s pulse infinite;
+
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 0;
+        }
+        50% {
+          opacity: 1;
+        }
+      }
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@import', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @import './test.css';
+
+    @import './test.css' prefix(tw);
+    @import './test.css' layer(utilities) prefix(tw);
+
+    @import './test.css' source(none);
+    @import './test.css' source('./foo');
+    @import './test.css' layer(utilities) source('./foo');
+
+    @import './test.css' theme(static);
+    @import './test.css' theme(static default inline);
+    @import './test.css' theme(reference deprecated);
+    @import './test.css' theme(prefix(tw) reference);
+    @import './test.css' theme(default invalid reference);
+
+    @reference './test.css';
+
+    @reference './test.css' prefix(tw);
+    @reference './test.css' layer(utilities) prefix(tw);
+
+    @reference './test.css' source(none);
+    @reference './test.css' source('./foo');
+    @reference './test.css' layer(utilities) source('./foo');
+
+    @reference './test.css' theme(static);
+    @reference './test.css' theme(static default inline);
+    @reference './test.css' theme(reference deprecated);
+    @reference './test.css' theme(prefix(tw) reference);
+    @reference './test.css' theme(default invalid reference);
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@plugin statement', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @plugin "./foo";
+    @plugin "./bar";
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@plugin with options', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @import 'tailwindcss';
+    @plugin "testing" {
+      color: red;
+    }
+
+    html,
+    body {
+      color: red;
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@config statement', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @config "./foo";
+    @config "./bar";
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@tailwind', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+    @tailwind utilities source(none);
+    @tailwind utilities source("./**/*");
+    @tailwind screens;
+    @tailwind variants;
+    @tailwind unknown;
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@source', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @source "./dir";
+    @source "./file.ts";
+    @source "./dir/**/file-{a,b}.ts";
+    @source not "./dir";
+    @source not "./file.ts";
+    @source not "./dir/**/file-{a,b}.ts";
+
+    @source inline("flex");
+    @source inline("flex bg-red-{50,{100..900..100},950}");
+    @source not inline("flex");
+    @source not inline("flex bg-red-{50,{100..900..100},950}");
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@layer', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @layer theme, base, components, utilities;
+    @layer utilities {
+      .custom {
+        width: 12px;
+      }
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@utility', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @utility custom {
+      width: 12px;
+    }
+
+    @utility functional-* {
+      width: calc(--value(number) * 1px);
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('--value(…)', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @utility functional-* {
+      width: --value(
+        --size,
+        'literal',
+        integer,
+        number,
+        percentage,
+        ratio,
+        [integer],
+        [number],
+        [percentage],
+        [ratio]
+      );
+
+      height: --modifier(
+        --size,
+        'literal',
+        integer,
+        number,
+        percentage,
+        ratio,
+        [integer],
+        [number],
+        [percentage],
+        [ratio]
+      );
+
+      color: --alpha(--value([color]) / --modifier(number));
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@variant', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @variant dark {
+      .foo {
+        color: white;
+      }
+    }
+
+    .bar {
+      @variant dark {
+        color: white;
+      }
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('@custom-variant', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @custom-variant dark (&:is(.dark, .dark *));
+    @custom-variant dark {
+      &:is(.dark, .dark *) {
+        @slot;
+      }
+    }
+    @custom-variant around {
+      color: '';
+      &::before,
+      &::after {
+        @slot;
+      }
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('legacy: @responsive', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @responsive {
+      .foo {
+        color: red;
+      }
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('legacy: @variants', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @variants hover, focus {
+      .foo {
+        color: red;
+      }
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})
+
+test('legacy: @screen', async ({ expect }) => {
+  let result = await grammar.tokenize(css`
+    @screen sm {
+      .foo {
+        color: red;
+      }
+    }
+  `)
+
+  expect(result.toString()).toMatchSnapshot()
+})

--- a/packages/tailwindcss-language-syntax/tests/utils.ts
+++ b/packages/tailwindcss-language-syntax/tests/utils.ts
@@ -1,0 +1,150 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import vsctm from 'vscode-textmate'
+import oniguruma from 'vscode-oniguruma'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { KNOWN_SCOPES } from './scopes'
+import { DefaultMap } from './default-map'
+
+const require = createRequire(import.meta.url)
+
+export interface TokenizeResult {
+  toString(): string
+}
+
+export interface TokenizedScope {
+  /**
+   * The name of the scope
+   */
+  name: string
+
+  /**
+   * An ordered list of ranges as they appear, one per token
+   */
+  ranges: [start: number, end: number][]
+}
+
+export interface Grammar {
+  tokenize(text: string, scope?: string): Promise<TokenizeResult>
+}
+
+// 1. Each line has a list of scopes
+// 2. Each scope has a set of ranges, one per token
+// 3. If two consecutive scopes have identical range lists they can be merged
+
+// @utility custom {
+// ^^^^^^^^^^^^^^^^^                     11 tok: source.css.tailwind
+// ^^^^^^^^                               2 tok: keyword.control.at-rule.utility.tailwind
+// ^                                      1 tok: punctuation.definition.keyword.css
+//          ^^^^^^                        6 tok: variable.parameter.utility.tailwind
+//                 ^                      1 tok: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
+
+function tokenizeText(grammar: vsctm.IGrammar, text: string): TokenizeResult {
+  let str = ''
+
+  let results: [string, vsctm.ITokenizeLineResult][] = []
+
+  let ruleStack = vsctm.INITIAL
+  let maxEndIndex = 0
+  for (let line of text.split(/\r\n|\r|\n/g)) {
+    let result = grammar.tokenizeLine(line, ruleStack)
+    ruleStack = result.ruleStack
+    maxEndIndex = Math.max(maxEndIndex, ...result.tokens.map((t) => t.endIndex))
+    results.push([line, result])
+  }
+
+  for (let [line, result] of results) {
+    // 1. Collect the scope information for this line
+    let scopes = new DefaultMap<string, TokenizedScope>((name) => ({ name, ranges: [] }))
+
+    for (let token of result.tokens) {
+      let range = [token.startIndex, token.endIndex] as [number, number]
+      for (let name of token.scopes) {
+        scopes.get(name).ranges.push(range)
+      }
+    }
+
+    let maxTokenCount = Math.max(...Array.from(scopes.values(), (s) => s.ranges.length))
+    let tokenCountSpace = Math.max(2, maxTokenCount.toString().length)
+
+    // 2. Write information to the output
+    str += '\n'
+    str += line
+
+    let lastRangeKey = ''
+
+    for (let scope of scopes.values()) {
+      let currentRangeKey = scope.ranges.map((r) => `${r[0]}:${r[1]}`).join(',')
+      if (lastRangeKey === currentRangeKey) {
+        str += ' '
+        str += scope.name
+        continue
+      }
+      lastRangeKey = currentRangeKey
+
+      str += '\n'
+
+      let lastRangeEnd = 0
+      for (let range of scope.ranges) {
+        str += ' '.repeat(range[0] - lastRangeEnd)
+        str += '^'.repeat(range[1] - range[0])
+        lastRangeEnd = range[1]
+      }
+      str += ' '.repeat(maxEndIndex - lastRangeEnd)
+
+      str += ' '
+      str += scope.ranges.length.toString().padStart(tokenCountSpace)
+      str += ': '
+      str += scope.name
+    }
+
+    str += '\n'
+  }
+
+  return {
+    toString: () => str,
+  }
+}
+
+export async function loadGrammar() {
+  let wasm = await readFile(require.resolve('vscode-oniguruma/release/onig.wasm'))
+  await oniguruma.loadWASM(wasm)
+
+  let registry = new vsctm.Registry({
+    onigLib: Promise.resolve({
+      createOnigScanner: (patterns) => new oniguruma.OnigScanner(patterns),
+      createOnigString: (s) => new oniguruma.OnigString(s),
+    }),
+
+    async loadGrammar(scope) {
+      let meta = KNOWN_SCOPES[scope]
+      if (!meta) throw new Error(`Unknown scope name: ${scope}`)
+
+      let grammar = await meta.content.then((m) => m.default)
+
+      return vsctm.parseRawGrammar(JSON.stringify(grammar), `${scope}.json`)
+    },
+
+    getInjections(scope) {
+      let parts = scope.split('.')
+
+      let injections: string[] = []
+      for (let i = 1; i <= parts.length; i++) {
+        let subscope = parts.slice(0, i).join('.')
+        injections.push(...(KNOWN_SCOPES[subscope]?.inject ?? []))
+      }
+
+      return injections
+    },
+  })
+
+  async function tokenize(text: string, scope?: string): Promise<TokenizeResult> {
+    let grammar = await registry.loadGrammar(scope ?? 'source.css.tailwind')
+    return tokenizeText(grammar, text)
+  }
+
+  return {
+    tokenize,
+  }
+}

--- a/packages/tailwindcss-language-syntax/tsconfig.json
+++ b/packages/tailwindcss-language-syntax/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "rootDir": "..",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".."
+  },
+  "include": ["tests"]
+}

--- a/packages/tailwindcss-language-syntax/vitest.config.ts
+++ b/packages/tailwindcss-language-syntax/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    testTimeout: 15000,
+  },
+})

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -204,7 +204,7 @@
           "name": "punctuation.definition.keyword.tailwind"
         }
       },
-      "end": ";",
+      "end": ";|(?=[@{])",
       "endCaptures": {
         "0": {
           "name": "punctuation.terminator.rule.css"

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -699,11 +699,11 @@
           "patterns": [
             {
               "match": "[a-z]+",
-              "name": "variable.other.css"
+              "name": "variable.parameter.prefix.css"
             },
             {
               "match": "[^a-z]+",
-              "name": "invalid.illegal.invalid-source.css"
+              "name": "invalid.illegal.prefix.css"
             }
           ]
         }

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -190,7 +190,55 @@
       "end": "(?<=}|;)(?!\\G)",
       "patterns": [
         {
-          "include": "source.css#rule-list"
+          "include": "#prefix-meta-fn"
+        },
+        {
+          "match": "\\s+",
+          "name": "variable.other.css"
+        },
+        {
+          "match": "reference",
+          "name": "variable.other.css"
+        },
+        {
+          "match": "inline",
+          "name": "variable.other.css"
+        },
+        {
+          "match": "static",
+          "name": "variable.other.css"
+        },
+        {
+          "match": "default",
+          "name": "variable.other.css"
+        },
+        {
+          "match": "deprecated",
+          "name": "variable.other.css"
+        },
+        {
+          "match": "[^{\\s]+",
+          "name": "invalid.illegal.invalid-theme.css"
+        },
+        {
+          "begin": "{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.theme.begin.bracket.curly.tailwind"
+            }
+          },
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.theme.end.bracket.curly.tailwind"
+            }
+          },
+          "name": "meta.at-rule.theme.body.tailwind",
+          "patterns": [
+            {
+              "include": "#property-list"
+            }
+          ]
         }
       ]
     },

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -306,6 +306,10 @@
           "name": "invalid.illegal.invalid-source.css"
         },
         {
+          "match": "not(?=\\s)",
+          "name": "support.constant.not.css"
+        },
+        {
           "include": "source.css#string"
         }
       ]

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -189,36 +189,10 @@
       },
       "end": "(?<=}|;)(?!\\G)",
       "patterns": [
-        {
-          "include": "#prefix-meta-fn"
-        },
-        {
-          "match": "\\s+",
-          "name": "variable.other.css"
-        },
-        {
-          "match": "reference",
-          "name": "variable.other.css"
-        },
-        {
-          "match": "inline",
-          "name": "variable.other.css"
-        },
-        {
-          "match": "static",
-          "name": "variable.other.css"
-        },
-        {
-          "match": "default",
-          "name": "variable.other.css"
-        },
-        {
-          "match": "deprecated",
-          "name": "variable.other.css"
-        },
+        { "include": "#theme-options" },
         {
           "match": "[^{\\s]+",
-          "name": "invalid.illegal.invalid-theme.css"
+          "name": "invalid.illegal.theme-option.css"
         },
         {
           "begin": "{",
@@ -646,6 +620,36 @@
         }
       ]
     },
+    "theme-options": {
+      "patterns": [
+        {
+          "match": "\\s+"
+        },
+        {
+          "match": "reference",
+          "name": "support.constant.theme-option.css"
+        },
+        {
+          "match": "inline",
+          "name": "support.constant.theme-option.css"
+        },
+        {
+          "match": "static",
+          "name": "support.constant.theme-option.css"
+        },
+        {
+          "match": "default",
+          "name": "support.constant.theme-option.css"
+        },
+        {
+          "match": "deprecated",
+          "name": "support.constant.theme-option.css"
+        },
+        {
+          "include": "#prefix-meta-fn"
+        }
+      ]
+    },
     "theme-meta-fn": {
       "patterns": [
         {
@@ -665,36 +669,10 @@
             }
           },
           "patterns": [
-            {
-              "match": "\\s+",
-              "name": "variable.other.css"
-            },
-            {
-              "match": "reference",
-              "name": "variable.other.css"
-            },
-            {
-              "match": "inline",
-              "name": "variable.other.css"
-            },
-            {
-              "match": "static",
-              "name": "variable.other.css"
-            },
-            {
-              "match": "default",
-              "name": "variable.other.css"
-            },
-            {
-              "match": "deprecated",
-              "name": "variable.other.css"
-            },
-            {
-              "include": "#prefix-meta-fn"
-            },
+            { "include": "#theme-options" },
             {
               "match": "[^)\\s]+",
-              "name": "invalid.illegal.invalid-source.css"
+              "name": "invalid.illegal.theme-option.css"
             }
           ]
         }

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -82,7 +82,7 @@
           "include": "#source-fn"
         },
         {
-          "match": "[^\\s;]+?",
+          "match": "[^\\s;]+",
           "name": "variable.parameter.tailwind.tailwind"
         }
       ]
@@ -103,7 +103,7 @@
           "include": "source.css#comment-block"
         },
         {
-          "match": "[^\\s{]+?",
+          "match": "[^\\s{]+",
           "name": "variable.parameter.screen.tailwind"
         },
         {
@@ -144,7 +144,7 @@
           "include": "source.css#comment-block"
         },
         {
-          "match": "[^\\s{;,]+?",
+          "match": "[^\\s{;,]+",
           "name": "variable.parameter.layer.tailwind"
         },
         {
@@ -351,7 +351,7 @@
           "include": "source.css#commas"
         },
         {
-          "match": "[^\\s{,]+?",
+          "match": "[^\\s{,]+",
           "name": "variable.parameter.variants.tailwind"
         },
         {
@@ -389,7 +389,7 @@
       "end": "(?<=})(?!\\G)",
       "patterns": [
         {
-          "match": "[^\\s{,]+?",
+          "match": "[^\\s{,]+",
           "name": "variable.parameter.utility.tailwind"
         },
         {
@@ -427,7 +427,7 @@
       "end": "(?<=[};])(?!\\G)",
       "patterns": [
         {
-          "match": "[^\\s({;,]+?",
+          "match": "[^\\s({;,]+",
           "name": "variable.parameter.variant.tailwind"
         },
         {

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -415,7 +415,7 @@
       ]
     },
     {
-      "begin": "(?i)((@)variant)(?=[\\s{(]|$)",
+      "begin": "(?i)((@)(?:custom-)?variant)(?=[\\s{(]|$)",
       "beginCaptures": {
         "1": {
           "name": "keyword.control.at-rule.variant.tailwind"

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -653,6 +653,9 @@
               "name": "variable.other.css"
             },
             {
+              "include": "#prefix-meta-fn"
+            },
+            {
               "match": "[^)\\s]+",
               "name": "invalid.illegal.invalid-source.css"
             }

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -408,7 +408,7 @@
           "name": "meta.at-rule.utility.body.tailwind",
           "patterns": [
             {
-              "include": "source.css#rule-list"
+              "include": "source.css#rule-list-innards"
             }
           ]
         }

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -311,6 +311,9 @@
         },
         {
           "include": "source.css#string"
+        },
+        {
+          "include": "#inline-fn"
         }
       ]
     },
@@ -608,6 +611,36 @@
             {
               "match": "\\s*([a-zA-Z][a-zA-Z0-9.]+|\\\\(?:[0-9a-fA-F]{1,6}))?\\s*",
               "name": "support.constant.layer-name.css"
+            }
+          ]
+        }
+      ]
+    },
+    "inline-fn": {
+      "patterns": [
+        {
+          "begin": "(?i)(?:\\s*)(?<![\\w@-])(inline)([(])",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.inline.css"
+            },
+            "2": {
+              "name": "punctuation.section.function.begin.bracket.round.css"
+            }
+          },
+          "end": "[)]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.function.end.bracket.round.css"
+            }
+          },
+          "patterns": [
+            {
+              "match": "none(?=[)])",
+              "name": "support.constant.none.css"
+            },
+            {
+              "include": "source.css#string"
             }
           ]
         }

--- a/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-rules.tmLanguage.json
@@ -605,7 +605,7 @@
               "name": "variable.other.css"
             },
             {
-              "match": "[^)]+",
+              "match": "[^)\\s]+",
               "name": "invalid.illegal.invalid-source.css"
             }
           ]

--- a/packages/vscode-tailwindcss/syntaxes/theme-fn.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/theme-fn.tmLanguage.json
@@ -1,7 +1,10 @@
 {
   "scopeName": "tailwindcss.theme-fn.injection",
   "fileTypes": [],
-  "injectionSelector": "L:meta.property-list.css -comment",
+  "injectionSelector": [
+    "L:meta.property-list.css -comment",
+    "L:meta.at-rule.utility.body.tailwind -comment"
+  ],
   "name": "TailwindCSS",
   "patterns": [
     {
@@ -55,6 +58,135 @@
           "name": "variable.parameter.screen.tailwind"
         }
       ]
+    },
+    {
+      "begin": "(?i)(?<![\\w-])(--alpha)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.alpha.tailwind"
+        },
+        "2": {
+          "name": "punctuation.section.function.begin.bracket.round.css"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.function.end.bracket.round.css"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.css#string"
+        },
+        {
+          "match": "[^\\s\\)]+",
+          "name": "variable.parameter.alpha.tailwind"
+        }
+      ]
+    },
+    {
+      "begin": "(?i)(?<![\\w-])(--value)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.value.tailwind"
+        },
+        "2": {
+          "name": "punctuation.section.function.begin.bracket.round.css"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.function.end.bracket.round.css"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#utility-helper-innards"
+        },
+        {
+          "match": "[^\\s\\)]+",
+          "name": "variable.parameter.value.tailwind"
+        }
+      ]
+    },
+    {
+      "begin": "(?i)(?<![\\w-])(--modifier)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.modifier.tailwind"
+        },
+        "2": {
+          "name": "punctuation.section.function.begin.bracket.round.css"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.function.end.bracket.round.css"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#utility-helper-innards"
+        },
+        {
+          "match": "[^\\s\\)]+",
+          "name": "variable.parameter.modifier.tailwind"
+        }
+      ]
     }
-  ]
+  ],
+  "repository": {
+    "utility-helper-innards": {
+      "patterns": [
+        { "match": "\\s+" },
+        {
+          "match": ",",
+          "name": "punctuation.separator.list.comma.css"
+        },
+        {
+          "match": "(--[^,\\s]+)",
+          "name": "variable.theme-namespace.css"
+        },
+        { "include": "#utility-data-type-bare" },
+        {
+          "begin": "\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.arbitrary.begin.bracket.square.css"
+            }
+          },
+          "end": "\\]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.arbitrary.end.bracket.square.css"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#utility-data-type-all"
+            }
+          ]
+        },
+        {
+          "include": "source.css#string"
+        }
+      ]
+    },
+    "utility-data-type-bare": {
+      "match": "(integer|number|percentage|ratio)",
+      "name": "support.constant.utility.data-type.css"
+    },
+    "utility-data-type-all": {
+      "patterns": [
+        { "include": "#utility-data-type-bare" },
+        {
+          "match": "(color|length|url|position|angle|vector)",
+          "name": "support.constant.utility.data-type.css"
+        }
+      ]
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,24 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9(@types/node@18.19.43)
 
+  packages/tailwindcss-language-syntax:
+    devDependencies:
+      '@types/node':
+        specifier: ^18.19.33
+        version: 18.19.43
+      dedent:
+        specifier: ^1.5.3
+        version: 1.5.3
+      vitest:
+        specifier: ^3.1.4
+        version: 3.1.4(@types/node@18.19.43)
+      vscode-oniguruma:
+        specifier: ^2.0.1
+        version: 2.0.1
+      vscode-textmate:
+        specifier: ^9.2.0
+        version: 9.2.0
+
   packages/vscode-tailwindcss:
     devDependencies:
       '@tailwindcss/language-server':
@@ -1148,8 +1166,22 @@ packages:
   '@vitest/expect@3.0.9':
     resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
 
+  '@vitest/expect@3.1.4':
+    resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
+
   '@vitest/mocker@3.0.9':
     resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@3.1.4':
+    resolution: {integrity: sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -1162,17 +1194,32 @@ packages:
   '@vitest/pretty-format@3.0.9':
     resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
 
+  '@vitest/pretty-format@3.1.4':
+    resolution: {integrity: sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==}
+
   '@vitest/runner@3.0.9':
     resolution: {integrity: sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==}
+
+  '@vitest/runner@3.1.4':
+    resolution: {integrity: sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==}
 
   '@vitest/snapshot@3.0.9':
     resolution: {integrity: sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==}
 
+  '@vitest/snapshot@3.1.4':
+    resolution: {integrity: sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==}
+
   '@vitest/spy@3.0.9':
     resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
 
+  '@vitest/spy@3.1.4':
+    resolution: {integrity: sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==}
+
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
+
+  '@vitest/utils@3.1.4':
+    resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
 
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
@@ -1554,6 +1601,9 @@ packages:
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild-node-externals@1.14.0:
     resolution: {integrity: sha512-jMWnTlCII3cLEjR5+u0JRSTJuP+MgbjEHKfwSIAI41NgLQ0ZjfzjchlbEn0r7v2u5gCBMSEYvYlkO7GDG8gG3A==}
     engines: {node: '>=12'}
@@ -1589,6 +1639,10 @@ packages:
     resolution: {integrity: sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==}
     engines: {node: '>=12.0.0'}
 
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
+
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -1601,6 +1655,14 @@ packages:
 
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.4.4:
+    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2484,6 +2546,9 @@ packages:
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2574,6 +2639,10 @@ packages:
 
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.13:
+    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.0.2:
@@ -2696,6 +2765,11 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-node@3.1.4:
+    resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@4.3.2:
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
@@ -2745,6 +2819,34 @@ packages:
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       '@vitest/browser': 3.0.9
       '@vitest/ui': 3.0.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.1.4:
+    resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.4
+      '@vitest/ui': 3.1.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2813,6 +2915,12 @@ packages:
   vscode-languageserver@8.1.0:
     resolution: {integrity: sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==}
     hasBin: true
+
+  vscode-oniguruma@2.0.1:
+    resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
+
+  vscode-textmate@9.2.0:
+    resolution: {integrity: sha512-rkvG4SraZQaPSN/5XjwKswdU0OP9MF28QjrYzUBbhb8QyG3ljB1Ky996m++jiI7KdiAP2CkBiQZd9pqEDTClqA==}
 
   vscode-uri@3.0.2:
     resolution: {integrity: sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==}
@@ -3388,9 +3496,24 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@3.1.4':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
   '@vitest/mocker@3.0.9(vite@5.4.14(@types/node@18.19.43))':
     dependencies:
       '@vitest/spy': 3.0.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.14(@types/node@18.19.43)
+
+  '@vitest/mocker@3.1.4(vite@5.4.14(@types/node@18.19.43))':
+    dependencies:
+      '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
@@ -3400,9 +3523,18 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.1.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@3.0.9':
     dependencies:
       '@vitest/utils': 3.0.9
+      pathe: 2.0.3
+
+  '@vitest/runner@3.1.4':
+    dependencies:
+      '@vitest/utils': 3.1.4
       pathe: 2.0.3
 
   '@vitest/snapshot@3.0.9':
@@ -3411,13 +3543,29 @@ snapshots:
       magic-string: 0.30.17
       pathe: 2.0.3
 
+  '@vitest/snapshot@3.1.4':
+    dependencies:
+      '@vitest/pretty-format': 3.1.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
   '@vitest/spy@3.0.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/spy@3.1.4':
     dependencies:
       tinyspy: 3.0.2
 
   '@vitest/utils@3.0.9':
     dependencies:
       '@vitest/pretty-format': 3.0.9
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.1.4':
+    dependencies:
+      '@vitest/pretty-format': 3.1.4
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -3807,6 +3955,8 @@ snapshots:
 
   es-module-lexer@1.6.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   esbuild-node-externals@1.14.0(esbuild@0.25.0):
     dependencies:
       esbuild: 0.25.0
@@ -3880,6 +4030,8 @@ snapshots:
 
   expect-type@1.2.0: {}
 
+  expect-type@1.2.1: {}
+
   fast-glob@3.3.2:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3897,6 +4049,10 @@ snapshots:
       pend: 1.2.0
 
   fdir@6.4.3(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
+  fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -4770,6 +4926,8 @@ snapshots:
 
   std-env@3.8.0: {}
 
+  std-env@3.9.0: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -4899,6 +5057,11 @@ snapshots:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.13:
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinypool@1.0.2: {}
 
   tinyrainbow@2.0.0: {}
@@ -5001,6 +5164,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.1.4(@types/node@18.19.43):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.14(@types/node@18.19.43)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@5.4.14(@types/node@18.19.43)):
     dependencies:
       debug: 4.3.6
@@ -5042,6 +5223,42 @@ snapshots:
       tinyrainbow: 2.0.0
       vite: 5.4.14(@types/node@18.19.43)
       vite-node: 3.0.9(@types/node@18.19.43)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.43
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.1.4(@types/node@18.19.43):
+    dependencies:
+      '@vitest/expect': 3.1.4
+      '@vitest/mocker': 3.1.4(vite@5.4.14(@types/node@18.19.43))
+      '@vitest/pretty-format': 3.1.4
+      '@vitest/runner': 3.1.4
+      '@vitest/snapshot': 3.1.4
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 5.4.14(@types/node@18.19.43)
+      vite-node: 3.1.4(@types/node@18.19.43)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.43
@@ -5109,6 +5326,10 @@ snapshots:
   vscode-languageserver@8.1.0:
     dependencies:
       vscode-languageserver-protocol: 3.17.3
+
+  vscode-oniguruma@2.0.1: {}
+
+  vscode-textmate@9.2.0: {}
 
   vscode-uri@3.0.2: {}
 


### PR DESCRIPTION
Fixes #1340
Fixes #1250

This PR is intended to improve syntax highlighting for CSS. Currently things like `@plugin` are not always handled right, declarations inside `@theme` may be incorrectly tokenized — or even not at all, etc…

**Proper nesting support will come in a separate PR**

The best way to test this is to:
- Clone the repo
- Run the extension in the dev host
- New file in the Tailwind CSS language mode
- Toss in a bunch of CSS (can look at the tests for lots of stuff)
