### PR TITLE
Don't register ability to hover, request colors, etc… more than once

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -174,6 +174,10 @@ export class TW {
       }
     }
 
+    if (results.some((result) => result.status === 'fulfilled')) {
+      await this.updateCommonCapabilities()
+    }
+
     await this.listenForEvents()
   }
 
@@ -628,8 +632,6 @@ export class TW {
 
     console.log(`[Global] Initializing projects...`)
 
-    await this.updateCommonCapabilities()
-
     // init projects for documents that are _already_ open
     let readyDocuments: string[] = []
     let enabledProjectCount = 0
@@ -896,6 +898,7 @@ export class TW {
       capabilities.add(DidChangeConfigurationNotification.type, undefined)
     }
 
+    this.commonRegistrations?.dispose()
     this.commonRegistrations = await this.connection.client.register(capabilities)
   }
 

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -941,6 +941,18 @@ export class TW {
 
     this.lastTriggerCharacters = chars
 
+    // TODO: This might technically be a race condition if:
+    // - There are multiple workspace roots
+    // - There are multiple projects with different separators
+    //
+    // Everything up to this point is synchronous including the bailout code
+    // so it *should* be fine
+    //
+    // The proper fix here is to:
+    // - Refactor workspace folder initialization so discovery, initialization,
+    //   file events, config watchers, etc… are all shared.
+    // - Remove the need for the "restart" concept in the server for as much as
+    //   possible. Each project should be capable of reloading its modules.
     this.completionRegistration?.dispose()
     this.completionRegistration = await this.connection.client.register(CompletionRequest.type, {
       documentSelector: null,


### PR DESCRIPTION
We're currently re-registering "common" capabilities per workspace folder. This causes VSCode to make multiple requests to the server for things like hover causing higher CPU usage. This then results multiple hovers being displayed. What's worse is that for some scenarios where the server has to internally do a restart the old registrations weren't getting disposed of because of a race condition when calling it concurrently for multiple folders.

I've done two things to address this:
- Common capability registration will only happen after all project folders have been initialized — hopefully this doesn't cause any problems (though if it does it's revealing a bigger underlying one)
- Common capabilities will be explicitly disposed before registering again

This should mean that this only happens one time per server initialization.

Fixes #1371
