### PR TITLE
Properly restart server when detecting new Tailwind CSS v4 configs

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -1133,7 +1133,7 @@ export class TW {
     this.commonRegistrations?.dispose()
     this.commonRegistrations = undefined
 
-    this.lastTriggerCharacters.clear()
+    this.lastTriggerCharacters?.clear()
     this.completionRegistration?.then((r) => r.dispose())
     this.completionRegistration = undefined
 

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Prerelease
 
 - Simplify completion details for border and outline utilities ([#1384](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1384))
+- Fix error initializing a new project when editing a CSS file ([#1387](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1387))
 
 # 0.14.19
 


### PR DESCRIPTION
In editors that use our language server directly (not our VSCode extension), if you start with a project with a CSS file that isn't a Tailwind CSS config then edit it we want the server to restart.

Unfortunately this was hitting an error causing the restart to fail but because of how things are set up this error isn't easily catchable (but it did get logged thankfully).

This fixes that error and turning a CSS file from a non-config into a proper Tailwind CSS v4 config should work and the server should react accordingly.