### PR TITLE
Fix high CPU usage when encountering non-file URI workspaces

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -122,14 +122,23 @@ export class TW {
     await this.initPromise
   }
 
+  private validateFolderUri(uri: URI): boolean {
+    if (uri.scheme !== 'file') {
+      console.warn(
+        `The workspace folder [${uri.toString()}] will be ignored: it does not use the file scheme.`,
+      )
+      return false
+    }
+
+    return true
+  }
+
   private getWorkspaceFolders(): WorkspaceFolder[] {
     if (this.initializeParams.workspaceFolders?.length) {
       return this.initializeParams.workspaceFolders.flatMap((folder) => {
         let uri = URI.parse(folder.uri)
-        if (uri.scheme !== 'file') {
-          console.warn(`Non-file workspace folder will be ignored: ${folder.uri}`)
-          return []
-        }
+
+        if (!this.validateFolderUri(uri)) return []
 
         return [
           {
@@ -143,10 +152,7 @@ export class TW {
     if (this.initializeParams.rootUri) {
       let uri = URI.parse(this.initializeParams.rootUri)
 
-      if (uri.scheme !== 'file') {
-        console.warn(`Non-file workspace folder will be ignored: ${uri.toString()}`)
-        return []
-      }
+      if (!this.validateFolderUri(uri)) return []
 
       return [
         {
@@ -157,9 +163,13 @@ export class TW {
     }
 
     if (this.initializeParams.rootPath) {
+      let uri = URI.file(this.initializeParams.rootPath)
+
+      if (!this.validateFolderUri(uri)) return []
+
       return [
         {
-          uri: URI.file(this.initializeParams.rootPath).fsPath,
+          uri: uri.fsPath,
           name: 'Root',
         },
       ]

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -995,6 +995,15 @@ export class TW {
     let matchedPriority: number = Infinity
 
     let uri = URI.parse(document.uri)
+
+    if (uri.scheme !== 'file') {
+      console.debug(`Cannot get project for a non-file document. They are unsupported.`, {
+        uri: uri.toString(),
+      })
+
+      return null
+    }
+
     let fsPath = uri.fsPath
     let normalPath = uri.path
 

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -124,16 +124,24 @@ export class TW {
 
   private getWorkspaceFolders(): WorkspaceFolder[] {
     if (this.initializeParams.workspaceFolders?.length) {
-      return this.initializeParams.workspaceFolders.map((folder) => ({
-        uri: URI.parse(folder.uri).fsPath,
-        name: folder.name,
-      }))
+      return this.initializeParams.workspaceFolders.flatMap((folder) => {
+        let uri = URI.parse(folder.uri)
+
+        return [
+          {
+            uri: uri.fsPath,
+            name: folder.name,
+          },
+        ]
+      })
     }
 
     if (this.initializeParams.rootUri) {
+      let uri = URI.parse(this.initializeParams.rootUri)
+
       return [
         {
-          uri: URI.parse(this.initializeParams.rootUri).fsPath,
+          uri: uri.fsPath,
           name: 'Root',
         },
       ]

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -130,6 +130,13 @@ export class TW {
       return false
     }
 
+    if (uri.fsPath === '/' || uri.fsPath === '\\\\') {
+      console.warn(
+        `The workspace folder [${uri.toString()}] will be ignored: it starts at the root of the filesystem which is most likely an error.`,
+      )
+      return false
+    }
+
     return true
   }
 

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -126,6 +126,10 @@ export class TW {
     if (this.initializeParams.workspaceFolders?.length) {
       return this.initializeParams.workspaceFolders.flatMap((folder) => {
         let uri = URI.parse(folder.uri)
+        if (uri.scheme !== 'file') {
+          console.warn(`Non-file workspace folder will be ignored: ${folder.uri}`)
+          return []
+        }
 
         return [
           {
@@ -138,6 +142,11 @@ export class TW {
 
     if (this.initializeParams.rootUri) {
       let uri = URI.parse(this.initializeParams.rootUri)
+
+      if (uri.scheme !== 'file') {
+        console.warn(`Non-file workspace folder will be ignored: ${uri.toString()}`)
+        return []
+      }
 
       return [
         {
@@ -155,6 +164,8 @@ export class TW {
         },
       ]
     }
+
+    console.warn(`No workspace folders detected`)
 
     return []
   }


### PR DESCRIPTION
Fixes #1394

There are two issues here:
- Non-file schemes were being treated as if they were `file://` URIs and we were getting their filesystem path when ends up being an empty string.
- Neovim, when opening a virtual file (e.g. `foo://bar.html`), causes the server to be initialized with a file URI of `file://.` and rootPath of `/.`. I'd expect them to use the `foo://` scheme but that does not happen. I think it's super reasonable to have the server refuse a workspace folder that _is_ the filesystem root. This check is definitely not exhaustive (may not handle network shares, arbitrary mounts, different drives on Windows, etc…) but this is probably "good enough" to detect this situation. 

Both of these results in the folder being treated as `/` and results in a file search from the root causing super high CPU usage. I've also added a check inside `getProject` so files with non-file schemes are ignored. They'll get a `fsPath` of empty string as well and as such won't match any project. The VSCode extension already does this at the extension level but we weren't doing it in the language server.