### PR TITLE
Improve stylesheet "root" detection

### DIFF
--- a/packages/tailwindcss-language-server/src/project-locator.test.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.test.ts
@@ -499,6 +499,38 @@ testLocator({
   ],
 })
 
+testLocator({
+  name: 'Stylesheets that import Tailwind CSS are picked over ones that dont',
+  fs: {
+    'a/foo.css': css`
+      @import './bar.css';
+      .a {
+        color: red;
+      }
+    `,
+    'a/bar.css': css`
+      .b {
+        color: red;
+      }
+    `,
+    'src/app.css': css`
+      @import 'tailwindcss';
+    `,
+  },
+  expected: [
+    {
+      version: '4.1.1 (bundled)',
+      config: '/src/app.css',
+      content: [],
+    },
+    {
+      version: '4.1.1 (bundled)',
+      config: '/a/foo.css',
+      content: [],
+    },
+  ],
+})
+
 // ---
 
 function testLocator({

--- a/packages/tailwindcss-language-server/src/project-locator.test.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.test.ts
@@ -532,6 +532,41 @@ testLocator({
 })
 
 testLocator({
+  name: 'Stylesheets that import Tailwind CSS indirectly are picked over ones that dont',
+  fs: {
+    'a/foo.css': css`
+      @import './bar.css';
+      .a {
+        color: red;
+      }
+    `,
+    'a/bar.css': css`
+      .b {
+        color: red;
+      }
+    `,
+    'src/app.css': css`
+      @import './tw.css';
+    `,
+    'src/tw.css': css`
+      @import 'tailwindcss';
+    `,
+  },
+  expected: [
+    {
+      version: '4.1.1 (bundled)',
+      config: '/src/app.css',
+      content: [],
+    },
+    {
+      version: '4.1.1 (bundled)',
+      config: '/a/foo.css',
+      content: [],
+    },
+  ],
+})
+
+testLocator({
   name: 'Stylesheets that only have URL imports are not considered roots',
   fs: {
     'a/fonts.css': css`

--- a/packages/tailwindcss-language-server/src/project-locator.test.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.test.ts
@@ -531,6 +531,28 @@ testLocator({
   ],
 })
 
+testLocator({
+  name: 'Stylesheets that only have URL imports are not considered roots',
+  fs: {
+    'a/fonts.css': css`
+      @import 'https://example.com/fonts/some-font.css';
+      .a {
+        color: red;
+      }
+    `,
+    'src/app.css': css`
+      @import 'tailwindcss';
+    `,
+  },
+  expected: [
+    {
+      version: '4.1.1 (bundled)',
+      config: '/src/app.css',
+      content: [],
+    },
+  ],
+})
+
 // ---
 
 function testLocator({

--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -729,7 +729,7 @@ class FileEntry {
    * Determine which Tailwind versions this file might be using
    */
   async resolvePossibleVersions() {
-    this.meta = this.content ? analyzeStylesheet(this.content) : null
+    this.meta ??= this.content ? analyzeStylesheet(this.content) : null
   }
 
   /**

--- a/packages/tailwindcss-language-server/src/project-locator.ts
+++ b/packages/tailwindcss-language-server/src/project-locator.ts
@@ -382,14 +382,18 @@ export class ProjectLocator {
     if (indexPath && themePath) graph.connect(indexPath, themePath)
     if (indexPath && utilitiesPath) graph.connect(indexPath, utilitiesPath)
 
-    // Sort the graph so potential "roots" appear first
-    // The entire concept of roots needs to be rethought because it's not always
-    // clear what the root of a project is. Even when imports are present a file
-    // may import a file that is the actual "root" of the project.
     let roots = Array.from(graph.roots())
 
     roots.sort((a, b) => {
-      return a.meta.root === b.meta.root ? 0 : a.meta.root ? -1 : 1
+      return (
+        // Sort the graph so potential "roots" appear first
+        // The entire concept of roots needs to be rethought because it's not always
+        // clear what the root of a project is. Even when imports are present a file
+        // may import a file that is the actual "root" of the project.
+        Number(b.meta.root) - Number(a.meta.root) ||
+        // Otherwise stylesheets are kept in discovery order
+        0
+      )
     })
 
     for (let root of roots) {

--- a/packages/tailwindcss-language-server/src/version-guesser.ts
+++ b/packages/tailwindcss-language-server/src/version-guesser.ts
@@ -10,6 +10,11 @@ export interface TailwindStylesheet {
    * The likely Tailwind version used by the given file
    */
   versions: TailwindVersion[]
+
+  /**
+   * Whether or not this stylesheet explicitly imports Tailwind CSS
+   */
+  explicitImport: boolean
 }
 
 // It's likely this is a v4 file if it has a v4 import:
@@ -60,6 +65,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
     return {
       root: true,
       versions: ['4'],
+      explicitImport: true,
     }
   }
 
@@ -71,6 +77,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
       return {
         root: true,
         versions: ['4'],
+        explicitImport: false,
       }
     }
 
@@ -78,6 +85,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
       // This file MUST be imported by another file to be a valid root
       root: false,
       versions: ['4'],
+      explicitImport: false,
     }
   }
 
@@ -87,6 +95,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
       // This file MUST be imported by another file to be a valid root
       root: false,
       versions: ['4'],
+      explicitImport: false,
     }
   }
 
@@ -96,6 +105,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
       // Roots are only a valid concept in v4
       root: false,
       versions: ['3'],
+      explicitImport: false,
     }
   }
 
@@ -104,6 +114,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
     return {
       root: true,
       versions: ['4', '3'],
+      explicitImport: false,
     }
   }
 
@@ -112,6 +123,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
     return {
       root: false,
       versions: ['4', '3'],
+      explicitImport: false,
     }
   }
 
@@ -120,6 +132,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
     return {
       root: true,
       versions: ['4', '3'],
+      explicitImport: false,
     }
   }
 
@@ -127,5 +140,6 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
   return {
     root: false,
     versions: [],
+    explicitImport: false,
   }
 }

--- a/packages/tailwindcss-language-server/src/version-guesser.ts
+++ b/packages/tailwindcss-language-server/src/version-guesser.ts
@@ -49,7 +49,8 @@ const HAS_TAILWIND = /@tailwind\s*[^;]+;/
 const HAS_COMMON_DIRECTIVE = /@(config|apply)\s*[^;{]+[;{]/
 
 // If it's got imports at all it could be either
-const HAS_IMPORT = /@import\s*['"]/
+// Note: We only care about non-url imports
+const HAS_NON_URL_IMPORT = /@import\s*['"](?!([a-z]+:|\/\/))/
 
 /**
  * Determine the likely Tailwind version used by the given file
@@ -128,7 +129,7 @@ export function analyzeStylesheet(content: string): TailwindStylesheet {
   }
 
   // Files that import other files could be either and are potentially roots
-  if (HAS_IMPORT.test(content)) {
+  if (HAS_NON_URL_IMPORT.test(content)) {
     return {
       root: true,
       versions: ['4', '3'],

--- a/packages/tailwindcss-language-service/src/util/rewriting/index.test.ts
+++ b/packages/tailwindcss-language-service/src/util/rewriting/index.test.ts
@@ -25,6 +25,7 @@ test('replacing CSS variables with their fallbacks (when they have them)', () =>
 
   let state: State = {
     enabled: true,
+    features: [],
     designSystem: {
       theme: { prefix: null } as any,
       resolveThemeValue: (name) => map.get(name) ?? null,
@@ -102,6 +103,7 @@ test('recursive theme replacements', () => {
 
   let state: State = {
     enabled: true,
+    features: [],
     designSystem: {
       theme: { prefix: null } as any,
       resolveThemeValue: (name) => map.get(name) ?? null,
@@ -142,6 +144,7 @@ test('recursive theme replacements (inlined)', () => {
 
   let state: State = {
     enabled: true,
+    features: [],
     designSystem: {
       theme: { prefix: null } as any,
       resolveThemeValue: (name) => map.get(name) ?? null,
@@ -184,6 +187,7 @@ test('Inlining calc expressions using the design system', () => {
 
   let state: State = {
     enabled: true,
+    features: [],
     designSystem: {
       theme: { prefix: null } as any,
       resolveThemeValue: (name) => map.get(name) ?? null,

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump bundled CSS language service ([#1395](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1395))
 - Fix infinite loop when resolving completion details with recursive theme keys ([#1400](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1400))
 - Simplify completion details for more utilities ([#1397](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1397))
+- Improve project stylesheet detection ([#1401](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1401))
 
 ## 0.14.20
 


### PR DESCRIPTION
Fixes #1388

There's two problems here:
- We consider any stylesheet with an `@import` a potential root. This includes *compiled* stylesheets that have URL imports to things like google fonts
- We consider all "roots" graphs equally instead of prioritizing ones that import Tailwind CSS.