### PR TITLE
Ensure color swatches show in completions when using a prefix

### DIFF
--- a/packages/tailwindcss-language-service/src/util/color.ts
+++ b/packages/tailwindcss-language-service/src/util/color.ts
@@ -216,6 +216,14 @@ export function getColor(state: State, className: string): culori.Color | Keywor
 
     let color = getColorFromRoot(state, css)
 
+    // TODO: Either all consumers of this API should assume there's no prefix
+    // or pass in correctly prefixed classes
+    if (state.designSystem.theme.prefix !== '' && !color) {
+      className = `${state.designSystem.theme.prefix}:${className}`
+      css = state.designSystem.compile([className])[0]
+      color = getColorFromRoot(state, css)
+    }
+
     return color
   }
 


### PR DESCRIPTION
Fixes #1421

Before:

<img width="937" alt="Screenshot 2025-07-07 at 10 38 10" src="https://github.com/user-attachments/assets/da008d37-4b81-4306-b86d-bb1a47df42b4" />


After:
<img width="959" alt="Screenshot 2025-07-07 at 10 37 24" src="https://github.com/user-attachments/assets/d9b536e0-d916-48b8-aeb0-3f4d621a460c" />
