### PR TITLE
Add `css-language-server` to binary list

### DIFF
--- a/packages/tailwindcss-language-server/package.json
+++ b/packages/tailwindcss-language-server/package.json
@@ -24,6 +24,7 @@
     "pretest": "node tests/prepare.mjs"
   },
   "bin": {
+    "css-language-server": "./bin/css-language-server",
     "tailwindcss-language-server": "./bin/tailwindcss-language-server"
   },
   "files": [

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Prerelease
 
-- Nothing yet!
+- Publish our fork of the CSS language server ([#1437](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1437))
 
 ## 0.14.26
 


### PR DESCRIPTION
This makes sure the binary is place into `node_modules/.bin`. Before you'd have to path into `node_modules/@tailwindcss/language-server/bin/css-language-server` to get access to it.

This was done on purpose originally as it's just a fork of VSCode's CSS language server + some additions and really was just to improve test coverage. I'd thought about possibly folding this functionality directly into the main language server so completions could eventually be a bit smarter but that's a larger effort (if it's even reasonable at all — no idea).

In the meantime it feels reasonable to me to mark this so it's treated as a binary by package managers.