### PR TITLE
Fix race condition when launching Oxide helper process

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -21,6 +21,9 @@ let ctx = await esbuild.context({
   platform: 'node',
   external: ['pnpapi', 'vscode', 'lightningcss', '@tailwindcss/oxide'],
   format: 'cjs',
+  define: {
+    'process.env.TEST': '0',
+  },
   outdir: args.outdir,
   outfile: args.outfile,
   minify: args.minify,

--- a/packages/tailwindcss-language-server/src/oxide-helper.ts
+++ b/packages/tailwindcss-language-server/src/oxide-helper.ts
@@ -10,5 +10,11 @@ let connection = rpc.createMessageConnection(
 
 let scanRequest = new rpc.RequestType<ScanOptions, ScanResult, void>('scan')
 connection.onRequest<ScanOptions, ScanResult, void>(scanRequest, (options) => scan(options))
-
 connection.listen()
+
+console.log('Listening for messages...')
+
+process.on('disconnect', () => {
+  console.log('Shutting down...')
+  process.exit(0)
+})

--- a/packages/tailwindcss-language-server/vitest.config.mts
+++ b/packages/tailwindcss-language-server/vitest.config.mts
@@ -8,6 +8,10 @@ export default defineConfig({
     silent: 'passed-only',
   },
 
+  define: {
+    'process.env.TEST': '1',
+  },
+
   plugins: [
     tsconfigPaths(),
     {

--- a/packages/tailwindcss-language-service/vitest.config.mts
+++ b/packages/tailwindcss-language-service/vitest.config.mts
@@ -5,4 +5,8 @@ export default defineConfig({
     testTimeout: 15000,
     silent: 'passed-only',
   },
+
+  define: {
+    'process.env.TEST': '1',
+  },
 })

--- a/packages/tailwindcss-language-syntax/vitest.config.mts
+++ b/packages/tailwindcss-language-syntax/vitest.config.mts
@@ -5,4 +5,8 @@ export default defineConfig({
     testTimeout: 15000,
     silent: 'passed-only',
   },
+
+  define: {
+    'process.env.TEST': '1',
+  },
 })


### PR DESCRIPTION
Fixes #1519

We were calling `startIfNeeded()` but it did async work before assigning the connection which means if scan() is called once per project the flow looks like this:
  Project 1-N: `scan()` -> `startIfNeeded()` -> check for existing connection -> `await … ` -> setup connection -> done
  
Since projects are loaded via `Promise.all(…)` every single one will run all the way up to the `await` call, wait, fork a process, setup an RPC connection, and overwrite the `this.helper` and `this.connection` properties. I think the additional processes would stick around because of closure scopes but not 100% sure about that as they should've otherwise been unreferenced.

This PR changes the setup in a few ways:
- The code that looks for the Oxide helper async is gone. The relative path is resolved at startup.
- We synchronously store a promise to the object containing details to access the helper process
- Most of the process is now synchronous with a small promise that waits for the process to become ready.
