### PR TITLE
feat: add fix-all canonical classes suggestion

### DIFF
--- a/packages/tailwindcss-language-service/src/codeActions/provideFixAllSuggestionCodeAction.ts
+++ b/packages/tailwindcss-language-service/src/codeActions/provideFixAllSuggestionCodeAction.ts
@@ -1,0 +1,35 @@
+import type { CodeAction, CodeActionParams } from 'vscode-languageserver'
+import type { SuggestCanonicalClassesDiagnostic } from '../diagnostics/types'
+import { dedupeByRange } from '../util/array'
+
+export const FIX_ALL_SUGGESTION_KIND = 'source.fixAll.tailwindcss'
+
+export function provideFixAllSuggestionCodeAction(
+  params: CodeActionParams,
+  diagnostics: SuggestCanonicalClassesDiagnostic[],
+  kind: string = FIX_ALL_SUGGESTION_KIND,
+  title: string = 'Fix all canonical class suggestions',
+): CodeAction[] {
+  let edits = dedupeByRange(
+    diagnostics
+      .filter((diagnostic) => diagnostic.suggestions.length > 0)
+      .map((diagnostic) => ({
+        range: diagnostic.range,
+        newText: diagnostic.suggestions[0],
+      })),
+  )
+
+  if (edits.length === 0) return []
+
+  return [
+    {
+      title,
+      kind,
+      edit: {
+        changes: {
+          [params.textDocument.uri]: edits,
+        },
+      },
+    },
+  ]
+}


### PR DESCRIPTION
### Goal of PR
Add a fix-all canonical classes suggestions quick code action, as manually going through and applying all suggestions can be quite mundane on large codebases.

As requested in: [#19323](https://github.com/tailwindlabs/tailwindcss/discussions/19323)

### Example
Added quick-fix item:
<img width="555" height="106" alt="image" src="https://github.com/user-attachments/assets/08c3fa2e-ae27-4841-ac1a-57f404d84fa5" />
