### PR TITLE
Simplify document class list detection

### DIFF
--- a/packages/tailwindcss-language-service/src/diagnostics/canonical-classes.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/canonical-classes.ts
@@ -3,11 +3,11 @@ import type { State, Settings } from '../util/state'
 import { type SuggestCanonicalClassesDiagnostic, DiagnosticKind } from './types'
 import { findClassListsInDocument, getClassNamesInClassList } from '../util/find'
 
-export async function getSuggestCanonicalClassesDiagnostics(
+export function getSuggestCanonicalClassesDiagnostics(
   state: State,
   document: TextDocument,
   settings: Settings,
-): Promise<SuggestCanonicalClassesDiagnostic[]> {
+): SuggestCanonicalClassesDiagnostic[] {
   if (!state.v4) return []
   if (!state.designSystem.canonicalizeCandidates) return []
 
@@ -16,7 +16,7 @@ export async function getSuggestCanonicalClassesDiagnostics(
 
   let diagnostics: SuggestCanonicalClassesDiagnostic[] = []
 
-  let classLists = await findClassListsInDocument(state, document)
+  let classLists = findClassListsInDocument(state, document, settings)
 
   for (let classList of classLists) {
     let classNames = getClassNamesInClassList(classList, [])

--- a/packages/tailwindcss-language-service/src/diagnostics/diagnosticsProvider.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/diagnosticsProvider.ts
@@ -33,10 +33,10 @@ export async function doValidate(
   return settings.tailwindCSS.validate
     ? [
         ...(only.includes(DiagnosticKind.CssConflict)
-          ? await getCssConflictDiagnostics(state, document, settings)
+          ? getCssConflictDiagnostics(state, document, settings)
           : []),
         ...(only.includes(DiagnosticKind.InvalidApply)
-          ? await getInvalidApplyDiagnostics(state, document, settings)
+          ? getInvalidApplyDiagnostics(state, document, settings)
           : []),
         ...(only.includes(DiagnosticKind.InvalidScreen)
           ? getInvalidScreenDiagnostics(state, document, settings)
@@ -54,13 +54,13 @@ export async function doValidate(
           ? getInvalidSourceDiagnostics(state, document, settings)
           : []),
         ...(only.includes(DiagnosticKind.RecommendedVariantOrder)
-          ? await getRecommendedVariantOrderDiagnostics(state, document, settings)
+          ? getRecommendedVariantOrderDiagnostics(state, document, settings)
           : []),
         ...(only.includes(DiagnosticKind.UsedBlocklistedClass)
-          ? await getUsedBlocklistedClassDiagnostics(state, document, settings)
+          ? getUsedBlocklistedClassDiagnostics(state, document, settings)
           : []),
         ...(only.includes(DiagnosticKind.SuggestCanonicalClasses)
-          ? await getSuggestCanonicalClassesDiagnostics(state, document, settings)
+          ? getSuggestCanonicalClassesDiagnostics(state, document, settings)
           : []),
       ]
     : []

--- a/packages/tailwindcss-language-service/src/diagnostics/getCssConflictDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getCssConflictDiagnostics.ts
@@ -41,16 +41,16 @@ function getRuleProperties(rule: Rule): string[] {
   return properties
 }
 
-export async function getCssConflictDiagnostics(
+export function getCssConflictDiagnostics(
   state: State,
   document: TextDocument,
   settings: Settings,
-): Promise<CssConflictDiagnostic[]> {
+): CssConflictDiagnostic[] {
   let severity = settings.tailwindCSS.lint.cssConflict
   if (severity === 'ignore') return []
 
   let diagnostics: CssConflictDiagnostic[] = []
-  const classLists = await findClassListsInDocument(state, document)
+  const classLists = findClassListsInDocument(state, document, settings)
 
   classLists.forEach((classList) => {
     const classNames = getClassNamesInClassList(classList, state.blocklist)

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidApplyDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidApplyDiagnostics.ts
@@ -5,16 +5,16 @@ import type { Settings, State } from '../util/state'
 import { validateApply } from '../util/validateApply'
 import { isCssDoc } from '../util/css'
 
-export async function getInvalidApplyDiagnostics(
+export function getInvalidApplyDiagnostics(
   state: State,
   document: TextDocument,
   settings: Settings,
-): Promise<InvalidApplyDiagnostic[]> {
+): InvalidApplyDiagnostic[] {
   let severity = settings.tailwindCSS.lint.invalidApply
   if (severity === 'ignore') return []
   if (!isCssDoc(state, document)) return []
 
-  const classLists = await findClassListsInDocument(state, document)
+  const classLists = findClassListsInDocument(state, document, settings)
   const classNames = classLists.flatMap((classList) =>
     getClassNamesInClassList(classList, state.blocklist),
   )

--- a/packages/tailwindcss-language-service/src/diagnostics/getInvalidApplyDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getInvalidApplyDiagnostics.ts
@@ -1,8 +1,9 @@
 import type { TextDocument } from 'vscode-languageserver-textdocument'
-import { findClassNamesInRange } from '../util/find'
+import { findClassListsInDocument, getClassNamesInClassList } from '../util/find'
 import { type InvalidApplyDiagnostic, DiagnosticKind } from './types'
 import type { Settings, State } from '../util/state'
 import { validateApply } from '../util/validateApply'
+import { isCssDoc } from '../util/css'
 
 export async function getInvalidApplyDiagnostics(
   state: State,
@@ -11,8 +12,12 @@ export async function getInvalidApplyDiagnostics(
 ): Promise<InvalidApplyDiagnostic[]> {
   let severity = settings.tailwindCSS.lint.invalidApply
   if (severity === 'ignore') return []
+  if (!isCssDoc(state, document)) return []
 
-  const classNames = await findClassNamesInRange(state, document, undefined, 'css', false)
+  const classLists = await findClassListsInDocument(state, document)
+  const classNames = classLists.flatMap((classList) =>
+    getClassNamesInClassList(classList, state.blocklist),
+  )
 
   let diagnostics: InvalidApplyDiagnostic[] = classNames.map((className) => {
     let result = validateApply(state, className.className)

--- a/packages/tailwindcss-language-service/src/diagnostics/getRecommendedVariantOrderDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getRecommendedVariantOrderDiagnostics.ts
@@ -7,11 +7,11 @@ import { getVariantsFromClassName } from '../util/getVariantsFromClassName'
 import { equalExact } from '../util/array'
 import * as semver from '../util/semver'
 
-export async function getRecommendedVariantOrderDiagnostics(
+export function getRecommendedVariantOrderDiagnostics(
   state: State,
   document: TextDocument,
   settings: Settings,
-): Promise<RecommendedVariantOrderDiagnostic[]> {
+): RecommendedVariantOrderDiagnostic[] {
   if (state.v4) return []
   if (!state.jit) return []
 
@@ -21,7 +21,7 @@ export async function getRecommendedVariantOrderDiagnostics(
   if (severity === 'ignore') return []
 
   let diagnostics: RecommendedVariantOrderDiagnostic[] = []
-  const classLists = await findClassListsInDocument(state, document)
+  const classLists = findClassListsInDocument(state, document, settings)
 
   classLists.forEach((classList) => {
     const classNames = getClassNamesInClassList(classList, state.blocklist)

--- a/packages/tailwindcss-language-service/src/diagnostics/getUsedBlocklistedClassDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getUsedBlocklistedClassDiagnostics.ts
@@ -3,11 +3,11 @@ import type { State, Settings } from '../util/state'
 import { type UsedBlocklistedClassDiagnostic, DiagnosticKind } from './types'
 import { findClassListsInDocument, getClassNamesInClassList } from '../util/find'
 
-export async function getUsedBlocklistedClassDiagnostics(
+export function getUsedBlocklistedClassDiagnostics(
   state: State,
   document: TextDocument,
   settings: Settings,
-): Promise<UsedBlocklistedClassDiagnostic[]> {
+): UsedBlocklistedClassDiagnostic[] {
   if (!state.v4) return []
   if (!state.blocklist?.length) return []
 
@@ -17,7 +17,7 @@ export async function getUsedBlocklistedClassDiagnostics(
   let blocklist = new Set(state.blocklist ?? [])
   let diagnostics: UsedBlocklistedClassDiagnostic[] = []
 
-  let classLists = await findClassListsInDocument(state, document)
+  let classLists = findClassListsInDocument(state, document, settings)
 
   for (let classList of classLists) {
     let classNames = getClassNamesInClassList(classList, [])

--- a/packages/tailwindcss-language-service/src/documentColorProvider.ts
+++ b/packages/tailwindcss-language-service/src/documentColorProvider.ts
@@ -21,7 +21,7 @@ export async function getDocumentColors(
   let settings = await state.editor.getConfiguration(document.uri)
   if (settings.tailwindCSS.colorDecorators === false) return colors
 
-  let classLists = await findClassListsInDocument(state, document)
+  let classLists = findClassListsInDocument(state, document, settings)
   classLists.forEach((classList) => {
     let classNames = getClassNamesInClassList(classList, state.blocklist)
     classNames.forEach((className) => {

--- a/packages/tailwindcss-language-service/src/hoverProvider.ts
+++ b/packages/tailwindcss-language-service/src/hoverProvider.ts
@@ -6,7 +6,7 @@ import { isCssContext } from './util/css'
 import {
   findAll,
   findClassNameAtPosition,
-  findHelperFunctionsInRange,
+  findHelperFunctionsInDocument,
   indexToPosition,
 } from './util/find'
 import { validateApply } from './util/validateApply'
@@ -46,10 +46,7 @@ async function provideCssHelperHover(
 
   const settings = await state.editor.getConfiguration(document.uri)
 
-  let helperFns = findHelperFunctionsInRange(document, {
-    start: { line: position.line, character: 0 },
-    end: { line: position.line + 1, character: 0 },
-  })
+  let helperFns = findHelperFunctionsInDocument(state, document)
 
   for (let helperFn of helperFns) {
     if (!isWithinRange(position, helperFn.ranges.path)) continue

--- a/packages/tailwindcss-language-service/src/hoverProvider.ts
+++ b/packages/tailwindcss-language-service/src/hoverProvider.ts
@@ -1,4 +1,4 @@
-import type { State } from './util/state'
+import type { Settings, State } from './util/state'
 import type { Hover, MarkupContent, Position, Range } from 'vscode-languageserver'
 import { stringifyCss, stringifyConfigValue } from './util/stringify'
 import dlv from 'dlv'
@@ -94,7 +94,8 @@ async function provideClassNameHover(
   document: TextDocument,
   position: Position,
 ): Promise<Hover> {
-  let className = await findClassNameAtPosition(state, document, position)
+  let settings = await state.editor.getConfiguration(document.uri)
+  let className = findClassNameAtPosition(state, document, settings, position)
   if (className === null) return null
 
   if (state.v4) {
@@ -135,8 +136,6 @@ async function provideClassNameHover(
       return null
     }
   }
-
-  const settings = await state.editor.getConfiguration(document.uri)
 
   const css = stringifyCss(
     className.className,

--- a/packages/tailwindcss-language-service/src/util/doc.ts
+++ b/packages/tailwindcss-language-service/src/util/doc.ts
@@ -5,19 +5,19 @@ import { spliceChangesIntoString, StringChange } from './splice-changes-into-str
 
 export function getTextWithoutComments(
   doc: TextDocument,
-  type: 'html' | 'js' | 'jsx' | 'css',
+  type: 'html' | 'js' | 'css',
   range?: Range,
 ): string
-export function getTextWithoutComments(text: string, type: 'html' | 'js' | 'jsx' | 'css'): string
+export function getTextWithoutComments(text: string, type: 'html' | 'js' | 'css'): string
 
 export function getTextWithoutComments(
   docOrText: TextDocument | string,
-  type: 'html' | 'js' | 'jsx' | 'css',
+  type: 'html' | 'js' | 'css',
   range?: Range,
 ): string {
   let text = typeof docOrText === 'string' ? docOrText : docOrText.getText(range)
 
-  if (type === 'js' || type === 'jsx') {
+  if (type === 'js') {
     return getJsWithoutComments(text)
   }
 

--- a/packages/tailwindcss-language-service/src/util/find.test.ts
+++ b/packages/tailwindcss-language-service/src/util/find.test.ts
@@ -104,8 +104,34 @@ test('find class lists in functions', async ({ expect }) => {
     `,
   })
 
+  let fileC = createDocument({
+    name: 'file.jsx',
+    lang: 'javascriptreact',
+    settings: {
+      tailwindCSS: {
+        classFunctions: ['clsx', 'cva'],
+      },
+    },
+    content: js`
+      // These should not match (commented)
+      // let classes = clsx(
+      //   'flex p-4',
+      //   'block sm:p-0',
+      //   Date.now() > 100 ? 'text-white' : 'text-black',
+      // )
+
+      // These should not match (commented)
+      // let classes = cva(
+      //   'flex p-4',
+      //   'block sm:p-0',
+      //   Date.now() > 100 ? 'text-white' : 'text-black',
+      // )
+    `,
+  })
+
   let classListsA = await findClassListsInDocument(fileA.state, fileA.doc)
   let classListsB = await findClassListsInDocument(fileB.state, fileB.doc)
+  let classListsC = await findClassListsInDocument(fileC.state, fileC.doc)
 
   expect(classListsA).toEqual([
     // from clsx(…)
@@ -171,6 +197,9 @@ test('find class lists in functions', async ({ expect }) => {
 
   // none from cn(…) since it's not in the list of class functions
   expect(classListsB).toEqual([])
+
+  // none from commented code
+  expect(classListsC).toEqual([])
 })
 
 test('find class lists in nested fn calls', async ({ expect }) => {

--- a/packages/tailwindcss-language-service/src/util/find.test.ts
+++ b/packages/tailwindcss-language-service/src/util/find.test.ts
@@ -847,7 +847,7 @@ test('Can find class name inside JS/TS functions in <script> tags (HTML)', async
     `,
   })
 
-  let className = await findClassNameAtPosition(file.state, file.doc, {
+  let className = findClassNameAtPosition(file.state, file.doc, file.settings, {
     line: 1,
     character: 23,
   })
@@ -889,7 +889,7 @@ test('Can find class name inside JS/TS functions in <script> tags (Svelte)', asy
     `,
   })
 
-  let className = await findClassNameAtPosition(file.state, file.doc, {
+  let className = findClassNameAtPosition(file.state, file.doc, file.settings, {
     line: 1,
     character: 23,
   })

--- a/packages/tailwindcss-language-service/src/util/find.test.ts
+++ b/packages/tailwindcss-language-service/src/util/find.test.ts
@@ -34,7 +34,7 @@ test('class regex works in astro', async ({ expect }) => {
     ],
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -129,9 +129,9 @@ test('find class lists in functions', async ({ expect }) => {
     `,
   })
 
-  let classListsA = await findClassListsInDocument(fileA.state, fileA.doc)
-  let classListsB = await findClassListsInDocument(fileB.state, fileB.doc)
-  let classListsC = await findClassListsInDocument(fileC.state, fileC.doc)
+  let classListsA = findClassListsInDocument(fileA.state, fileA.doc, fileA.settings)
+  let classListsB = findClassListsInDocument(fileB.state, fileB.doc, fileB.settings)
+  let classListsC = findClassListsInDocument(fileC.state, fileC.doc, fileC.settings)
 
   expect(classListsA).toEqual([
     // from clsx(…)
@@ -243,7 +243,7 @@ test('find class lists in nested fn calls', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toMatchObject([
     {
@@ -345,7 +345,7 @@ test('find class lists in nested fn calls (only nested matches)', async ({ expec
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toMatchObject([
     {
@@ -408,8 +408,8 @@ test('find class lists in tagged template literals', async ({ expect }) => {
     `,
   })
 
-  let classListsA = await findClassListsInDocument(fileA.state, fileA.doc)
-  let classListsB = await findClassListsInDocument(fileB.state, fileB.doc)
+  let classListsA = findClassListsInDocument(fileA.state, fileA.doc, fileA.settings)
+  let classListsB = findClassListsInDocument(fileB.state, fileB.doc, fileB.settings)
 
   expect(classListsA).toEqual([
     // from clsx`…`
@@ -490,8 +490,8 @@ test('classFunctions can be a regex', async ({ expect }) => {
     `,
   })
 
-  let classListsA = await findClassListsInDocument(fileA.state, fileA.doc)
-  let classListsB = await findClassListsInDocument(fileB.state, fileB.doc)
+  let classListsA = findClassListsInDocument(fileA.state, fileA.doc, fileA.settings)
+  let classListsB = findClassListsInDocument(fileB.state, fileB.doc, fileB.settings)
 
   expect(classListsA).toEqual([
     {
@@ -523,7 +523,7 @@ test('classFunctions regexes only match on function names', async ({ expect }) =
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([])
 })
@@ -546,7 +546,7 @@ test('Finds consecutive instances of a class function', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -609,7 +609,7 @@ test('classFunctions & classAttributes should not duplicate matches', async ({ e
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -688,7 +688,7 @@ test('classFunctions should only match in JS-like contexts', async ({ expect }) 
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -748,7 +748,7 @@ test('classAttributes find class lists inside variables in JS(X)/TS(X)', async (
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -789,7 +789,7 @@ test('classAttributes find class lists inside pug', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -818,7 +818,7 @@ test('classAttributes find class lists inside Vue bindings', async ({ expect }) 
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -1137,7 +1137,7 @@ test('class functions work inside astro code fences', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {
@@ -1173,7 +1173,7 @@ test('classFunctions are detected inside of arrays in javascript just after open
     `,
   })
 
-  let classLists = await findClassListsInDocument(file.state, file.doc)
+  let classLists = findClassListsInDocument(file.state, file.doc, file.settings)
 
   expect(classLists).toEqual([
     {

--- a/packages/tailwindcss-language-service/src/util/find.test.ts
+++ b/packages/tailwindcss-language-service/src/util/find.test.ts
@@ -1114,15 +1114,15 @@ test('class functions work inside astro code fences', async ({ expect }) => {
     {
       classList: 'relative flex bg-red-500',
       range: {
-        start: { line: 3, character: 12 },
-        end: { line: 3, character: 36 },
+        start: { line: 1, character: 14 },
+        end: { line: 1, character: 38 },
       },
     },
     {
       classList: 'relative flex bg-red-500',
       range: {
-        start: { line: 1, character: 14 },
-        end: { line: 1, character: 38 },
+        start: { line: 3, character: 12 },
+        end: { line: 3, character: 36 },
       },
     },
   ])

--- a/packages/tailwindcss-language-service/src/util/find.test.ts
+++ b/packages/tailwindcss-language-service/src/util/find.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import {
-  findClassListsInHtmlRange,
+  findClassListsInDocument,
   findClassNameAtPosition,
   findHelperFunctionsInDocument,
 } from './find'
@@ -34,7 +34,7 @@ test('class regex works in astro', async ({ expect }) => {
     ],
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'html')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -104,8 +104,8 @@ test('find class lists in functions', async ({ expect }) => {
     `,
   })
 
-  let classListsA = await findClassListsInHtmlRange(fileA.state, fileA.doc, 'js')
-  let classListsB = await findClassListsInHtmlRange(fileB.state, fileB.doc, 'js')
+  let classListsA = await findClassListsInDocument(fileA.state, fileA.doc)
+  let classListsB = await findClassListsInDocument(fileB.state, fileB.doc)
 
   expect(classListsA).toEqual([
     // from clsx(…)
@@ -214,7 +214,7 @@ test('find class lists in nested fn calls', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'html')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toMatchObject([
     {
@@ -316,7 +316,7 @@ test('find class lists in nested fn calls (only nested matches)', async ({ expec
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'html')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toMatchObject([
     {
@@ -379,8 +379,8 @@ test('find class lists in tagged template literals', async ({ expect }) => {
     `,
   })
 
-  let classListsA = await findClassListsInHtmlRange(fileA.state, fileA.doc, 'js')
-  let classListsB = await findClassListsInHtmlRange(fileB.state, fileB.doc, 'js')
+  let classListsA = await findClassListsInDocument(fileA.state, fileA.doc)
+  let classListsB = await findClassListsInDocument(fileB.state, fileB.doc)
 
   expect(classListsA).toEqual([
     // from clsx`…`
@@ -461,8 +461,8 @@ test('classFunctions can be a regex', async ({ expect }) => {
     `,
   })
 
-  let classListsA = await findClassListsInHtmlRange(fileA.state, fileA.doc, 'js')
-  let classListsB = await findClassListsInHtmlRange(fileB.state, fileB.doc, 'js')
+  let classListsA = await findClassListsInDocument(fileA.state, fileA.doc)
+  let classListsB = await findClassListsInDocument(fileB.state, fileB.doc)
 
   expect(classListsA).toEqual([
     {
@@ -494,7 +494,7 @@ test('classFunctions regexes only match on function names', async ({ expect }) =
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([])
 })
@@ -517,7 +517,7 @@ test('Finds consecutive instances of a class function', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -580,7 +580,7 @@ test('classFunctions & classAttributes should not duplicate matches', async ({ e
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -659,7 +659,7 @@ test('classFunctions should only match in JS-like contexts', async ({ expect }) 
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -719,7 +719,7 @@ test('classAttributes find class lists inside variables in JS(X)/TS(X)', async (
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -760,7 +760,7 @@ test('classAttributes find class lists inside pug', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -789,7 +789,7 @@ test('classAttributes find class lists inside Vue bindings', async ({ expect }) 
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -1108,7 +1108,7 @@ test('class functions work inside astro code fences', async ({ expect }) => {
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'html')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {
@@ -1144,7 +1144,7 @@ test('classFunctions are detected inside of arrays in javascript just after open
     `,
   })
 
-  let classLists = await findClassListsInHtmlRange(file.state, file.doc, 'js')
+  let classLists = await findClassListsInDocument(file.state, file.doc)
 
   expect(classLists).toEqual([
     {

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -49,10 +49,10 @@ const BY_ASCII_WHITESPACE = /([\t\n\f\r ]+)/
  *
  * The CSS spec also effectively uses the above definition for whitespace.
  *
- * @see {@link https://dom.spec.whatwg.org/#concept-getelementsbyclassname}
- * @see {@link https://dom.spec.whatwg.org/#concept-ordered-set-parser}
- * @see {@link https://infra.spec.whatwg.org/#ascii-whitespace}
- * @see {@link https://www.w3.org/TR/css-syntax-3/#whitespace}
+ * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
+ * @see https://dom.spec.whatwg.org/#concept-ordered-set-parser
+ * @see https://infra.spec.whatwg.org/#ascii-whitespace
+ * @see https://www.w3.org/TR/css-syntax-3/#whitespace
  */
 export function getClassNamesInClassList(
   classList: DocumentClassList,

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -282,15 +282,14 @@ function findClassListsInHtmlRange(
   return results
 }
 
-export async function findClassListsInDocument(
+export function findClassListsInDocument(
   state: State,
   doc: TextDocument,
-): Promise<DocumentClassList[]> {
+  settings: Settings,
+): DocumentClassList[] {
   if (isCssDoc(state, doc)) {
     return findClassListsInCssRange(state, doc)
   }
-
-  let settings = await state.editor.getConfiguration(doc.uri)
 
   let classLists: DocumentClassList[] = []
 
@@ -546,7 +545,8 @@ export async function findClassNameAtPosition(
   doc: TextDocument,
   position: Position,
 ): Promise<DocumentClassName> {
-  let classLists = await findClassListsInDocument(state, doc)
+  let settings = await state.editor.getConfiguration(doc.uri)
+  let classLists = findClassListsInDocument(state, doc, settings)
   let classNames = classLists.flatMap((classList) =>
     getClassNamesInClassList(classList, state.blocklist),
   )

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -540,12 +540,12 @@ export function indexToPosition(str: string, index: number): Position {
   return { line: line - 1, character: col - 1 }
 }
 
-export async function findClassNameAtPosition(
+export function findClassNameAtPosition(
   state: State,
   doc: TextDocument,
+  settings: Settings,
   position: Position,
-): Promise<DocumentClassName> {
-  let settings = await state.editor.getConfiguration(doc.uri)
+): DocumentClassName {
   let classLists = findClassListsInDocument(state, doc, settings)
   let classNames = classLists.flatMap((classList) =>
     getClassNamesInClassList(classList, state.blocklist),

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -225,6 +225,8 @@ export async function findClassListsInHtmlRange(
   const existingResultSet = new Set<string>()
   const results: DocumentClassList[] = []
 
+  matches.sort((a, b) => a.index - b.index)
+
   matches.forEach((match) => {
     const subtext = text.substr(match.index + match[0].length - 1)
 

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -108,19 +108,11 @@ function findClassListsInCssRange(
   return matches.map((match) => {
     const start = indexToPosition(text, match.index + match[1].length)
     const end = indexToPosition(text, match.index + match[1].length + match.groups.classList.length)
+    const range = absoluteRange({ start, end }, { start: globalStart, end: globalStart })
     return {
       classList: match.groups.classList,
       important: Boolean(match.groups.important),
-      range: {
-        start: {
-          line: globalStart.line + start.line,
-          character: (end.line === 0 ? globalStart.character : 0) + start.character,
-        },
-        end: {
-          line: globalStart.line + end.line,
-          character: (end.line === 0 ? globalStart.character : 0) + end.character,
-        },
-      },
+      range,
     }
   })
 }
@@ -264,19 +256,11 @@ function findClassListsInHtmlRange(
         text,
         match.index + match[0].length - 1 + offset + value.length + afterOffset,
       )
+      const resultRange = absoluteRange({ start, end }, range)
 
       const result: DocumentClassList = {
         classList: value.substr(beforeOffset, value.length + afterOffset),
-        range: {
-          start: {
-            line: (range?.start.line || 0) + start.line,
-            character: (end.line === 0 ? range?.start.character || 0 : 0) + start.character,
-          },
-          end: {
-            line: (range?.start.line || 0) + end.line,
-            character: (end.line === 0 ? range?.start.character || 0 : 0) + end.character,
-          },
-        },
+        range: resultRange,
       }
 
       const resultKey = [

--- a/packages/tailwindcss-language-service/src/util/language-blocks.ts
+++ b/packages/tailwindcss-language-service/src/util/language-blocks.ts
@@ -1,45 +1,73 @@
 import type { State } from '../util/state'
-import type { Range } from 'vscode-languageserver'
-import type { TextDocument } from 'vscode-languageserver-textdocument'
+import type { TextDocument, Range } from 'vscode-languageserver-textdocument'
 import { getLanguageBoundaries } from '../util/getLanguageBoundaries'
 import { isCssDoc } from '../util/css'
 import { getTextWithoutComments } from './doc'
+import { isHtmlDoc } from './html'
+import { isJsDoc } from './js'
 
 export interface LanguageBlock {
-  document: TextDocument
+  context: 'html' | 'js' | 'css' | 'other'
   range: Range | undefined
   lang: string
-  readonly text: string
+  text: string
 }
 
-export function* getCssBlocks(
-  state: State,
-  document: TextDocument,
-): Iterable<LanguageBlock | undefined> {
-  if (isCssDoc(state, document)) {
-    yield {
-      document,
-      range: undefined,
-      lang: document.languageId,
-      get text() {
-        return getTextWithoutComments(document, 'css')
-      },
-    }
-  } else {
-    let boundaries = getLanguageBoundaries(state, document)
-    if (!boundaries) return []
+export function getDocumentBlocks(state: State, doc: TextDocument): LanguageBlock[] {
+  let text = doc.getText()
 
-    for (let boundary of boundaries) {
-      if (boundary.type !== 'css') continue
+  let boundaries = getLanguageBoundaries(state, doc, text)
+  if (boundaries && boundaries.length > 0) {
+    return boundaries.map((boundary) => {
+      let context: 'html' | 'js' | 'css' | 'other'
 
-      yield {
-        document,
-        range: boundary.range,
-        lang: boundary.lang ?? document.languageId,
-        get text() {
-          return getTextWithoutComments(document, 'css', boundary.range)
-        },
+      if (boundary.type === 'html') {
+        context = 'html'
+      } else if (boundary.type === 'css') {
+        context = 'css'
+      } else if (boundary.type === 'js' || boundary.type === 'jsx') {
+        context = 'js'
+      } else {
+        context = 'other'
       }
-    }
+
+      let text = doc.getText(boundary.range)
+
+      return {
+        context,
+        range: boundary.range,
+        lang: boundary.lang ?? doc.languageId,
+        text: context === 'other' ? text : getTextWithoutComments(text, context),
+      }
+    })
   }
+
+  // If we get here we most likely have non-HTML document in a single language
+  let context: 'html' | 'js' | 'css' | 'other'
+
+  if (isHtmlDoc(state, doc)) {
+    context = 'html'
+  } else if (isCssDoc(state, doc)) {
+    context = 'css'
+  } else if (isJsDoc(state, doc)) {
+    context = 'js'
+  } else {
+    context = 'other'
+  }
+
+  return [
+    {
+      context,
+      range: {
+        start: doc.positionAt(0),
+        end: doc.positionAt(text.length),
+      },
+      lang: doc.languageId,
+      text: context === 'other' ? text : getTextWithoutComments(text, context),
+    },
+  ]
+}
+
+export function getCssBlocks(state: State, document: TextDocument): LanguageBlock[] {
+  return getDocumentBlocks(state, document).filter((block) => block.context === 'css')
 }

--- a/packages/tailwindcss-language-service/src/util/languages.ts
+++ b/packages/tailwindcss-language-service/src/util/languages.ts
@@ -23,6 +23,7 @@ export const htmlLanguages: string[] = [
   'html-eex',
   'htmldjango',
   'jade',
+  'pug',
   'latte',
   'leaf',
   'liquid',

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -69,7 +69,7 @@ export type TailwindCssSettings = {
     suggestCanonicalClasses: DiagnosticSeveritySetting
   }
   experimental: {
-    classRegex: string[] | [string, string][]
+    classRegex: (string | [string] | [string, string])[]
     configFile: string | Record<string, string | string[]> | null
   }
   files: {

--- a/packages/tailwindcss-language-service/src/util/test-utils.ts
+++ b/packages/tailwindcss-language-service/src/util/test-utils.ts
@@ -51,7 +51,7 @@ export function createDocument({
   lang: string
   content: string | string[]
   settings?: DeepPartial<Settings>
-}): { doc: TextDocument; state: State } {
+}): { doc: TextDocument; state: State; settings: Settings } {
   let doc = TextDocument.create(
     `file://${name}`,
     lang,
@@ -71,5 +71,6 @@ export function createDocument({
   return {
     doc,
     state,
+    settings: documentSettings,
   }
 }

--- a/packages/tailwindcss-language-service/src/util/test-utils.ts
+++ b/packages/tailwindcss-language-service/src/util/test-utils.ts
@@ -12,6 +12,35 @@ export const html: Dedent = dedent
 export const astro: Dedent = dedent
 export const pug: Dedent = dedent
 
+export function createSettings(settings: DeepPartial<Settings>): Settings {
+  let defaults = getDefaultTailwindSettings()
+  settings ??= {}
+
+  return {
+    ...defaults,
+    ...settings,
+    tailwindCSS: {
+      ...defaults.tailwindCSS,
+      ...settings.tailwindCSS,
+      lint: {
+        ...defaults.tailwindCSS.lint,
+        ...(settings.tailwindCSS?.lint ?? {}),
+      },
+      experimental: {
+        ...defaults.tailwindCSS.experimental,
+        ...(settings.tailwindCSS?.experimental ?? {}),
+      },
+      files: {
+        ...defaults.tailwindCSS.files,
+        ...(settings.tailwindCSS?.files ?? {}),
+      },
+    },
+    editor: {
+      ...defaults.editor,
+      ...settings.editor,
+    },
+  }
+}
 export function createDocument({
   name,
   lang,
@@ -29,34 +58,13 @@ export function createDocument({
     1,
     typeof content === 'string' ? content : content.join('\n'),
   )
-  let defaults = getDefaultTailwindSettings()
-  settings ??= {}
+
+  let documentSettings = createSettings(settings ?? {})
+
   let state = createState({
     editor: {
-      getConfiguration: async () => ({
-        ...defaults,
-        ...settings,
-        tailwindCSS: {
-          ...defaults.tailwindCSS,
-          ...settings.tailwindCSS,
-          lint: {
-            ...defaults.tailwindCSS.lint,
-            ...(settings.tailwindCSS?.lint ?? {}),
-          },
-          experimental: {
-            ...defaults.tailwindCSS.experimental,
-            ...(settings.tailwindCSS?.experimental ?? {}),
-          },
-          files: {
-            ...defaults.tailwindCSS.files,
-            ...(settings.tailwindCSS?.files ?? {}),
-          },
-        },
-        editor: {
-          ...defaults.editor,
-          ...settings.editor,
-        },
-      }),
+      userLanguages: documentSettings.tailwindCSS.includeLanguages ?? {},
+      getConfiguration: async () => documentSettings,
     },
   })
 


### PR DESCRIPTION
This should be mostly functionally equivalent. It simplifies a good chunk of the code used throughout to find class lists and class names.

1. It eliminates many repeated calls to `getConfiguration(…)` which would increase based on the number of embedded languages in the document. These hit a cache anyway so the overhead wasn't significant but the repeated calls aren't necessary.
2. Because of this I've now made several things synchronous where they were async before.
3. It eliminates a search range limitation for hovers which would cause some class name hovers to fail on large enough documents depending on document structure and what came *after* the class name further in the document.
4. This will simplify a future refactor that caches language boundaries, class lists, and class names on a per-document basis and only recompute when documents change.
