### PR TITLE
Pass settings into `jit.*` helper functions

### DIFF
--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -2285,6 +2285,8 @@ export async function resolveCompletionItem(
     return item
   }
 
+  let settings = await state.editor.getConfiguration()
+
   let className = item.data?.className ?? item.label
   if (item.data?.important) {
     className = `!${className}`
@@ -2369,7 +2371,7 @@ export async function resolveCompletionItem(
         let root = toPostCSSAst([{ kind: 'rule', selector: '', nodes: decls }])
         let rule = root.nodes[0] as postcss.Rule
 
-        item.detail = await jit.stringifyDecls(state, rule)
+        item.detail = jit.stringifyDecls(state, rule, settings)
       } else {
         item.detail = `${rules.length} rules`
       }
@@ -2381,7 +2383,7 @@ export async function resolveCompletionItem(
         value: [
           //
           '```css',
-          await jit.stringifyRoot(state, toPostCSSAst(rules)),
+          jit.stringifyRoot(state, toPostCSSAst(rules), settings),
           '```',
         ].join('\n'),
       }
@@ -2397,7 +2399,7 @@ export async function resolveCompletionItem(
     if (rules.length === 0) return item
     if (!item.detail) {
       if (rules.length === 1) {
-        item.detail = await jit.stringifyDecls(state, rules[0])
+        item.detail = jit.stringifyDecls(state, rules[0], settings)
       } else {
         item.detail = `${rules.length} rules`
       }
@@ -2405,7 +2407,7 @@ export async function resolveCompletionItem(
     if (!item.documentation) {
       item.documentation = {
         kind: 'markdown' as typeof MarkupKind.Markdown,
-        value: ['```css', await jit.stringifyRoot(state, root), '```'].join('\n'),
+        value: ['```css', jit.stringifyRoot(state, root, settings), '```'].join('\n'),
       }
     }
     return item
@@ -2417,7 +2419,6 @@ export async function resolveCompletionItem(
   } else {
     item.detail = await getCssDetail(state, rules)
     if (!item.documentation) {
-      const settings = await state.editor.getConfiguration()
       const css = stringifyCss([...variants, className].join(':'), rules, settings)
       if (css) {
         item.documentation = {

--- a/packages/tailwindcss-language-service/src/hoverProvider.ts
+++ b/packages/tailwindcss-language-service/src/hoverProvider.ts
@@ -105,7 +105,7 @@ async function provideClassNameHover(
     return {
       contents: {
         language: 'css',
-        value: await jit.stringifyRoot(state, toPostCSSAst(root), document.uri),
+        value: jit.stringifyRoot(state, toPostCSSAst(root), settings),
       },
       range: className.range,
     }
@@ -121,7 +121,7 @@ async function provideClassNameHover(
     return {
       contents: {
         language: 'css',
-        value: await jit.stringifyRoot(state, root, document.uri),
+        value: jit.stringifyRoot(state, root, settings),
       },
       range: className.range,
     }

--- a/packages/tailwindcss-language-service/src/util/jit.ts
+++ b/packages/tailwindcss-language-service/src/util/jit.ts
@@ -1,4 +1,4 @@
-import type { State } from './state'
+import type { Settings, State } from './state'
 import type { Container, Document, Root, Rule, Node, AtRule } from 'postcss'
 import { addPixelEquivalentsToValue } from './pixelEquivalents'
 import { addEquivalents } from './equivalents'
@@ -35,8 +35,7 @@ export function generateRules(
   }
 }
 
-export async function stringifyRoot(state: State, root: Root, uri?: string): Promise<string> {
-  let settings = await state.editor.getConfiguration(uri)
+export function stringifyRoot(state: State, root: Root, settings: Settings): string {
   let clone = root.clone()
 
   clone.walkAtRules('defaults', (node) => {
@@ -65,9 +64,7 @@ export function stringifyRules(state: State, rules: Rule[], tabSize: number = 2)
     .replace(/^(?:    )+/gm, (indent: string) => ' '.repeat((indent.length / 4) * tabSize))
 }
 
-export async function stringifyDecls(state: State, rule: Rule, uri?: string): Promise<string> {
-  let settings = await state.editor.getConfiguration(uri)
-
+export function stringifyDecls(state: State, rule: Rule, settings: Settings): string {
   let result = []
 
   rule.walkDecls(({ prop, value }) => {


### PR DESCRIPTION
This will eliminate additional config resolution calls and let us make these functions synchronous