### PR TITLE
Add suggestGapUtilities rule

### DIFF
--- a/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises'
 import { expect, test } from 'vitest'
 import { withFixture } from '../common'
-import { css, defineTest, json } from '../../src/testing'
+import { css, defineTest } from '../../src/testing'
 import { createClient } from '../utils/client'
 
 withFixture('basic', (c) => {
@@ -37,6 +37,20 @@ withFixture('basic', (c) => {
   testFixture('css-conflict/vue-style-lang-sass')
   testFixture('invalid-screen/simple')
   testFixture('invalid-theme/simple')
+  testFixture('suggest-gap-utilities/flex-space-x-y')
+  testFixture('suggest-gap-utilities/flex-space-x')
+  testFixture('suggest-gap-utilities/flex-space-y')
+  testFixture('suggest-gap-utilities/flex-row-space-x-y')
+  testFixture('suggest-gap-utilities/flex-row-space-x')
+  testFixture('suggest-gap-utilities/flex-row-space-y')
+  testFixture('suggest-gap-utilities/flex-col-space-x-y')
+  testFixture('suggest-gap-utilities/flex-col-space-x')
+  testFixture('suggest-gap-utilities/flex-col-space-y')
+  testFixture('suggest-gap-utilities/flex-row-reverse-space-x')
+  testFixture('suggest-gap-utilities/flex-col-reverse-space-y')
+  testFixture('suggest-gap-utilities/arbitrary-value-space')
+  testFixture('suggest-gap-utilities/negative-space')
+  testFixture('suggest-gap-utilities/space-without-flex')
 })
 
 withFixture('v4/basic', (c) => {

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/arbitrary-value-space.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/arbitrary-value-space.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"flex flex-row space-x-[4px]\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-reverse-space-y.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-reverse-space-y.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"flex flex-col-reverse space-y-4\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-space-x-y.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-space-x-y.json
@@ -1,0 +1,17 @@
+{
+  "code": "<div class=\"flex flex-col space-y-4 space-x-2\"></div>",
+  "language": "html",
+  "expected": [
+    {
+      "code": "suggestGapUtilities",
+      "source": "tailwindcss",
+      "severity": 2,
+      "message": "Consider using `gap-y-4` instead of `space-y-4` when using flex layouts.",
+      "range": {
+        "start": { "line": 0, "character": 26 },
+        "end": { "line": 0, "character": 35 }
+      },
+      "suggestions": ["gap-y-4"]
+    }
+  ]
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-space-x.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-space-x.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"flex flex-col space-x-4\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-space-y.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-col-space-y.json
@@ -1,0 +1,17 @@
+{
+  "code": "<div class=\"flex flex-col space-y-4\"></div>",
+  "language": "html",
+  "expected": [
+    {
+      "code": "suggestGapUtilities",
+      "source": "tailwindcss",
+      "severity": 2,
+      "message": "Consider using `gap-y-4` instead of `space-y-4` when using flex layouts.",
+      "range": {
+        "start": { "line": 0, "character": 26 },
+        "end": { "line": 0, "character": 35 }
+      },
+      "suggestions": ["gap-y-4"]
+    }
+  ]
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-reverse-space-x.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-reverse-space-x.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"flex flex-row-reverse space-x-4\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-space-x-y.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-space-x-y.json
@@ -1,0 +1,17 @@
+{
+  "code": "<div class=\"flex flex-row space-x-4 spac-y-2\"></div>",
+  "language": "html",
+  "expected": [
+    {
+      "code": "suggestGapUtilities",
+      "source": "tailwindcss",
+      "severity": 2,
+      "message": "Consider using `gap-x-4` instead of `space-x-4` when using flex layouts.",
+      "range": {
+        "start": { "line": 0, "character": 26 },
+        "end": { "line": 0, "character": 35 }
+      },
+      "suggestions": ["gap-x-4"]
+    }
+  ]
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-space-x.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-space-x.json
@@ -1,0 +1,17 @@
+{
+  "code": "<div class=\"flex flex-row space-x-4\"></div>",
+  "language": "html",
+  "expected": [
+    {
+      "code": "suggestGapUtilities",
+      "source": "tailwindcss",
+      "severity": 2,
+      "message": "Consider using `gap-x-4` instead of `space-x-4` when using flex layouts.",
+      "range": {
+        "start": { "line": 0, "character": 26 },
+        "end": { "line": 0, "character": 35 }
+      },
+      "suggestions": ["gap-x-4"]
+    }
+  ]
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-space-y.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-row-space-y.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"flex flex-row space-y-4\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-space-x-y.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-space-x-y.json
@@ -1,0 +1,17 @@
+{
+  "code": "<div class=\"flex space-y-2 space-x-4\"></div>",
+  "language": "html",
+  "expected": [
+    {
+      "code": "suggestGapUtilities",
+      "source": "tailwindcss",
+      "severity": 2,
+      "message": "Consider using `gap-x-4` instead of `space-x-4` when using flex layouts.",
+      "range": {
+        "start": { "line": 0, "character": 27 },
+        "end": { "line": 0, "character": 36 }
+      },
+      "suggestions": ["gap-x-4"]
+    }
+  ]
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-space-x.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-space-x.json
@@ -1,0 +1,17 @@
+{
+  "code": "<div class=\"flex space-x-4\"></div>",
+  "language": "html",
+  "expected": [
+    {
+      "code": "suggestGapUtilities",
+      "source": "tailwindcss",
+      "severity": 2,
+      "message": "Consider using `gap-x-4` instead of `space-x-4` when using flex layouts.",
+      "range": {
+        "start": { "line": 0, "character": 17 },
+        "end": { "line": 0, "character": 26 }
+      },
+      "suggestions": ["gap-x-4"]
+    }
+  ]
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-space-y.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/flex-space-y.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"flex space-y-4\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/negative-space.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/negative-space.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"flex flex-row -space-x-4\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/space-without-flex.json
+++ b/packages/tailwindcss-language-server/tests/diagnostics/suggest-gap-utilities/space-without-flex.json
@@ -1,0 +1,5 @@
+{
+  "code": "<div class=\"space-x-4\"></div>",
+  "language": "html",
+  "expected": []
+}

--- a/packages/tailwindcss-language-service/src/codeActions/codeActionProvider.ts
+++ b/packages/tailwindcss-language-service/src/codeActions/codeActionProvider.ts
@@ -14,6 +14,7 @@ import {
   isInvalidVariantDiagnostic,
   isRecommendedVariantOrderDiagnostic,
   isSuggestCanonicalClasses,
+  isSuggestGapUtilities,
 } from '../diagnostics/types'
 import { flatten, dedupeBy } from '../util/array'
 import { provideCssConflictCodeActions } from './provideCssConflictCodeActions'
@@ -76,7 +77,8 @@ export async function doCodeActions(
         isInvalidScreenDiagnostic(diagnostic) ||
         isInvalidVariantDiagnostic(diagnostic) ||
         isRecommendedVariantOrderDiagnostic(diagnostic) ||
-        isSuggestCanonicalClasses(diagnostic)
+        isSuggestCanonicalClasses(diagnostic) ||
+        isSuggestGapUtilities(diagnostic)
       ) {
         return provideSuggestionCodeActions(state, params, diagnostic)
       }

--- a/packages/tailwindcss-language-service/src/codeActions/provideSuggestionCodeActions.ts
+++ b/packages/tailwindcss-language-service/src/codeActions/provideSuggestionCodeActions.ts
@@ -7,6 +7,7 @@ import type {
   InvalidVariantDiagnostic,
   RecommendedVariantOrderDiagnostic,
   SuggestCanonicalClassesDiagnostic,
+  SuggestGapUtilitiesDiagnostic,
 } from '../diagnostics/types'
 
 export function provideSuggestionCodeActions(
@@ -18,7 +19,8 @@ export function provideSuggestionCodeActions(
     | InvalidScreenDiagnostic
     | InvalidVariantDiagnostic
     | RecommendedVariantOrderDiagnostic
-    | SuggestCanonicalClassesDiagnostic,
+    | SuggestCanonicalClassesDiagnostic
+    | SuggestGapUtilitiesDiagnostic,
 ): CodeAction[] {
   return diagnostic.suggestions.map((suggestion) => ({
     title: `Replace with '${suggestion}'`,

--- a/packages/tailwindcss-language-service/src/diagnostics/diagnosticsProvider.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/diagnosticsProvider.ts
@@ -11,6 +11,7 @@ import { getRecommendedVariantOrderDiagnostics } from './getRecommendedVariantOr
 import { getInvalidSourceDiagnostics } from './getInvalidSourceDiagnostics'
 import { getUsedBlocklistedClassDiagnostics } from './getUsedBlocklistedClassDiagnostics'
 import { getSuggestCanonicalClassesDiagnostics } from './canonical-classes'
+import { getSuggestGapUtilitiesDiagnostics } from './getSuggestGapUtilitiesDiagnostics'
 
 export async function doValidate(
   state: State,
@@ -26,6 +27,7 @@ export async function doValidate(
     DiagnosticKind.RecommendedVariantOrder,
     DiagnosticKind.UsedBlocklistedClass,
     DiagnosticKind.SuggestCanonicalClasses,
+    DiagnosticKind.SuggestGapUtilities,
   ],
 ): Promise<AugmentedDiagnostic[]> {
   const settings = await state.editor.getConfiguration(document.uri)
@@ -61,6 +63,9 @@ export async function doValidate(
           : []),
         ...(only.includes(DiagnosticKind.SuggestCanonicalClasses)
           ? await getSuggestCanonicalClassesDiagnostics(state, document, settings)
+          : []),
+        ...(only.includes(DiagnosticKind.SuggestGapUtilities)
+          ? await getSuggestGapUtilitiesDiagnostics(state, document, settings)
           : []),
       ]
     : []

--- a/packages/tailwindcss-language-service/src/diagnostics/getSuggestGapUtilitiesDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getSuggestGapUtilitiesDiagnostics.ts
@@ -1,0 +1,59 @@
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import type { State, Settings } from '../util/state'
+import { type SuggestGapUtilitiesDiagnostic, DiagnosticKind } from './types'
+import { findClassListsInDocument, getClassNamesInClassList } from '../util/find'
+
+const SPACE_REGEX = /^-?space-([xy])-(.+)$/
+type FlexAxis = 'x' | 'y' | null
+
+function getFlexAxis(classes: string[]): FlexAxis {
+  if (classes.includes('flex-col')) return 'y'
+  if (classes.includes('flex') || classes.includes('flex-row')) return 'x'
+  return null
+}
+
+export async function getSuggestGapUtilitiesDiagnostics(
+  state: State,
+  document: TextDocument,
+  settings: Settings,
+): Promise<SuggestGapUtilitiesDiagnostic[]> {
+  const severity = settings.tailwindCSS.lint.suggestGapUtilities
+  if (severity === 'ignore') return []
+
+  const diagnostics: SuggestGapUtilitiesDiagnostic[] = []
+  const classLists = await findClassListsInDocument(state, document)
+
+  for (const classList of classLists) {
+    const classNames = getClassNamesInClassList(classList, [])
+    const allClasses = classNames.map((c) => c.className)
+
+    if (allClasses.some((c) => c.endsWith('-reverse'))) continue
+    const axis = getFlexAxis(allClasses)
+    if (!axis) continue
+
+    for (const classInfo of classNames) {
+      const { className, range } = classInfo
+      const match = className.match(SPACE_REGEX)
+      if (!match) continue
+
+      const [, spaceAxis, value] = match
+      if (className.startsWith('-') || value.startsWith('[') || spaceAxis !== axis) continue
+
+      const suggestion = `gap-${spaceAxis}-${value}`
+
+      diagnostics.push({
+        code: DiagnosticKind.SuggestGapUtilities,
+        source: 'tailwindcss',
+        range,
+        severity:
+          severity === 'error'
+            ? 1 /* DiagnosticSeverity.Error */
+            : 2 /* DiagnosticSeverity.Warning */,
+        message: `Consider using \`${suggestion}\` instead of \`${className}\` when using flex layouts.`,
+        suggestions: [suggestion],
+      })
+    }
+  }
+
+  return diagnostics
+}

--- a/packages/tailwindcss-language-service/src/diagnostics/types.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/types.ts
@@ -12,6 +12,7 @@ export enum DiagnosticKind {
   RecommendedVariantOrder = 'recommendedVariantOrder',
   UsedBlocklistedClass = 'usedBlocklistedClass',
   SuggestCanonicalClasses = 'suggestCanonicalClasses',
+  SuggestGapUtilities = 'suggestGapUtilities',
 }
 
 export type CssConflictDiagnostic = Diagnostic & {
@@ -123,6 +124,17 @@ export function isSuggestCanonicalClasses(
   return diagnostic.code === DiagnosticKind.SuggestCanonicalClasses
 }
 
+export type SuggestGapUtilitiesDiagnostic = Diagnostic & {
+  code: DiagnosticKind.SuggestGapUtilities
+  suggestions: string[]
+}
+
+export function isSuggestGapUtilities(
+  diagnostic: AugmentedDiagnostic,
+): diagnostic is SuggestGapUtilitiesDiagnostic {
+  return diagnostic.code === DiagnosticKind.SuggestCanonicalClasses
+}
+
 export type AugmentedDiagnostic =
   | CssConflictDiagnostic
   | InvalidApplyDiagnostic
@@ -134,3 +146,4 @@ export type AugmentedDiagnostic =
   | RecommendedVariantOrderDiagnostic
   | UsedBlocklistedClassDiagnostic
   | SuggestCanonicalClassesDiagnostic
+  | SuggestGapUtilitiesDiagnostic

--- a/packages/tailwindcss-language-service/src/util/state.ts
+++ b/packages/tailwindcss-language-service/src/util/state.ts
@@ -67,6 +67,7 @@ export type TailwindCssSettings = {
     recommendedVariantOrder: DiagnosticSeveritySetting
     usedBlocklistedClass: DiagnosticSeveritySetting
     suggestCanonicalClasses: DiagnosticSeveritySetting
+    suggestGapUtilities: DiagnosticSeveritySetting
   }
   experimental: {
     classRegex: string[] | [string, string][]
@@ -207,6 +208,7 @@ export function getDefaultTailwindSettings(): Settings {
         recommendedVariantOrder: 'warning',
         usedBlocklistedClass: 'warning',
         suggestCanonicalClasses: 'warning',
+        suggestGapUtilities: 'warning',
       },
       showPixelEquivalents: true,
       includeLanguages: {},

--- a/packages/vscode-tailwindcss/README.md
+++ b/packages/vscode-tailwindcss/README.md
@@ -194,6 +194,10 @@ Some examples of the changes this makes:
 | `[color:red]/100`               | `text-[red]`   |
 | `[@media_print]:[display:flex]` | `print:flex`   |
 
+#### `tailwindCSS.lint.suggestGapUtilities`
+
+Detect usage of `space-*` utilities in `flex` layouts where `gap-*` utilities are the more idiomatic and predictable choice. **Default: `warning`**
+
 ### `tailwindCSS.inspectPort`
 
 Enable the Node.js inspector agent for the language server and listen on the specified port. **Default: `null`**


### PR DESCRIPTION
Adds a new lint rule to detect `space-*` classes in flex containers and suggest using `gap-*` instead for more predictable layouts.