### PR TITLE
fix: Respect file exclusions when discovering tsconfig files

### DIFF
--- a/packages/tailwindcss-language-server/src/resolver/index.ts
+++ b/packages/tailwindcss-language-server/src/resolver/index.ts
@@ -7,7 +7,7 @@ import {
   FileSystem,
 } from 'enhanced-resolve'
 import { loadPnPApi, type PnpApi } from './pnp'
-import { loadTsConfig, type TSConfigApi } from './tsconfig'
+import { loadTsConfig, type TSConfigApi, type TSConfigLoadOptions } from './tsconfig'
 import { normalizeYarnPnPDriveLetter } from '../utils'
 
 export interface ResolverOptions {
@@ -33,6 +33,13 @@ export interface ResolverOptions {
    * provided, the resolver will use that API to resolve module paths.
    */
   tsconfig?: boolean | TSConfigApi
+
+  /**
+   * Glob patterns to exclude while discovering tsconfig files.
+   *
+   * This mirrors the semantics of `tailwindCSS.files.exclude`.
+   */
+  tsconfigExclude?: TSConfigLoadOptions['exclude']
 
   /**
    * A filesystem to use for resolution. If not provided, the resolver will
@@ -132,7 +139,7 @@ export async function createResolver(opts: ResolverOptions): Promise<Resolver> {
     tsconfig = opts.tsconfig
   } else if (opts.tsconfig) {
     try {
-      tsconfig = await loadTsConfig(opts.root)
+      tsconfig = await loadTsConfig(opts.root, { exclude: opts.tsconfigExclude })
     } catch (err) {
       // We don't want to hard crash in case of an error handling tsconfigs
       // It does affect what projects we can resolve or how we load files
@@ -302,6 +309,7 @@ export async function createResolver(opts: ResolverOptions): Promise<Resolver> {
         // Inherit defaults from parent
         pnp: childOpts.pnp ?? pnpApi,
         tsconfig: childOpts.tsconfig ?? tsconfig,
+        tsconfigExclude: childOpts.tsconfigExclude ?? opts.tsconfigExclude,
         fileSystem: childOpts.fileSystem ?? fileSystem,
       })
     },

--- a/packages/tailwindcss-language-server/src/resolver/tsconfig.test.ts
+++ b/packages/tailwindcss-language-server/src/resolver/tsconfig.test.ts
@@ -1,0 +1,42 @@
+import * as path from 'node:path'
+import { expect } from 'vitest'
+import { loadTsConfig } from './tsconfig'
+import { json, defineTest } from '../testing'
+import { normalizePath } from '../utils'
+
+defineTest({
+  name: 'loadTsConfig respects excluded paths',
+  fs: {
+    'tsconfig.json': json`
+      {
+        "compilerOptions": {
+          "baseUrl": "."
+        }
+      }
+    `,
+    'repos/ai/tsconfig.json': json`
+      {
+        "extends": "@vercel/ai-tsconfig/base.json"
+      }
+    `,
+  },
+  async handle({ root }) {
+    let withoutExclude = await loadTsConfig(root)
+    expect(withoutExclude.errors.length).toBeGreaterThan(0)
+
+    let rootRelativeExclude = await loadTsConfig(root, {
+      exclude: ['repos/**'],
+    })
+    expect(rootRelativeExclude.errors).toHaveLength(0)
+
+    let rootAnchoredExclude = await loadTsConfig(root, {
+      exclude: ['/repos/**'],
+    })
+    expect(rootAnchoredExclude.errors).toHaveLength(0)
+
+    let absoluteExclude = await loadTsConfig(root, {
+      exclude: [normalizePath(path.join(root, 'repos/**'))],
+    })
+    expect(absoluteExclude.errors).toHaveLength(0)
+  },
+})

--- a/packages/tailwindcss-language-server/src/resolver/tsconfig.ts
+++ b/packages/tailwindcss-language-server/src/resolver/tsconfig.ts
@@ -8,6 +8,7 @@
 import * as path from 'node:path'
 import * as tsconfig from 'tsconfig-paths'
 import * as tsconfck from 'tsconfck'
+import picomatch from 'picomatch'
 import { normalizeDriveLetter, normalizePath } from '../utils'
 import { DefaultMap } from '../util/default-map'
 
@@ -52,8 +53,15 @@ export interface TSConfigApi {
   errors: unknown[]
 }
 
-export async function loadTsConfig(root: string): Promise<TSConfigApi> {
-  let { configs, errors } = await findConfigs(root)
+export interface TSConfigLoadOptions {
+  exclude?: string[]
+}
+
+export async function loadTsConfig(
+  root: string,
+  options: TSConfigLoadOptions = {},
+): Promise<TSConfigApi> {
+  let { configs, errors } = await findConfigs(root, options.exclude ?? [])
 
   let matchers = await createMatchers(configs)
 
@@ -105,7 +113,7 @@ export async function loadTsConfig(root: string): Promise<TSConfigApi> {
   }
 
   async function refresh() {
-    let { configs, errors } = await findConfigs(root)
+    let { configs, errors } = await findConfigs(root, options.exclude ?? [])
 
     matchers = await createMatchers(configs)
 
@@ -123,10 +131,15 @@ export async function loadTsConfig(root: string): Promise<TSConfigApi> {
   }
 }
 
-async function findConfigs(root: string): Promise<{
+async function findConfigs(
+  root: string,
+  exclude: string[],
+): Promise<{
   configs: Set<tsconfck.TSConfckParseResult>
   errors: unknown[]
 }> {
+  let isExcluded = createExcludeMatcher(root, exclude)
+
   // 1. Find all tsconfig files in the project
   let files = await tsconfck.findAll(root, {
     configNames: ['tsconfig.json', 'jsconfig.json'],
@@ -134,17 +147,10 @@ async function findConfigs(root: string): Promise<{
       if (dir === 'node_modules') return true
       if (dir === '.git') return true
 
-      // TODO: Incorporate thee `exclude` option from VSCode settings.
-      //
-      // Doing so here is complicated because we don't have access to the
-      // full path to the file here and we need that to match it against the
-      // exclude patterns.
-      //
-      // This probably means we need to filter them after we've found them all.
-
       return false
     },
   })
+  files = files.filter((file) => !isExcluded(file))
 
   // 2. Load them all
   let options: tsconfck.TSConfckParseOptions = {
@@ -170,6 +176,7 @@ async function findConfigs(root: string): Promise<{
 
     // Mach against referenced projects rather than the project itself
     for (let ref of result.referenced) {
+      if (isExcluded(ref.tsconfigFile)) continue
       parsed.add(ref)
     }
 
@@ -282,4 +289,55 @@ function findBaseDir(project: tsconfck.TSConfckParseResult): string {
   }
 
   return path.dirname(project.tsconfigFile)
+}
+
+function createExcludeMatcher(root: string, patterns: string[]) {
+  if (patterns.length === 0) return (_filepath: string) => false
+
+  let normalizedRoot = normalizeDriveLetter(normalizePath(root))
+
+  let absoluteMatchers: Array<(filepath: string) => boolean> = []
+  let relativeMatchers: Array<(filepath: string) => boolean> = []
+
+  for (let pattern of patterns) {
+    pattern = normalizePath(pattern)
+
+    let isWorkspaceRootRelativePattern =
+      pattern.startsWith('/') &&
+      !pattern.startsWith('//') &&
+      !pattern.startsWith(`${normalizedRoot}/`) &&
+      pattern !== normalizedRoot
+
+    if (isWorkspaceRootRelativePattern) {
+      relativeMatchers.push(picomatch(pattern.slice(1), { dot: true }))
+      continue
+    }
+
+    if (path.isAbsolute(pattern)) {
+      absoluteMatchers.push(picomatch(normalizeDriveLetter(pattern), { dot: true }))
+      continue
+    }
+
+    if (pattern.startsWith('/')) {
+      pattern = pattern.slice(1)
+    }
+
+    relativeMatchers.push(picomatch(pattern, { dot: true }))
+  }
+
+  return (filepath: string) => {
+    let normalizedFile = normalizeDriveLetter(normalizePath(filepath))
+
+    for (let matcher of absoluteMatchers) {
+      if (matcher(normalizedFile)) return true
+    }
+
+    let relativeFile = normalizePath(path.relative(normalizedRoot, normalizedFile))
+
+    for (let matcher of relativeMatchers) {
+      if (matcher(relativeFile)) return true
+    }
+
+    return false
+  }
 }

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -320,6 +320,7 @@ export class TW {
       root: base,
       pnp: true,
       tsconfig: true,
+      tsconfigExclude: ignore,
     })
 
     let locator = new ProjectLocator(base, globalSettings, resolver)


### PR DESCRIPTION
When `tailwindCSS.files.exclude` is configured, tsconfig discovery still parses excluded `tsconfig.json` and `jsconfig.json` files. In larger monorepos this can surface repeated `EXTENDS_RESOLVE` noise and add unnecessary project resolution work.

This change forwards `tailwindCSS.files.exclude` into the resolver and applies it while collecting configs and referenced projects. It also handles root-relative (`repos/**`), root-anchored (`/repos/**`), and absolute path patterns, with a regression test that covers all three.

## Test plan
- [x] `pnpm --filter @tailwindcss/language-server test run src/resolver/tsconfig.test.ts`
- [x] `pnpm --filter @tailwindcss/language-server build`
- [x] `pnpm --filter vscode-tailwindcss run _esbuild --minify`
- [x] Verified in a local Cursor workspace that Tailwind initialization no longer scans `repos/**` (a large directory with 100+ git cloned repositories)

## AI Disclosure
- AI assistance used: yes
- Model: `gpt-5.3-codex-xhigh`
- Scope: implementation support, regression test authoring, and PR drafting
- Human verification: manually reviewed diff and validated test/build commands and extension logs