### PR TITLE
fix: correct @apply grammar inside @utility

### DIFF
--- a/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
+++ b/packages/tailwindcss-language-syntax/tests/__snapshots__/syntax.test.ts.snap
@@ -1115,11 +1115,12 @@ exports[`@utility 1`] = `
              ^                         1: meta.at-rule.utility.body.tailwind punctuation.section.utility.begin.bracket.curly.tailwind
 
   @apply flex;
-^^^^^^^^^^^^^^                         5: source.css.tailwind meta.at-rule.utility.body.tailwind
-  ^^^^^^^^^^^^                         4: meta.at-rule.header.css
-  ^^^^^^                               2: keyword.control.at-rule.css
+^^^^^^^^^^^^^^                         9: source.css.tailwind meta.at-rule.utility.body.tailwind
+  ^^^^^^^^^^^^                         8: meta.at-rule.apply.tailwind
+  ^^^^^^                               2: keyword.control.at-rule.apply.tailwind
   ^                                    1: punctuation.definition.keyword.css
-             ^                         1: punctuation.terminator.rule.css
+         ^^^^                          4: entity.other.attribute-name.class.css
+             ^                         1: punctuation.terminator.apply.tailwind
 
 }
 ^                                      1: source.css.tailwind meta.at-rule.utility.body.tailwind punctuation.section.utility.end.bracket.curly.tailwind

--- a/packages/vscode-tailwindcss/syntaxes/at-apply.tmLanguage.json
+++ b/packages/vscode-tailwindcss/syntaxes/at-apply.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "scopeName": "tailwindcss.at-apply.injection",
   "fileTypes": [],
-  "injectionSelector": "L:meta.property-list.css -comment, meta.property-list.scss -comment",
+  "injectionSelector": "L:meta.property-list.css -comment, meta.property-list.scss -comment, L:meta.at-rule.utility.body.tailwind -comment, meta.at-rule.utility.body.tailwind -comment",
   "name": "TailwindCSS",
   "patterns": [
     {


### PR DESCRIPTION
Fix the grammar for `@apply` when used inside `@utility` in css.
This also improves syntax highlighting for classes passed to `@apply`.

### Before

`@apply` was not highlighted correctly.

![before](https://github.com/user-attachments/assets/d4c9ef2c-a8e1-4fea-b604-1a358f7e717c)

### After

`@apply` is now highlighted correctly.

![after](https://github.com/user-attachments/assets/0939b92c-b10c-4a0e-b3f3-b6f5301c9cc2)