### PR TITLE
Skip empty capability dynamic registration

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -913,31 +913,42 @@ export class TW {
   private commonRegistrations: BulkUnregistration | undefined
   private async updateCommonCapabilities() {
     let capabilities = BulkRegistration.create()
+    let hasRegistration = false
 
     let client = this.initializeParams.capabilities
 
     if (client.textDocument?.hover?.dynamicRegistration) {
       capabilities.add(HoverRequest.type, { documentSelector: null })
+      hasRegistration = true
     }
 
     if (client.textDocument?.colorProvider?.dynamicRegistration) {
       capabilities.add(DocumentColorRequest.type, { documentSelector: null })
+      hasRegistration = true
     }
 
     if (client.textDocument?.codeAction?.dynamicRegistration) {
       capabilities.add(CodeActionRequest.type, { documentSelector: null })
+      hasRegistration = true
     }
 
     if (client.textDocument?.codeLens?.dynamicRegistration) {
       capabilities.add(CodeLensRequest.type, { documentSelector: null })
+      hasRegistration = true
     }
 
     if (client.textDocument?.documentLink?.dynamicRegistration) {
       capabilities.add(DocumentLinkRequest.type, { documentSelector: null })
+      hasRegistration = true
     }
 
     if (client.workspace?.didChangeConfiguration?.dynamicRegistration) {
       capabilities.add(DidChangeConfigurationNotification.type, undefined)
+      hasRegistration = true
+    }
+
+    if (!hasRegistration) {
+      return
     }
 
     this.commonRegistrations?.dispose()


### PR DESCRIPTION
Add a hasRegistration flag to track if any capabilities need dynamic registration. When no capabilities are supported by the client, avoid sending an empty client/registerCapability request which could cause unnecessary network overhead or hang in some LSP clients.