### PR TITLE
tests: fix 'recieved' -> 'received' typo in client.ts comment

### DIFF
--- a/packages/tailwindcss-language-server/tests/utils/client.ts
+++ b/packages/tailwindcss-language-server/tests/utils/client.ts
@@ -641,7 +641,7 @@ export async function createClientWorkspace({
 
       currentDiagnostics = new Promise<Diagnostic[]>((resolve) => {
         notifications.onPublishedDiagnostics(uri.toString(), (params) => {
-          // We recieved diagnostics for different version of this document
+          // We received diagnostics for different version of this document
           if (params.version !== undefined) {
             if (params.version !== version) return
           }


### PR DESCRIPTION
Comment in `packages/tailwindcss-language-server/tests/utils/client.ts` line 644 reads `We recieved diagnostics`. Fixed to `received`. Comment-only change.