### PR TITLE
Add canonical class fix-all actions for files and workspaces

### DIFF
--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -80,6 +80,8 @@ const TRIGGER_CHARACTERS = [
   '-',
 ] as const
 
+const CODE_ACTION_KINDS = ['quickfix', 'source.fixAll.tailwindcss']
+
 async function getConfigFileFromCssFile(cssFile: string): Promise<string | null> {
   let css = await readCssFile(cssFile)
   if (!css) return null
@@ -925,7 +927,10 @@ export class TW {
     }
 
     if (client.textDocument?.codeAction?.dynamicRegistration) {
-      capabilities.add(CodeActionRequest.type, { documentSelector: null })
+      capabilities.add(CodeActionRequest.type, {
+        documentSelector: null,
+        codeActionKinds: CODE_ACTION_KINDS,
+      })
     }
 
     if (client.textDocument?.codeLens?.dynamicRegistration) {
@@ -1139,7 +1144,9 @@ export class TW {
     }
 
     if (!client.textDocument?.codeAction?.dynamicRegistration) {
-      capabilities.codeActionProvider = true
+      capabilities.codeActionProvider = {
+        codeActionKinds: CODE_ACTION_KINDS,
+      }
     }
 
     if (!client.textDocument?.codeLens?.dynamicRegistration) {

--- a/packages/tailwindcss-language-server/tests/code-actions/code-actions.v4.test.js
+++ b/packages/tailwindcss-language-server/tests/code-actions/code-actions.v4.test.js
@@ -35,4 +35,111 @@ withFixture('v4/basic', (c) => {
   testFixture('conflict')
   // testFixture('invalid-theme')
   // testFixture('invalid-screen')
+
+  test('canonical class suggestions include a fix-all action', async () => {
+    let promise = new Promise((resolve) => {
+      c.onNotification('textDocument/publishDiagnostics', ({ diagnostics }) => {
+        resolve(diagnostics)
+      })
+    })
+
+    let textDocument = await c.openDocument({
+      text: '<div class="[@media_print]:flex [color:red]/50 mt-[16px]">',
+      lang: 'html',
+    })
+    let diagnostics = await promise
+
+    let res = await c.sendRequest('textDocument/codeAction', {
+      textDocument,
+      context: {
+        diagnostics,
+      },
+    })
+
+    expect(res).toEqual([
+      {
+        title: "Replace with 'print:flex'",
+        kind: 'quickfix',
+        diagnostics: [diagnostics[0]],
+        edit: {
+          changes: {
+            [textDocument.uri]: [{ range: diagnostics[0].range, newText: 'print:flex' }],
+          },
+        },
+      },
+      {
+        title: "Replace with 'text-[red]/50'",
+        kind: 'quickfix',
+        diagnostics: [diagnostics[1]],
+        edit: {
+          changes: {
+            [textDocument.uri]: [{ range: diagnostics[1].range, newText: 'text-[red]/50' }],
+          },
+        },
+      },
+      {
+        title: "Replace with 'mt-4'",
+        kind: 'quickfix',
+        diagnostics: [diagnostics[2]],
+        edit: {
+          changes: {
+            [textDocument.uri]: [{ range: diagnostics[2].range, newText: 'mt-4' }],
+          },
+        },
+      },
+      {
+        title: 'Fix all Tailwind CSS canonical class suggestions',
+        kind: 'source.fixAll.tailwindcss',
+        diagnostics,
+        edit: {
+          changes: {
+            [textDocument.uri]: [
+              { range: diagnostics[0].range, newText: 'print:flex' },
+              { range: diagnostics[1].range, newText: 'text-[red]/50' },
+              { range: diagnostics[2].range, newText: 'mt-4' },
+            ],
+          },
+        },
+      },
+    ])
+  })
+
+  test('canonical class fix-all can be requested directly', async () => {
+    let promise = new Promise((resolve) => {
+      c.onNotification('textDocument/publishDiagnostics', ({ diagnostics }) => {
+        resolve(diagnostics)
+      })
+    })
+
+    let textDocument = await c.openDocument({
+      text: '<div class="[@media_print]:flex [color:red]/50 mt-[16px]">',
+      lang: 'html',
+    })
+    let diagnostics = await promise
+
+    let res = await c.sendRequest('textDocument/codeAction', {
+      textDocument,
+      context: {
+        diagnostics,
+        only: ['source.fixAll'],
+      },
+    })
+
+    expect(res).toEqual([
+      {
+        title: 'Fix all Tailwind CSS canonical class suggestions',
+        kind: 'source.fixAll.tailwindcss',
+        diagnostics,
+        edit: {
+          changes: {
+            [textDocument.uri]: [
+              { range: diagnostics[0].range, newText: 'print:flex' },
+              { range: diagnostics[1].range, newText: 'text-[red]/50' },
+              { range: diagnostics[2].range, newText: 'mt-4' },
+            ],
+          },
+        },
+      },
+    ])
+  })
 })

--- a/packages/tailwindcss-language-server/tests/env/capabilities.test.ts
+++ b/packages/tailwindcss-language-server/tests/env/capabilities.test.ts
@@ -4,6 +4,32 @@ import { createClient } from '../utils/client'
 import * as fs from 'node:fs/promises'
 
 defineTest({
+  name: 'Code actions advertise Tailwind fix-all support',
+  fs: {
+    'app.css': '@import "tailwindcss"',
+  },
+  prepare: async ({ root }) => ({ client: await createClient({ root }) }),
+  handle: async ({ client }) => {
+    expect(client.serverCapabilities).toEqual([])
+
+    await client.open({
+      lang: 'html',
+      text: '<div class="[@media_print]:flex">',
+    })
+
+    expect(client.serverCapabilities).toContainEqual(
+      expect.objectContaining({
+        method: 'textDocument/codeAction',
+        registerOptions: {
+          documentSelector: null,
+          codeActionKinds: ['quickfix', 'source.fixAll.tailwindcss'],
+        },
+      }),
+    )
+  },
+})
+
+defineTest({
   name: 'Changing the separator registers new trigger characters',
   fs: {
     'tailwind.config.js': js`

--- a/packages/tailwindcss-language-service/src/codeActions/codeActionProvider.ts
+++ b/packages/tailwindcss-language-service/src/codeActions/codeActionProvider.ts
@@ -5,6 +5,7 @@ import { doValidate } from '../diagnostics/diagnosticsProvider'
 import { rangesEqual } from '../util/rangesEqual'
 import {
   type DiagnosticKind,
+  DiagnosticKind as DiagnosticKindEnum,
   isInvalidApplyDiagnostic,
   type AugmentedDiagnostic,
   isCssConflictDiagnostic,
@@ -16,10 +17,22 @@ import {
   isRecommendedVariantOrderDiagnostic,
   isSuggestCanonicalClasses,
 } from '../diagnostics/types'
-import { flatten, dedupeBy } from '../util/array'
+import { flatten } from '../util/array'
 import { provideCssConflictCodeActions } from './provideCssConflictCodeActions'
+import { provideFixAllSuggestionCodeActions } from './provideFixAllSuggestionCodeActions'
 import { provideInvalidApplyCodeActions } from './provideInvalidApplyCodeActions'
 import { provideSuggestionCodeActions } from './provideSuggestionCodeActions'
+
+const QUICK_FIX_KIND = 'quickfix'
+const SOURCE_FIX_ALL_TAILWIND_KIND = 'source.fixAll.tailwindcss'
+
+function matchesRequestedKind(only: string[] | undefined, kind: string): boolean {
+  if (!only?.length) return true
+
+  return only.some((requestedKind) => {
+    return requestedKind === kind || kind.startsWith(`${requestedKind}.`)
+  })
+}
 
 async function getDiagnosticsFromCodeActionParams(
   state: State,
@@ -52,40 +65,71 @@ export async function doCodeActions(
     return []
   }
 
-  let diagnostics = await getDiagnosticsFromCodeActionParams(
-    state,
-    params,
-    document,
-    params.context.diagnostics
-      .map((diagnostic) => diagnostic.code)
-      .filter(Boolean) as DiagnosticKind[],
-  )
+  let shouldProvideQuickFixes = matchesRequestedKind(params.context.only, QUICK_FIX_KIND)
+  let shouldProvideFixAll = matchesRequestedKind(params.context.only, SOURCE_FIX_ALL_TAILWIND_KIND)
 
-  return Promise.all(
-    diagnostics.map((diagnostic) => {
-      if (isInvalidApplyDiagnostic(diagnostic)) {
-        return provideInvalidApplyCodeActions(state, document, diagnostic)
-      }
+  let diagnostics = shouldProvideQuickFixes
+    ? await getDiagnosticsFromCodeActionParams(
+        state,
+        params,
+        document,
+        params.context.diagnostics
+          .map((diagnostic) => diagnostic.code)
+          .filter(Boolean) as DiagnosticKind[],
+      )
+    : []
 
-      if (isCssConflictDiagnostic(diagnostic)) {
-        return provideCssConflictCodeActions(state, params, diagnostic)
-      }
+  let quickFixCodeActions = shouldProvideQuickFixes
+    ? await Promise.all(
+        diagnostics.map((diagnostic) => {
+          if (isInvalidApplyDiagnostic(diagnostic)) {
+            return provideInvalidApplyCodeActions(state, document, diagnostic)
+          }
 
-      if (
-        isInvalidConfigPathDiagnostic(diagnostic) ||
-        isInvalidTailwindDirectiveDiagnostic(diagnostic) ||
-        isInvalidScreenDiagnostic(diagnostic) ||
-        isInvalidVariantDiagnostic(diagnostic) ||
-        isDeprecatedAtRuleDiagnostic(diagnostic) ||
-        isRecommendedVariantOrderDiagnostic(diagnostic) ||
-        isSuggestCanonicalClasses(diagnostic)
-      ) {
-        return provideSuggestionCodeActions(state, params, diagnostic)
-      }
+          if (
+            isInvalidConfigPathDiagnostic(diagnostic) ||
+            isInvalidTailwindDirectiveDiagnostic(diagnostic) ||
+            isInvalidScreenDiagnostic(diagnostic) ||
+            isInvalidVariantDiagnostic(diagnostic) ||
+            isDeprecatedAtRuleDiagnostic(diagnostic) ||
+            isRecommendedVariantOrderDiagnostic(diagnostic) ||
+            isSuggestCanonicalClasses(diagnostic)
+          ) {
+            return provideSuggestionCodeActions(state, params, diagnostic)
+          }
 
-      return []
-    }),
-  )
-    .then(flatten)
-    .then((x) => dedupeBy(x, (item) => JSON.stringify(item.edit)))
+          if (isCssConflictDiagnostic(diagnostic)) {
+            return provideCssConflictCodeActions(state, params, diagnostic)
+          }
+
+          return []
+        }),
+      ).then(flatten)
+    : []
+
+  let shouldComputeFixAll =
+    shouldProvideFixAll &&
+    (params.context.only?.length
+      ? true
+      : params.context.diagnostics.some(
+          (diagnostic) => diagnostic.code === DiagnosticKindEnum.SuggestCanonicalClasses,
+        ))
+
+  let fixAllCodeActions = shouldComputeFixAll
+    ? await provideFixAllSuggestionCodeActions(state, document)
+    : []
+
+  let seen = new Set<string>()
+
+  return [...quickFixCodeActions, ...fixAllCodeActions].filter((action) => {
+    let fingerprint = JSON.stringify({
+      kind: action.kind,
+      edit: action.edit,
+    })
+
+    if (seen.has(fingerprint)) return false
+
+    seen.add(fingerprint)
+    return true
+  })
 }

--- a/packages/tailwindcss-language-service/src/codeActions/provideFixAllSuggestionCodeActions.ts
+++ b/packages/tailwindcss-language-service/src/codeActions/provideFixAllSuggestionCodeActions.ts
@@ -1,0 +1,48 @@
+import type { CodeAction, TextEdit } from 'vscode-languageserver'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import { doValidate } from '../diagnostics/diagnosticsProvider'
+import { DiagnosticKind, isSuggestCanonicalClasses } from '../diagnostics/types'
+import type { State } from '../util/state'
+
+const SOURCE_FIX_ALL_TAILWIND_KIND = 'source.fixAll.tailwindcss'
+
+export async function provideFixAllSuggestionCodeActions(
+  state: State,
+  document: TextDocument,
+): Promise<CodeAction[]> {
+  let diagnostics = await doValidate(state, document, [DiagnosticKind.SuggestCanonicalClasses])
+  let canonicalDiagnostics = diagnostics.filter(isSuggestCanonicalClasses)
+
+  if (canonicalDiagnostics.length === 0) {
+    return []
+  }
+
+  let changes = canonicalDiagnostics.reduce<TextEdit[]>((all, diagnostic) => {
+    let suggestion = diagnostic.suggestions[0]
+    if (!suggestion) return all
+
+    all.push({
+      range: diagnostic.range,
+      newText: suggestion,
+    })
+
+    return all
+  }, [])
+
+  if (changes.length === 0) {
+    return []
+  }
+
+  return [
+    {
+      title: 'Fix all Tailwind CSS canonical class suggestions',
+      kind: SOURCE_FIX_ALL_TAILWIND_KIND,
+      diagnostics: canonicalDiagnostics,
+      edit: {
+        changes: {
+          [document.uri]: changes,
+        },
+      },
+    },
+  ]
+}

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -65,6 +65,10 @@
         "command": "tailwindCSS.sortSelection",
         "title": "Tailwind CSS: Sort Selection",
         "enablement": "editorHasSelection && (resourceScheme == file || resourceScheme == vscode-remote) && tailwindCSS.activeTextEditorSupportsClassSorting"
+      },
+      {
+        "command": "tailwindCSS.fixAllCanonicalClassesInWorkspace",
+        "title": "Tailwind CSS: Fix Canonical Class Suggestions in Workspace"
       }
     ],
     "grammars": [

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -1,4 +1,6 @@
 import * as path from 'path'
+import { spawn } from 'node:child_process'
+import braces from 'braces'
 import type {
   ExtensionContext,
   TextDocument,
@@ -14,6 +16,10 @@ import {
   SymbolInformation,
   Position,
   Range,
+  RelativePattern,
+  ProgressLocation,
+  WorkspaceEdit,
+  languages,
 } from 'vscode'
 import type {
   DocumentFilter,
@@ -33,7 +39,7 @@ import namedColors from 'color-name'
 import { CONFIG_GLOB, CSS_GLOB } from '@tailwindcss/language-server/src/lib/constants'
 import normalizePath from 'normalize-path'
 import * as servers from './servers/index'
-import { isExcluded, mergeExcludes } from './exclusions'
+import { getExcludePatterns, isExcluded, mergeExcludes } from './exclusions'
 import { createApi } from './api'
 
 const colorNames = Object.keys(namedColors)
@@ -103,6 +109,64 @@ async function activeTextEditorSupportsClassSorting(): Promise<boolean> {
   }
   // TODO: Use feature detection instead of version checking
   return semver.gte(project.version, '3.0.0')
+}
+
+function getWorkspaceFolderExcludeGlob(folder: WorkspaceFolder): string | undefined {
+  let exclusions = getExcludePatterns(folder).flatMap((pattern) => braces.expand(pattern))
+
+  if (exclusions.length === 0) {
+    return undefined
+  }
+
+  return `{${exclusions.join(',').replace(/{/g, '%7B').replace(/}/g, '%7D')}}`
+}
+
+function getCanonicalClassDiagnostics(uri: Uri) {
+  return languages
+    .getDiagnostics(uri)
+    .filter((diagnostic) => diagnostic.source === 'tailwindcss')
+    .filter((diagnostic) => diagnostic.code === 'suggestCanonicalClasses')
+}
+
+async function getGitIgnoredFiles(folder: WorkspaceFolder, files: Uri[]): Promise<Set<string>> {
+  if (files.length === 0) {
+    return new Set()
+  }
+
+  let relativePaths = files.map((file) => normalizePath(path.relative(folder.uri.fsPath, file.fsPath)))
+  let ignored = new Set<string>()
+
+  await new Promise<void>((resolve) => {
+    let child = spawn('git', ['check-ignore', '--stdin', '-z'], {
+      cwd: folder.uri.fsPath,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    })
+
+    let stdout = Buffer.alloc(0)
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout = Buffer.concat([stdout, chunk])
+    })
+
+    child.on('error', () => {
+      resolve()
+    })
+
+    child.on('close', (code) => {
+      if (code === 0 && stdout.length > 0) {
+        for (let item of stdout.toString('utf8').split('\0')) {
+          if (!item) continue
+          ignored.add(path.resolve(folder.uri.fsPath, item))
+        }
+      }
+
+      resolve()
+    })
+
+    child.stdin.end(relativePaths.join('\0') + '\0')
+  })
+
+  return ignored
 }
 
 async function updateActiveTextEditorContext(): Promise<void> {
@@ -201,6 +265,136 @@ export async function activate(context: ExtensionContext) {
         await sortSelection()
       } catch (error) {
         Window.showWarningMessage(`Couldn’t sort Tailwind classes: ${(error as any)?.message}`)
+      }
+    }),
+  )
+
+  async function fixAllCanonicalClassesInWorkspace(): Promise<void> {
+    let editor = Window.activeTextEditor
+
+    if (!editor) {
+      return
+    }
+
+    let folder = Workspace.getWorkspaceFolder(editor.document.uri)
+
+    if (!folder || isExcluded(editor.document.uri.fsPath, folder)) {
+      throw Error(`No active workspace folder found for file ${editor.document.uri.fsPath}`)
+    }
+
+    await bootWorkspaceClient()
+
+    if (!currentClient) {
+      throw Error('No active Tailwind project found for this workspace folder')
+    }
+
+    let client = await currentClient
+
+    if (!client.isRunning()) {
+      throw Error('Tailwind CSS language server is not running')
+    }
+
+    let exclude = getWorkspaceFolderExcludeGlob(folder)
+    let workspaceEdit = new WorkspaceEdit()
+    let supportedLanguages = new Set([...defaultLanguages, ...Object.keys(getUserLanguages(folder))])
+    let files = await Workspace.findFiles(new RelativePattern(folder, '**/*'), exclude)
+    let gitIgnoredFiles = await getGitIgnoredFiles(folder, files)
+    let processedFiles = 0
+    let changedFiles = 0
+    let totalSuggestions = 0
+
+    await Window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: 'Tailwind CSS: Fixing canonical class suggestions in workspace',
+        cancellable: true,
+      },
+      async (progress, token) => {
+        let searchableFiles = files.filter((uri) => !gitIgnoredFiles.has(uri.fsPath))
+
+        for (let [index, uri] of searchableFiles.entries()) {
+          if (token.isCancellationRequested) {
+            break
+          }
+
+          progress.report({
+            message: `${index + 1}/${searchableFiles.length}: ${Workspace.asRelativePath(uri, false)}`,
+            increment: searchableFiles.length > 0 ? 100 / searchableFiles.length : undefined,
+          })
+
+          let document: TextDocument
+
+          try {
+            document = await Workspace.openTextDocument(uri)
+          } catch {
+            continue
+          }
+
+          if (!supportedLanguages.has(document.languageId)) {
+            continue
+          }
+
+          processedFiles += 1
+
+          let codeActions = await client.sendRequest<any[]>('textDocument/codeAction', {
+            textDocument: {
+              uri: uri.toString(),
+            },
+            context: {
+              diagnostics: [],
+              only: ['source.fixAll'],
+            },
+          })
+
+          let fixAllAction = codeActions?.find(
+            (action) => action?.kind === 'source.fixAll.tailwindcss' && action?.edit?.changes?.[uri.toString()],
+          )
+
+          let edits = fixAllAction?.edit?.changes?.[uri.toString()]
+
+          if (!Array.isArray(edits) || edits.length === 0) {
+            continue
+          }
+
+          for (let edit of edits) {
+            workspaceEdit.replace(uri, edit.range, edit.newText)
+          }
+
+          totalSuggestions += edits.length
+          changedFiles += 1
+        }
+      },
+    )
+
+    if (totalSuggestions === 0) {
+      Window.showInformationMessage(
+        'No Tailwind canonical class suggestions found in this workspace folder.',
+      )
+      return
+    }
+
+    let success = await Workspace.applyEdit(workspaceEdit)
+
+    if (!success) {
+      Window.showWarningMessage(
+        'Failed to apply Tailwind canonical class suggestions in the workspace folder.',
+      )
+      return
+    }
+
+    Window.showInformationMessage(
+      `Applied ${totalSuggestions} canonical class suggestion${totalSuggestions === 1 ? '' : 's'} across ${changedFiles} file${changedFiles === 1 ? '' : 's'} in ${processedFiles} scanned file${processedFiles === 1 ? '' : 's'}.`,
+    )
+  }
+
+  context.subscriptions.push(
+    commands.registerCommand('tailwindCSS.fixAllCanonicalClassesInWorkspace', async () => {
+      try {
+        await fixAllCanonicalClassesInWorkspace()
+      } catch (error) {
+        Window.showWarningMessage(
+          `Couldn’t fix Tailwind canonical class suggestions in the workspace: ${(error as any)?.message}`,
+        )
       }
     }),
   )

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -137,6 +137,7 @@ async function getGitIgnoredFiles(folder: WorkspaceFolder, files: Uri[]): Promis
   let ignored = new Set<string>()
 
   await new Promise<void>((resolve) => {
+    let settled = false
     let child = spawn('git', ['check-ignore', '--stdin', '-z'], {
       cwd: folder.uri.fsPath,
       stdio: ['pipe', 'pipe', 'ignore'],
@@ -144,12 +145,24 @@ async function getGitIgnoredFiles(folder: WorkspaceFolder, files: Uri[]): Promis
 
     let stdout = Buffer.alloc(0)
 
+    function finish() {
+      if (settled) return
+      settled = true
+      resolve()
+    }
+
     child.stdout.on('data', (chunk: Buffer) => {
       stdout = Buffer.concat([stdout, chunk])
     })
 
+    child.stdin.on('error', () => {
+      // `git check-ignore` can exit before consuming stdin, especially outside
+      // a Git repo. Ignore write-side stream errors and let the process close
+      // handler finish the request without crashing the extension host.
+    })
+
     child.on('error', () => {
-      resolve()
+      finish()
     })
 
     child.on('close', (code) => {
@@ -160,7 +173,7 @@ async function getGitIgnoredFiles(folder: WorkspaceFolder, files: Uri[]): Promis
         }
       }
 
-      resolve()
+      finish()
     })
 
     child.stdin.end(relativePaths.join('\0') + '\0')


### PR DESCRIPTION
## Summary

Adds bulk-fix support for Tailwind canonical class suggestions in two places:

1. a standard LSP fix-all code action for the current file
2. a VS Code command to apply canonical class suggestions across the current workspace folder

## What changed

### File-level fix all
Before:
- users only saw one warning fix at a time, like `Replace with 'print:flex'`

After:
- users still get the single-instance quick fixes
- users also get a standard Tailwind fix-all code action for the current file:
  - `Fix all Tailwind CSS canonical class suggestions`

### Workspace-level fix all
Before:
- there was no built-in way to apply canonical class suggestions across multiple files in the workspace

After:
- there is a new command:
  - `Tailwind CSS: Fix Canonical Class Suggestions in Workspace`
- it scans the current workspace folder and applies canonical class suggestions across all matching files
- it skips Git-ignored files

## Implementation details

- added `source.fixAll.tailwindcss` support to the language server code actions
- kept the existing per-warning quick fixes intact
- advertised Tailwind fix-all support through server capabilities
- added a VS Code command that requests per-file Tailwind fix-all actions from the language server and merges them into one workspace edit
- filtered workspace scans to ignore Git-ignored files

## Examples

Before:
```html
<div class="[@media_print]:flex [color:red]/50 mt-[16px]"></div>
```
After:
```html
<div class="print:flex text-[red]/50 mt-4"></div>
```

In a single file:
- the new fix-all action applies all canonical replacements in that document

Across a workspace:
- the new command applies the same kind of fixes across all non-gitignored files in the current workspace folder

## Testing
- added language-server tests covering the new file-level fix-all action
- added capability coverage for advertised Tailwind fix-all support
- rebuilt @tailwindcss/language-service
- rebuilt @tailwindcss/language-server
- rebuilt vscode-tailwindcss

## Notes
- the file-level behavior follows the review feedback on the earlier PR by using a standard LSP fix-all action instead of a custom command
- workspace-wide fixing is implemented as a separate VS Code command because LSP textDocument/codeAction is document-scoped

Supersedes #1508