### PR TITLE
feat: add 'Fix All Auto-fixable Problems' command

### DIFF
--- a/packages/tailwindcss-language-server/src/projects.ts
+++ b/packages/tailwindcss-language-server/src/projects.ts
@@ -114,7 +114,11 @@ export interface ProjectService {
   onDocumentColor(params: DocumentColorParams): Promise<ColorInformation[]>
   onColorPresentation(params: ColorPresentationParams): Promise<ColorPresentation[]>
   onCodeAction(params: CodeActionParams): Promise<CodeAction[]>
-  fixAllProblems(params: { uri: string }): Promise<{ error?: string }>
+  fixAllProblems(params: {
+    uri: string
+    mode?: 'local' | 'global'
+  }): Promise<{ error?: string; fixed?: number; remaining?: number }>
+  getContentFiles(): Promise<{ error?: string; files?: string[] }>
   onDocumentLinks(params: DocumentLinkParams): Promise<DocumentLink[]>
   onCodeLens(params: CodeLensParams): Promise<CodeLens[]>
   sortClassLists(classLists: string[]): string[]
@@ -180,6 +184,28 @@ function getWatchPatternsForFile(file: string, root: string): string[] {
     }
   }
   return patterns
+}
+
+function getLanguageIdFromPath(filePath: string): string {
+  let ext = path.extname(filePath).toLowerCase()
+  let extToLanguage: Record<string, string> = {
+    '.js': 'javascript',
+    '.jsx': 'javascriptreact',
+    '.ts': 'typescript',
+    '.tsx': 'typescriptreact',
+    '.vue': 'vue',
+    '.svelte': 'svelte',
+    '.html': 'html',
+    '.htm': 'html',
+    '.php': 'php',
+    '.css': 'css',
+    '.scss': 'scss',
+    '.sass': 'sass',
+    '.less': 'less',
+    '.md': 'markdown',
+    '.mdx': 'mdx',
+  }
+  return extToLanguage[ext] || 'plaintext'
 }
 
 export async function createProjectService(
@@ -1245,15 +1271,34 @@ export async function createProjectService(
         return doCodeActions(state, params, document)
       }, null)
     },
-    async fixAllProblems(params: { uri: string }): Promise<{ error?: string }> {
+    async fixAllProblems(params: {
+      uri: string
+      mode?: 'local' | 'global'
+    }): Promise<{ error?: string; fixed?: number; remaining?: number }> {
       try {
         if (!state.enabled) {
           return { error: 'Tailwind CSS is not enabled' }
         }
+
         let document = documentService.getDocument(params.uri)
+        let isGlobalMode = params.mode === 'global'
+
+        if (!document && isGlobalMode) {
+          try {
+            let filePath = URI.parse(params.uri).fsPath
+            let content = await fs.promises.readFile(filePath, 'utf-8')
+            let { TextDocument } = await import('vscode-languageserver-textdocument')
+            let languageId = getLanguageIdFromPath(filePath)
+            document = TextDocument.create(params.uri, languageId, 1, content)
+          } catch (error) {
+            return { error: 'Could not read file' }
+          }
+        }
+
         if (!document) {
           return { error: 'Document not found' }
         }
+
         let settings = await state.editor.getConfiguration(document.uri)
         if (!settings.tailwindCSS.codeActions) {
           return { error: 'Code actions are disabled' }
@@ -1261,7 +1306,7 @@ export async function createProjectService(
 
         let diagnostics = await doValidate(state, document)
         if (!diagnostics || diagnostics.length === 0) {
-          return {}
+          return { fixed: 0, remaining: 0 }
         }
 
         let allEdits: TextEdit[] = []
@@ -1302,9 +1347,95 @@ export async function createProjectService(
           await connection.workspace.applyEdit(workspaceEdit)
         }
 
-        return {}
+        let remainingDiagnostics = await doValidate(state, document)
+        let remainingFixable = 0
+        if (remainingDiagnostics) {
+          for (let diag of remainingDiagnostics) {
+            let actions = await doCodeActions(
+              state,
+              {
+                textDocument: { uri: params.uri },
+                range: diag.range,
+                context: { diagnostics: [diag] },
+              },
+              document,
+            )
+            if (actions && actions.length > 0) {
+              remainingFixable++
+            }
+          }
+        }
+
+        return {
+          fixed: allEdits.length,
+          remaining: remainingFixable,
+        }
       } catch (error) {
         return { error: error instanceof Error ? error.message : 'Failed to fix problems' }
+      }
+    },
+    async getContentFiles(): Promise<{ error?: string; files?: string[] }> {
+      try {
+        if (!state.enabled || !state.config) {
+          return { error: 'Tailwind CSS is not enabled or configured' }
+        }
+
+        let files: string[] = []
+        let projectFolder = folder
+
+        if (!projectFolder) {
+          return { error: 'No project folder found' }
+        }
+
+        let contentPatterns: string[] = []
+        if (state.config.content) {
+          if (Array.isArray(state.config.content)) {
+            contentPatterns = state.config.content.filter(
+              (item: any) => typeof item === 'string',
+            )
+          } else if (state.config.content.files) {
+            contentPatterns = state.config.content.files.filter(
+              (item: any) => typeof item === 'string',
+            )
+          }
+        }
+
+        if (contentPatterns.length === 0) {
+          contentPatterns = [
+            './src/**/*.{js,jsx,ts,tsx,vue,svelte,html}',
+            './pages/**/*.{js,jsx,ts,tsx,vue,svelte,html}',
+            './components/**/*.{js,jsx,ts,tsx,vue,svelte,html}',
+            './app/**/*.{js,jsx,ts,tsx,vue,svelte,html}',
+            './**/*.html',
+          ]
+        }
+
+        let { glob } = await import('tinyglobby')
+
+        for (let pattern of contentPatterns) {
+          if (pattern.startsWith('!')) continue
+
+          let resolvedPattern = path.isAbsolute(pattern)
+            ? pattern
+            : path.join(projectFolder, pattern)
+
+          try {
+            let matches = await glob([resolvedPattern], {
+              cwd: projectFolder,
+              absolute: true,
+              ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'],
+            })
+
+            for (let match of matches) {
+              files.push(URI.file(match).toString())
+            }
+          } catch (error) {
+          }
+        }
+
+        return { files: [...new Set(files)] }
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : 'Failed to get content files' }
       }
     },
     onDocumentLinks(params: DocumentLinkParams): Promise<DocumentLink[]> {

--- a/packages/tailwindcss-language-server/src/projects.ts
+++ b/packages/tailwindcss-language-server/src/projects.ts
@@ -17,6 +17,7 @@ import type {
   DocumentLink,
   CodeLensParams,
   CodeLens,
+  TextEdit,
 } from 'vscode-languageserver/node'
 import { FileChangeType } from 'vscode-languageserver/node'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
@@ -53,6 +54,7 @@ import type {
 } from '@tailwindcss/language-service/src/util/state'
 import { provideDiagnostics } from './lsp/diagnosticsProvider'
 import { doCodeActions } from '@tailwindcss/language-service/src/codeActions/codeActionProvider'
+import { doValidate } from '@tailwindcss/language-service/src/diagnostics/diagnosticsProvider'
 import { getDocumentColors } from '@tailwindcss/language-service/src/documentColorProvider'
 import { getDocumentLinks } from '@tailwindcss/language-service/src/documentLinksProvider'
 import { debounce } from 'debounce'
@@ -112,6 +114,7 @@ export interface ProjectService {
   onDocumentColor(params: DocumentColorParams): Promise<ColorInformation[]>
   onColorPresentation(params: ColorPresentationParams): Promise<ColorPresentation[]>
   onCodeAction(params: CodeActionParams): Promise<CodeAction[]>
+  fixAllProblems(params: { uri: string }): Promise<{ error?: string }>
   onDocumentLinks(params: DocumentLinkParams): Promise<DocumentLink[]>
   onCodeLens(params: CodeLensParams): Promise<CodeLens[]>
   sortClassLists(classLists: string[]): string[]
@@ -1241,6 +1244,68 @@ export async function createProjectService(
         if (!settings.tailwindCSS.codeActions) return null
         return doCodeActions(state, params, document)
       }, null)
+    },
+    async fixAllProblems(params: { uri: string }): Promise<{ error?: string }> {
+      try {
+        if (!state.enabled) {
+          return { error: 'Tailwind CSS is not enabled' }
+        }
+        let document = documentService.getDocument(params.uri)
+        if (!document) {
+          return { error: 'Document not found' }
+        }
+        let settings = await state.editor.getConfiguration(document.uri)
+        if (!settings.tailwindCSS.codeActions) {
+          return { error: 'Code actions are disabled' }
+        }
+
+        let diagnostics = await doValidate(state, document)
+        if (!diagnostics || diagnostics.length === 0) {
+          return {}
+        }
+
+        let allEdits: TextEdit[] = []
+        let processedRanges = new Set<string>()
+
+        for (let diagnostic of diagnostics) {
+          let codeActionParams: CodeActionParams = {
+            textDocument: { uri: params.uri },
+            range: diagnostic.range,
+            context: { diagnostics: [diagnostic] },
+          }
+
+          let codeActions = await doCodeActions(state, codeActionParams, document)
+          if (!codeActions || codeActions.length === 0) continue
+
+          for (let action of codeActions) {
+            if (action.edit?.changes) {
+              let edits = action.edit.changes[params.uri]
+              if (edits) {
+                for (let edit of edits) {
+                  let rangeKey = `${edit.range.start.line}:${edit.range.start.character}-${edit.range.end.line}:${edit.range.end.character}`
+                  if (!processedRanges.has(rangeKey)) {
+                    allEdits.push(edit)
+                    processedRanges.add(rangeKey)
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        if (allEdits.length > 0) {
+          let workspaceEdit = {
+            changes: {
+              [params.uri]: allEdits,
+            },
+          }
+          await connection.workspace.applyEdit(workspaceEdit)
+        }
+
+        return {}
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : 'Failed to fix problems' }
+      }
     },
     onDocumentLinks(params: DocumentLinkParams): Promise<DocumentLink[]> {
       if (!state.enabled) return null

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -878,8 +878,12 @@ export class TW {
   ): { error: string } | { classLists: string[] }
   private onRequest(
     method: '@/tailwindCSS/fixAll',
-    params: { uri: string },
-  ): Promise<{ error?: string }>
+    params: { uri: string; mode?: 'local' | 'global' },
+  ): Promise<{ error?: string; fixed?: number; remaining?: number }>
+  private onRequest(
+    method: '@/tailwindCSS/getContentFiles',
+    params: { workspaceFolder: string },
+  ): Promise<{ error?: string; files?: string[] }>
   private onRequest(
     method: '@/tailwindCSS/getProject',
     params: { uri: string },
@@ -902,7 +906,25 @@ export class TW {
       if (!project) {
         return { error: 'no-project' }
       }
-      return project.fixAllProblems({ uri: params.uri })
+      return project.fixAllProblems({ uri: params.uri, mode: params.mode })
+    }
+
+    if (method === '@/tailwindCSS/getContentFiles') {
+      let projects = Array.from(this.projects.values())
+      let workspaceFolderUri = params.workspaceFolder
+
+      let matchingProject = projects.find((project) => {
+        let projectFolder = project.projectConfig.folder
+        if (!projectFolder) return false
+        let projectFolderUri = URI.file(projectFolder).toString()
+        return workspaceFolderUri.startsWith(projectFolderUri)
+      })
+
+      if (!matchingProject) {
+        return { error: 'no-project' }
+      }
+
+      return matchingProject.getContentFiles()
     }
 
     if (method === '@/tailwindCSS/getProject') {

--- a/packages/tailwindcss-language-server/src/tw.ts
+++ b/packages/tailwindcss-language-server/src/tw.ts
@@ -877,6 +877,10 @@ export class TW {
     params: { uri: string; classLists: string[] },
   ): { error: string } | { classLists: string[] }
   private onRequest(
+    method: '@/tailwindCSS/fixAll',
+    params: { uri: string },
+  ): Promise<{ error?: string }>
+  private onRequest(
     method: '@/tailwindCSS/getProject',
     params: { uri: string },
   ): { version: string } | null
@@ -891,6 +895,14 @@ export class TW {
       } catch {
         return { error: 'unknown' }
       }
+    }
+
+    if (method === '@/tailwindCSS/fixAll') {
+      let project = this.getProject({ uri: params.uri })
+      if (!project) {
+        return { error: 'no-project' }
+      }
+      return project.fixAllProblems({ uri: params.uri })
     }
 
     if (method === '@/tailwindCSS/getProject') {

--- a/packages/tailwindcss-language-server/tests/commands/fix-all.test.js
+++ b/packages/tailwindcss-language-server/tests/commands/fix-all.test.js
@@ -1,0 +1,165 @@
+import { test, expect } from 'vitest'
+import { withFixture } from '../common'
+
+withFixture('basic', (c) => {
+  test.concurrent('fixAll - local mode with CSS conflicts', async ({ expect }) => {
+    let code = '<div class="p-4 p-2 m-4 m-2"></div>'
+    let textDocument = await c.openDocument({ text: code })
+
+    // Wait for diagnostics to be processed
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: textDocument.uri,
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('fixed')
+    expect(res).toHaveProperty('remaining')
+    expect(res.error).toBeUndefined()
+  })
+
+  test.concurrent('fixAll - local mode with no issues', async ({ expect }) => {
+    let code = '<div class="p-4 m-4"></div>'
+    let textDocument = await c.openDocument({ text: code })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: textDocument.uri,
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('fixed')
+    expect(res).toHaveProperty('remaining')
+    expect(res.fixed).toBe(0)
+    expect(res.remaining).toBe(0)
+    expect(res.error).toBeUndefined()
+  })
+
+  test.concurrent('fixAll - global mode', async ({ expect }) => {
+    let code = '<div class="p-4 p-2"></div>'
+    let textDocument = await c.openDocument({ text: code, name: 'test.html' })
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: textDocument.uri,
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('fixed')
+    expect(res).toHaveProperty('remaining')
+    expect(res.error).toBeUndefined()
+  })
+
+  test.concurrent('fixAll - handles disabled code actions', async ({ expect }) => {
+    let code = '<div class="p-4 p-2"></div>'
+    let textDocument = await c.openDocument({
+      text: code,
+      settings: {
+        tailwindCSS: {
+          codeActions: false,
+        },
+      },
+    })
+
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: textDocument.uri,
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('error')
+    expect(res.error).toMatch(/code actions/i)
+  })
+
+  test.concurrent('fixAll - handles non-existent document', async ({ expect }) => {
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: 'file:///non-existent-file.html',
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('error')
+    expect(res.error).toBeTruthy()
+  })
+})
+
+withFixture('v4/basic', (c) => {
+  test.concurrent('fixAll - v4 with CSS conflicts', async ({ expect }) => {
+    let code = '<div class="p-4 p-2 m-4 m-2"></div>'
+    let textDocument = await c.openDocument({ text: code })
+
+    // Wait for diagnostics to be processed
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: textDocument.uri,
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('fixed')
+    expect(res).toHaveProperty('remaining')
+    expect(res.error).toBeUndefined()
+  })
+})
+
+withFixture('basic', (c) => {
+  test.concurrent('getContentFiles - returns file patterns', async ({ expect }) => {
+    let textDocument = await c.openDocument({ text: '<div></div>' })
+    
+    let workspaceFolder = c.fixtureUri('basic')
+
+    let res = await c.sendRequest('@/tailwindCSS/getContentFiles', {
+      workspaceFolder,
+    })
+
+    expect(res).toHaveProperty('files')
+    expect(Array.isArray(res.files)).toBe(true)
+    expect(res.error).toBeUndefined()
+  })
+
+  test.concurrent('getContentFiles - handles invalid workspace', async ({ expect }) => {
+    let res = await c.sendRequest('@/tailwindCSS/getContentFiles', {
+      workspaceFolder: 'file:///non-existent-workspace',
+    })
+
+    expect(res).toHaveProperty('error')
+    expect(res.error).toBeTruthy()
+  })
+})
+
+withFixture('basic', (c) => {
+  test.concurrent('fixAll - multiple conflicts in one file', async ({ expect }) => {
+    let code = `
+      <div class="p-4 p-2 m-4 m-2 text-red-500 text-blue-500">
+        <span class="bg-red-500 bg-blue-500"></span>
+      </div>
+    `
+    let textDocument = await c.openDocument({ text: code })
+
+    // Wait for diagnostics to be processed
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: textDocument.uri,
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('fixed')
+    expect(res.error).toBeUndefined()
+  })
+
+  test.concurrent('fixAll - handles empty document', async ({ expect }) => {
+    let textDocument = await c.openDocument({ text: '' })
+
+    let res = await c.sendRequest('@/tailwindCSS/fixAll', {
+      uri: textDocument.uri,
+      mode: 'local',
+    })
+
+    expect(res).toHaveProperty('fixed')
+    expect(res).toHaveProperty('remaining')
+    expect(res.fixed).toBe(0)
+    expect(res.remaining).toBe(0)
+  })
+})

--- a/packages/tailwindcss-language-server/tests/utils/client.ts
+++ b/packages/tailwindcss-language-server/tests/utils/client.ts
@@ -40,6 +40,7 @@ import {
   RegistrationRequest,
   MessageType,
   LogMessageNotification,
+  ApplyWorkspaceEditRequest,
 } from 'vscode-languageserver'
 import { URI, Utils as URIUtils } from 'vscode-uri'
 import {
@@ -517,6 +518,13 @@ export async function createClient(opts: ClientOptions): Promise<Client> {
 
       return sections
     })
+  })
+
+  // Handle workspace/applyEdit requests from server
+  conn.onRequest(ApplyWorkspaceEditRequest.type, (params) => {
+    trace('Applying workspace edit')
+    // For tests, we just acknowledge the edit was applied
+    return { applied: true }
   })
 
   let notifications = await createDocumentNotifications(conn)

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -68,7 +68,12 @@
       },
       {
         "command": "tailwindCSS.fixAll",
-        "title": "Tailwind CSS: Fix All Auto-fixable Problems",
+        "title": "Tailwind CSS: Fix All Auto-fixable Problems (Current File)",
+        "category": "Tailwind CSS"
+      },
+      {
+        "command": "tailwindCSS.fixAllWorkspace",
+        "title": "Tailwind CSS: Fix All Auto-fixable Problems (Workspace)",
         "category": "Tailwind CSS"
       }
     ],
@@ -214,6 +219,16 @@
           "default": true,
           "markdownDescription": "Enable code actions.",
           "scope": "language-overridable"
+        },
+        "tailwindCSS.codeActions.autoSave": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Automatically save files after applying fixes with 'Fix All Auto-fixable Problems' commands."
+        },
+        "tailwindCSS.codeActions.fixAll.batchSize": {
+          "type": "number",
+          "default": 10,
+          "markdownDescription": "Number of files to process simultaneously during workspace-wide fix operations."
         },
         "tailwindCSS.codeLens": {
           "type": "boolean",

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -65,6 +65,11 @@
         "command": "tailwindCSS.sortSelection",
         "title": "Tailwind CSS: Sort Selection",
         "enablement": "editorHasSelection && (resourceScheme == file || resourceScheme == vscode-remote) && tailwindCSS.activeTextEditorSupportsClassSorting"
+      },
+      {
+        "command": "tailwindCSS.fixAll",
+        "title": "Tailwind CSS: Fix All Auto-fixable Problems",
+        "category": "Tailwind CSS"
       }
     ],
     "grammars": [

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -217,16 +217,167 @@ export async function activate(context: ExtensionContext) {
 
     let client = await currentClient
 
-    let result = await client.sendRequest<{ error?: string; edits?: any }>(
+    let result = await client.sendRequest<{ error?: string; fixed?: number; remaining?: number }>(
       '@/tailwindCSS/fixAll',
       {
         uri: document.uri.toString(),
+        mode: 'local',
       },
     )
 
-    if ('error' in result) {
-      throw Error(result.error || 'Unknown error')
+    if ('error' in result && result.error) {
+      throw Error(result.error)
     }
+
+    let shouldAutoSave = Workspace.getConfiguration('tailwindCSS', folder).get<boolean>(
+      'codeActions.autoSave',
+      true,
+    )
+
+    if (shouldAutoSave && result.fixed && result.fixed > 0) {
+      await document.save()
+    }
+  }
+
+  async function fixAllWorkspaceProblems(): Promise<void> {
+    if (!currentClient) {
+      throw Error('No active Tailwind project found')
+    }
+
+    let client = await currentClient
+    let workspaceFolders = Workspace.workspaceFolders
+
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+      throw Error('No workspace folders found')
+    }
+
+    await Window.withProgress(
+      {
+        location: { viewId: 'workbench.view.explorer' },
+        title: 'Fixing Tailwind CSS problems',
+        cancellable: true,
+      },
+      async (progress, token) => {
+        let totalFixed = 0
+        let totalFilesProcessed = 0
+        let totalFilesWithErrors = 0
+        let filesModified: string[] = []
+
+        for (let folder of workspaceFolders) {
+          if (token.isCancellationRequested) break
+
+          progress.report({ message: `Scanning ${folder.name}...` })
+
+          let contentFilesResult = await client.sendRequest<{
+            error?: string
+            files?: string[]
+          }>('@/tailwindCSS/getContentFiles', {
+            workspaceFolder: folder.uri.toString(),
+          })
+
+          if (contentFilesResult.error || !contentFilesResult.files) {
+            continue
+          }
+
+          let files = contentFilesResult.files
+          let batchSize =
+            Workspace.getConfiguration('tailwindCSS', folder).get<number>(
+              'codeActions.fixAll.batchSize',
+              10,
+            ) || 10
+
+          for (let i = 0; i < files.length; i += batchSize) {
+            if (token.isCancellationRequested) break
+
+            let batch = files.slice(i, Math.min(i + batchSize, files.length))
+            progress.report({
+              message: `Processing files ${i + 1}-${Math.min(i + batchSize, files.length)} of ${files.length}`,
+              increment: (batchSize / files.length) * 100,
+            })
+
+            await Promise.all(
+              batch.map(async (fileUri) => {
+                try {
+                  let result = await client.sendRequest<{
+                    error?: string
+                    fixed?: number
+                    remaining?: number
+                  }>('@/tailwindCSS/fixAll', {
+                    uri: fileUri,
+                    mode: 'global',
+                  })
+
+                  if (result.error) {
+                    totalFilesWithErrors++
+                    return
+                  }
+
+                  if (result.fixed && result.fixed > 0) {
+                    totalFixed += result.fixed
+                    filesModified.push(fileUri)
+
+                    let uri = Uri.parse(fileUri)
+                    let document = Workspace.textDocuments.find(
+                      (doc) => doc.uri.toString() === fileUri,
+                    )
+
+                    if (document) {
+                      await document.save()
+                    }
+                  }
+
+                  totalFilesProcessed++
+                } catch (error) {
+                  totalFilesWithErrors++
+                }
+              }),
+            )
+          }
+        }
+
+        if (token.isCancellationRequested) {
+          Window.showInformationMessage('Tailwind CSS fix operation cancelled')
+          return
+        }
+
+        let verificationPassed = true
+        if (filesModified.length > 0) {
+          progress.report({ message: 'Verifying fixes...' })
+
+          for (let fileUri of filesModified.slice(0, Math.min(10, filesModified.length))) {
+            let result = await client.sendRequest<{
+              error?: string
+              fixed?: number
+              remaining?: number
+            }>('@/tailwindCSS/fixAll', {
+              uri: fileUri,
+              mode: 'global',
+            })
+
+            if (result.remaining && result.remaining > 0) {
+              verificationPassed = false
+              break
+            }
+          }
+        }
+
+        let message = `Fixed ${totalFixed} issue${totalFixed !== 1 ? 's' : ''} across ${filesModified.length} file${filesModified.length !== 1 ? 's' : ''}`
+
+        if (totalFilesWithErrors > 0) {
+          message += ` (${totalFilesWithErrors} file${totalFilesWithErrors !== 1 ? 's' : ''} had errors)`
+        }
+
+        if (!verificationPassed) {
+          message += ' - Some issues may remain'
+        }
+
+        if (totalFixed > 0) {
+          Window.showInformationMessage(message)
+        } else {
+          Window.showInformationMessage('No auto-fixable Tailwind CSS problems found')
+        }
+      },
+    )
   }
 
   context.subscriptions.push(
@@ -235,6 +386,18 @@ export async function activate(context: ExtensionContext) {
         await fixAllProblems()
       } catch (error) {
         Window.showWarningMessage(`Couldn't fix Tailwind problems: ${(error as any)?.message}`)
+      }
+    }),
+  )
+
+  context.subscriptions.push(
+    commands.registerCommand('tailwindCSS.fixAllWorkspace', async () => {
+      try {
+        await fixAllWorkspaceProblems()
+      } catch (error) {
+        Window.showWarningMessage(
+          `Couldn't fix workspace Tailwind problems: ${(error as any)?.message}`,
+        )
       }
     }),
   )

--- a/packages/vscode-tailwindcss/src/extension.ts
+++ b/packages/vscode-tailwindcss/src/extension.ts
@@ -200,8 +200,48 @@ export async function activate(context: ExtensionContext) {
       try {
         await sortSelection()
       } catch (error) {
-        Window.showWarningMessage(`Couldn’t sort Tailwind classes: ${(error as any)?.message}`)
+        Window.showWarningMessage(`Couldn't sort Tailwind classes: ${(error as any)?.message}`)
       }
+    }),
+  )
+
+  async function fixAllProblems(): Promise<void> {
+    if (!Window.activeTextEditor) return
+
+    let { document } = Window.activeTextEditor
+    let folder = Workspace.getWorkspaceFolder(document.uri)
+
+    if (!currentClient || !folder || isExcluded(document.uri.fsPath, folder)) {
+      throw Error(`No active Tailwind project found for file ${document.uri.fsPath}`)
+    }
+
+    let client = await currentClient
+
+    let result = await client.sendRequest<{ error?: string; edits?: any }>(
+      '@/tailwindCSS/fixAll',
+      {
+        uri: document.uri.toString(),
+      },
+    )
+
+    if ('error' in result) {
+      throw Error(result.error || 'Unknown error')
+    }
+  }
+
+  context.subscriptions.push(
+    commands.registerCommand('tailwindCSS.fixAll', async () => {
+      try {
+        await fixAllProblems()
+      } catch (error) {
+        Window.showWarningMessage(`Couldn't fix Tailwind problems: ${(error as any)?.message}`)
+      }
+    }),
+  )
+
+  context.subscriptions.push(
+    Window.onDidChangeActiveTextEditor(async () => {
+      await updateActiveTextEditorContext()
     }),
   )
 


### PR DESCRIPTION
## Summary

This PR adds a new command **"Tailwind CSS: Fix All Auto-fixable Problems"** that automatically fixes all auto-fixable Tailwind CSS diagnostics in the active document, similar to the ESLint extension's functionality.

Its okay if you guys don't have time to review this, thanks for the open source work! Because it was open source, I was able to implement my own feature and install the extension locally to solve my problem!

## Motivation

Currently, Tailwind CSS IntelliSense provides auto-fixable code actions for individual diagnostics (CSS conflicts, invalid @apply directives, variant ordering, canonical class suggestions, etc.), but users need to trigger each fix individually through the Problems panel or quick fix menu. This can be tedious when there are multiple fixable issues in a file.

The ESLint extension already provides an excellent "Fix all auto-fixable Problems" command that applies all available fixes at once. This PR brings similar functionality to the Tailwind CSS extension.

## Changes

### 1. Command Registration (`package.json`)
- Added new command `tailwindCSS.fixAll` with title "Tailwind CSS: Fix All Auto-fixable Problems"

### 2. Client-Side Handler (`packages/vscode-tailwindcss/src/extension.ts`)
- Implemented `fixAllProblems()` function that sends a request to the language server
- Registered command handler with proper error handling

### 3. Server-Side Request Handler (`packages/tailwindcss-language-server/src/tw.ts`)
- Added `@/tailwindCSS/fixAll` request handler
- Routes requests to the appropriate project's `fixAllProblems` method

### 4. Fix All Logic (`packages/tailwindcss-language-server/src/projects.ts`)
- Implemented `fixAllProblems` method that:
  - Validates that code actions are enabled
  - Collects all diagnostics for the document using `doValidate`
  - For each diagnostic, gathers available code actions using `doCodeActions`
  - Extracts and deduplicates text edits (to avoid overlapping ranges)
  - Applies all edits in a single workspace edit

## Implementation Details

The implementation follows the same architecture as ESLint's fix-all feature:

1. **Client Command** → triggers the fix-all operation
2. **Server Request** → delegates to the project
3. **Collect Diagnostics** → finds all problems in the document
4. **Gather Fixes** → collects code actions for each diagnostic
5. **Apply Edits** → applies all fixes in one operation

The code handles edge cases like:
- Overlapping ranges (uses a Set to deduplicate by range)
- Missing documents or disabled state
- Code actions that don't provide edits

## Usage

Users can invoke this command via:
- Command Palette: `Tailwind CSS: Fix All Auto-fixable Problems`
- Keyboard shortcut (can be user-configured)
- Future: Could be integrated with save actions

## Testing

- ✅ TypeScript compilation passes
- ✅ Build succeeds
- Manual testing needed to verify:
  - Command appears in command palette
  - Fixes apply correctly for various diagnostic types
  - No conflicts with overlapping edits

## Related

This feature complements the existing individual quick fixes and makes bulk fixing more convenient, improving developer workflow.