### PR TITLE
Setup OIDC publishing

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -13,7 +13,7 @@ jobs:
           version: ^9.6.0
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - name: Install dependencies

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -43,5 +43,3 @@ jobs:
         run: >
           cd packages/tailwindcss-language-server &&
           pnpm publish --tag insiders --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,7 +16,7 @@ jobs:
           version: ^9.6.0
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - name: Install dependencies

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,11 +10,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v3
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
         with:
           version: ^9.6.0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,6 +3,9 @@ concurrency: publish
 on:
   push:
     branches: [main]
+permissions:
+  contents: read
+  id-token: write
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates some of the GitHub Workflows such that we can publish to npm using OIDC.
