### PR TITLE
Fix class function hover lookup in Vue script blocks

### DIFF
--- a/packages/tailwindcss-language-service/src/util/find.test.ts
+++ b/packages/tailwindcss-language-service/src/util/find.test.ts
@@ -844,6 +844,52 @@ test('Can find class name inside JS/TS functions in <script> tags (HTML)', async
   })
 })
 
+test('Can find class name inside JS/TS functions in Vue <script> tags after <template>', async ({ expect }) => {
+  let file = createDocument({
+    name: 'file.vue',
+    lang: 'vue',
+    settings: {
+      tailwindCSS: {
+        classFunctions: ['clsx'],
+      },
+    },
+    content: html`
+      <template>
+        <div></div>
+      </template>
+
+      <script lang="ts">
+        let classes = clsx('flex relative')
+      </script>
+    `,
+  })
+
+  let className = await findClassNameAtPosition(file.state, file.doc, {
+    line: 5,
+    character: 22,
+  })
+
+  expect(className).toEqual({
+    className: 'flex',
+    range: {
+      start: { line: 5, character: 22 },
+      end: { line: 5, character: 26 },
+    },
+    relativeRange: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 4 },
+    },
+    classList: {
+      classList: 'flex relative',
+      important: undefined,
+      range: {
+        start: { character: 22, line: 5 },
+        end: { character: 35, line: 5 },
+      },
+    },
+  })
+})
+
 test('Can find class name inside JS/TS functions in <script> tags (Svelte)', async ({ expect }) => {
   let file = createDocument({
     name: 'file.svelte',

--- a/packages/tailwindcss-language-service/src/util/find.ts
+++ b/packages/tailwindcss-language-service/src/util/find.ts
@@ -205,6 +205,7 @@ export async function findClassListsInHtmlRange(
   const matches = matchClassAttributes(text, settings.classAttributes)
 
   let boundaries = getLanguageBoundaries(state, doc)
+  let rangeStartOffset = range ? doc.offsetAt(range.start) : 0
 
   for (let boundary of boundaries ?? []) {
     let isJsContext = boundary.type === 'js' || boundary.type === 'jsx'
@@ -212,14 +213,14 @@ export async function findClassListsInHtmlRange(
     if (!settings.classFunctions?.length) continue
 
     let str = doc.getText(boundary.range)
-    let offset = doc.offsetAt(boundary.range.start)
+    let offset = doc.offsetAt(boundary.range.start) - rangeStartOffset
     let fnMatches = matchClassFunctions(str, settings.classFunctions)
 
     fnMatches.forEach((match) => {
       if (match.index) match.index += offset
     })
 
-    matches.push(...fnMatches)
+    matches.push(...fnMatches.filter((match) => match.index >= 0 && match.index < text.length))
   }
 
   const existingResultSet = new Set<string>()


### PR DESCRIPTION
With this hover now works after the template:

<img width="402" height="285" alt="image" src="https://github.com/user-attachments/assets/466b0e42-5ad3-4dcc-ba77-afef4041c11e" />

Matches were using absolute document offsets, but the parser expects range-relative offsets, so hover lookup could miss classes. This should hopefully also fix #1417.

I also added a small regression test.