### PR TITLE
chore(ci): declare contents: read on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block to `.github/workflows/ci.yml`.

The CI workflow only reads the repository contents; it does not push, comment, or release. Declaring the minimum scope means a compromised third-party action cannot abuse the run's token to escalate. This is the pattern GitHub recommends in their [token hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) and is what OpenSSF Scorecard's `Token-Permissions` check looks for.

A recent reminder of why this matters: tj-actions/changed-files compromise in March 2025 (CVE-2025-30066).

Verified with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`.
