### PR TITLE
Harden Oxide helper lifecycle + regression tests for #1553

### DIFF
--- a/packages/tailwindcss-language-server/src/oxide-session.test.ts
+++ b/packages/tailwindcss-language-server/src/oxide-session.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import * as proc from 'node:child_process'
+import * as path from 'node:path'
+import * as fs from 'node:fs/promises'
+import * as rpc from 'vscode-jsonrpc/node'
+import { OxideSession } from './oxide-session'
+
+const helperPath = path.resolve(__dirname, '../bin/oxide-helper.js')
+
+function countOxideHelpers(): number {
+  try {
+    let out = proc.execSync(`ps -axo pid=,command=`, { encoding: 'utf8' })
+    return out
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.includes('oxide-helper.js'))
+      .filter((line) => !line.includes(' rg') && !line.includes('vitest'))
+      .length
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Pre-#1520 OxideSession shape: async path lookup before assigning connection.
+ * Parallel startIfNeeded() callers each fork a helper (#1519 / #1553).
+ */
+class BuggyOxideSession {
+  helper: proc.ChildProcess | null = null
+  connection: rpc.MessageConnection | null = null
+
+  async startIfNeeded(): Promise<void> {
+    if (this.connection) return
+
+    // Yield before fork — same race window as the old fs.access() loop
+    await fs.access(helperPath)
+
+    let helper = proc.fork(helperPath)
+    let connection = rpc.createMessageConnection(
+      new rpc.IPCMessageReader(helper),
+      new rpc.IPCMessageWriter(helper),
+    )
+
+    helper.on('close', () => {
+      connection.dispose()
+      this.connection = null
+      this.helper = null
+    })
+
+    connection.listen()
+
+    this.helper = helper
+    this.connection = connection
+  }
+
+  async stop() {
+    if (!this.helper) return
+    this.helper.kill()
+    this.helper = null
+    this.connection = null
+  }
+}
+
+describe('OxideSession', () => {
+  let sessions: OxideSession[] = []
+  let buggySessions: BuggyOxideSession[] = []
+
+  afterEach(async () => {
+    for (let session of sessions) {
+      await session.stop()
+    }
+    for (let session of buggySessions) {
+      await session.stop()
+    }
+    sessions = []
+    buggySessions = []
+    // Best-effort cleanup of any orphans left by the buggy session demo
+    try {
+      proc.execSync(`pkill -f "${helperPath}"`, { stdio: 'ignore' })
+    } catch {
+      // no matching processes
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  })
+
+  test('documents the pre-#1520 race: parallel startIfNeeded forks many helpers', async () => {
+    let before = countOxideHelpers()
+    let session = new BuggyOxideSession()
+    buggySessions.push(session)
+
+    await Promise.all(Array.from({ length: 20 }, () => session.startIfNeeded()))
+    await new Promise((r) => setTimeout(r, 100))
+
+    let spawned = countOxideHelpers() - before
+    // Only the last helper is tracked — stop() cannot reap the rest.
+    expect(spawned).toBeGreaterThan(5)
+
+    await session.stop()
+    await new Promise((r) => setTimeout(r, 100))
+
+    // Orphans remain after stop() — this is the #1553 accumulation mode
+    expect(countOxideHelpers() - before).toBeGreaterThan(0)
+  })
+
+  test('parallel startIfNeeded() forks only one oxide-helper process', async () => {
+    let before = countOxideHelpers()
+
+    let session = new OxideSession()
+    sessions.push(session)
+
+    // Simulate ProjectLocator.search() loading many CSS roots via Promise.all.
+    let handles = await Promise.all(Array.from({ length: 25 }, () => session.startIfNeeded()))
+
+    expect(new Set(handles).size).toBe(1)
+    expect(handles[0].helper.pid).toBeTypeOf('number')
+
+    let during = countOxideHelpers()
+    expect(during - before).toBe(1)
+
+    await session.stop()
+    await new Promise((r) => setTimeout(r, 150))
+
+    expect(countOxideHelpers()).toBeLessThanOrEqual(before)
+  })
+
+  test('stop() terminates the helper even if start is still in flight', async () => {
+    let before = countOxideHelpers()
+    let session = new OxideSession()
+    sessions.push(session)
+
+    let starting = session.startIfNeeded()
+    await session.stop()
+    await starting.catch(() => {})
+    await new Promise((r) => setTimeout(r, 150))
+
+    expect(countOxideHelpers()).toBeLessThanOrEqual(before)
+  })
+
+  test('a new session can start after stop()', async () => {
+    let session = new OxideSession()
+    sessions.push(session)
+
+    let first = await session.startIfNeeded()
+    let firstPid = first.helper.pid
+
+    await session.stop()
+    await new Promise((r) => setTimeout(r, 100))
+
+    let second = await session.startIfNeeded()
+    expect(second.helper.pid).not.toBe(firstPid)
+    expect(second.helper.pid).toBeTypeOf('number')
+  })
+})

--- a/packages/tailwindcss-language-server/src/oxide-session.ts
+++ b/packages/tailwindcss-language-server/src/oxide-session.ts
@@ -53,50 +53,97 @@ export class OxideSession {
   }
 
   startIfNeeded(): Promise<ServerHandle> {
+    // Assign the promise synchronously so parallel callers (e.g. Promise.all
+    // over many CSS roots in ProjectLocator.search) share one helper process.
+    // See: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1519
+    // See: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1553
     this.server ??= this.start()
 
     return this.server
   }
 
-  private async start(): Promise<ServerHandle> {
+  private start(): Promise<ServerHandle> {
     // 1. Start the new process
     let helper = proc.fork(helperPath)
 
-    // 2. If the process fails to spawn we want to throw
-    //
-    // We do end up caching the failed promise but that should be
-    // fine. It seems unlikely that, if this fails, trying again
-    // would "fix" whatever problem there was and succeed.
-    await new Promise((resolve, reject) => {
-      helper.on('spawn', resolve)
-      helper.on('error', reject)
+    let serverPromise = (async (): Promise<ServerHandle> => {
+      try {
+        // 2. If the process fails to spawn we want to throw
+        await new Promise<void>((resolve, reject) => {
+          helper.once('spawn', () => resolve())
+          helper.once('error', reject)
+        })
+
+        // 3. Setup a channel to talk to the server
+        let connection = rpc.createMessageConnection(
+          new rpc.IPCMessageReader(helper),
+          new rpc.IPCMessageWriter(helper),
+        )
+
+        // 4. If the process exits we can tear down everything
+        helper.once('close', () => {
+          connection.dispose()
+          if (this.server === serverPromise) {
+            this.server = null
+          }
+        })
+
+        // 5. Start listening for messages
+        connection.listen()
+
+        return { helper, connection }
+      } catch (err) {
+        // Fork succeeded but setup failed — don't leave an orphan helper around.
+        helper.kill()
+        throw err
+      }
+    })()
+
+    // Clear a failed startup so a later call can retry (rebuilds, etc.)
+    serverPromise.catch(() => {
+      if (this.server === serverPromise) {
+        this.server = null
+      }
     })
 
-    // 3. Setup a channel to talk to the server
-    let connection = rpc.createMessageConnection(
-      new rpc.IPCMessageReader(helper),
-      new rpc.IPCMessageWriter(helper),
-    )
-
-    // 4. If the process exits we can tear down everything
-    helper.on('close', () => {
-      connection.dispose()
-      this.server = null
-    })
-
-    // 5. Start listening for messages
-    connection.listen()
-
-    return { helper, connection }
+    return serverPromise
   }
 
   async stop() {
-    if (!this.server) return
+    let serverPromise = this.server
+    if (!serverPromise) return
 
-    let server = await this.server
+    // Drop the cached handle immediately so concurrent startIfNeeded() calls
+    // open a fresh session instead of talking to a process we're killing.
+    // Without this, file-change restarts can accumulate live oxide-helpers
+    // (#1553) when an old helper's `close` is delayed.
+    this.server = null
 
-    // We terminate the server because, if for some reason it gets stuck,
-    // we don't want it to stick around.
-    server.helper.kill()
+    let server: ServerHandle
+    try {
+      server = await serverPromise
+    } catch {
+      return
+    }
+
+    await new Promise<void>((resolve) => {
+      let settled = false
+      let done = () => {
+        if (settled) return
+        settled = true
+        resolve()
+      }
+
+      server.helper.once('close', done)
+      server.helper.kill()
+
+      // Fallback: some platforms leave the child in an uninterruptible wait.
+      setTimeout(() => {
+        if (!server.helper.killed) {
+          server.helper.kill('SIGKILL')
+        }
+        done()
+      }, 1000)
+    })
   }
 }

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Mark `@variant` as deprecated when defining custom variants ([#1578](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1578))
 - Show pixel equivalents for `@container` ([#1585](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1585))
 - Fix class hover in Vue `<script></script>` tags when they exist after `<template></template>` tags ([#1580](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1580))
+- Harden Oxide helper lifecycle and add regression tests for helper process leaks ([#1553](https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1553))
 
 ## 0.14.29
 


### PR DESCRIPTION
## Summary
- Hardens `OxideSession` so `oxide-helper.js` processes cannot accumulate across parallel project loads / restarts ([#1553](https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1553), related to [#1519](https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1519) / [#1520](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1520)).
- Clears the cached server promise immediately in `stop()`, awaits child exit (with `SIGKILL` fallback), and kills the helper if startup fails mid-setup.
- Adds regression tests that:
  - document the pre-#1520 race (parallel `startIfNeeded` forks many helpers; `stop()` cannot reap orphans)
  - assert the fixed session forks exactly **one** helper under `Promise.all` × 25
  - cover stop-during-start and restart-after-stop

`v0.14.29` (latest release) still ships the racy `startIfNeeded` that awaits before assigning `connection`, which matches reports of hundreds/thousands of live helpers during normal editing.

## Test plan
- [x] `pnpm exec vitest run src/oxide-session.test.ts` in `packages/tailwindcss-language-server` (requires `pnpm run build` so `bin/oxide-helper.js` exists)
- [ ] Open a workspace with many v4 CSS roots (`@import "tailwindcss"`) and confirm helper count stays near 1
- [ ] Trigger config/CSS restarts and confirm helpers do not climb over time (`ps -axo pid,rss,command | rg oxide-helper`)


Made with [Cursor](https://cursor.com)