### PR TITLE
Fix incorrect `cssConflict` since Tailwind CSS v4.3.3

### DIFF
--- a/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
+++ b/packages/tailwindcss-language-server/tests/diagnostics/diagnostics.test.js
@@ -598,3 +598,56 @@ defineTest({
     expect((await doc.diagnostics())[0]).not.toHaveProperty('tags')
   },
 })
+
+// https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1600
+defineTest({
+  name: 'conflicts consider variants in flattened selectors (v4.3.3+)',
+  fs: {
+    'package.json': json`
+      {
+        "dependencies": {
+          "tailwindcss": "4.3.3"
+        }
+      }
+    `,
+    'app.css': css`
+      @import 'tailwindcss';
+    `,
+  },
+  prepare: async ({ root }) => ({ client: await createClient({ root }) }),
+  handle: async ({ client }) => {
+    let doc = await client.open({
+      lang: 'html',
+      text: [
+        '<div class="bg-white backdrop:bg-black/25">',
+        '<div class="sm:bg-white sm:bg-black">',
+        '<div class="bg-white sm:bg-black">',
+      ].join('\n'),
+    })
+
+    let diagnostics = await doc.diagnostics()
+
+    // `bg-white` and `backdrop:bg-black/25` target different elements so they
+    // do not conflict. Neither do `bg-white` and `sm:bg-black`. However,
+    // `sm:bg-white` and `sm:bg-black` do conflict with each other.
+    expect(diagnostics).toMatchObject([
+      {
+        code: 'cssConflict',
+        message: "'sm:bg-white' applies the same CSS properties as 'sm:bg-black'.",
+        range: {
+          start: { line: 1, character: 12 },
+          end: { line: 1, character: 23 },
+        },
+      },
+      {
+        code: 'cssConflict',
+        message: "'sm:bg-black' applies the same CSS properties as 'sm:bg-white'.",
+        range: {
+          start: { line: 1, character: 24 },
+          end: { line: 1, character: 35 },
+        },
+      },
+    ])
+    expect(diagnostics).toHaveLength(2)
+  },
+})

--- a/packages/tailwindcss-language-server/tests/fixtures/v1/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v1/package-lock.json
@@ -197,7 +197,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",

--- a/packages/tailwindcss-language-server/tests/fixtures/v2-jit/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v2-jit/package-lock.json
@@ -393,7 +393,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -573,7 +574,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.502",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.502.tgz",
-      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw=="
+      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw==",
+      "peer": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -587,6 +589,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -648,6 +651,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.1.tgz",
       "integrity": "sha512-/KxoyCnPM0GwYI4NN0Iag38Tqt+od3/mLuguepLgCAKPn0ZhC544nssAW0tG2/00zXEYl9W+7hwAIpLHo6Oc7Q==",
+      "peer": true,
       "engines": {
         "node": "*"
       },
@@ -990,7 +994,8 @@
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "peer": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -1004,6 +1009,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1107,7 +1113,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -1493,6 +1498,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/packages/tailwindcss-language-server/tests/fixtures/v2/package-lock.json
+++ b/packages/tailwindcss-language-server/tests/fixtures/v2/package-lock.json
@@ -393,7 +393,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -573,7 +574,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.502",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.502.tgz",
-      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw=="
+      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw==",
+      "peer": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -587,6 +589,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -648,6 +651,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.1.tgz",
       "integrity": "sha512-/KxoyCnPM0GwYI4NN0Iag38Tqt+od3/mLuguepLgCAKPn0ZhC544nssAW0tG2/00zXEYl9W+7hwAIpLHo6Oc7Q==",
+      "peer": true,
       "engines": {
         "node": "*"
       },
@@ -990,7 +994,8 @@
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "peer": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -1004,6 +1009,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1107,7 +1113,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -1493,6 +1498,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/packages/tailwindcss-language-service/src/diagnostics/getCssConflictDiagnostics.ts
+++ b/packages/tailwindcss-language-service/src/diagnostics/getCssConflictDiagnostics.ts
@@ -10,6 +10,7 @@ import * as postcss from 'postcss'
 import type { AtRule, Node, Rule } from 'postcss'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import { walk, WalkAction } from '../util/walk'
+import escapeClassName from 'css.escape'
 
 function isCustomProperty(property: string): boolean {
   return property.startsWith('--')
@@ -260,8 +261,13 @@ function recordClassDetails(state: State, classes: DocumentClassName[]): ClassDe
 
       if (properties.length === 0) return WalkAction.Continue
 
-      // We have to slice off the first `context` item because it's the class name and that's always different
-      let path = [...ctx.path(), node].slice(1)
+      let path = [...ctx.path(), node]
+
+      // The selector containing the class name itself is not relevant for
+      // conflict detection, so we replace it with `&`. Depending on the
+      // Tailwind CSS version the class can appear in a top-level selector (e.g.
+      // `.backdrop\:bg-black\/25::backdrop`) or in a nested one.
+      let classSelector = `.${escapeClassName(className)}`
 
       groups[className] ??= []
       groups[className].push({
@@ -269,14 +275,14 @@ function recordClassDetails(state: State, classes: DocumentClassName[]): ClassDe
         context: path
           .map((node) => {
             if (node.kind === 'rule') {
-              return node.selector
+              return node.selector.replaceAll(classSelector, '&')
             } else if (node.kind === 'at-rule') {
               return `${node.name} ${node.params}`
             }
 
             return ''
           })
-          .filter(Boolean),
+          .filter((selector) => selector !== '' && selector !== '&'),
       })
 
       return WalkAction.Continue

--- a/packages/vscode-tailwindcss/CHANGELOG.md
+++ b/packages/vscode-tailwindcss/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Mark `@variant` as deprecated when defining custom variants ([#1578](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1578))
 - Show pixel equivalents for `@container` ([#1585](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1585))
 - Fix class hover in Vue `<script></script>` tags when they exist after `<template></template>` tags ([#1580](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1580))
+- Fix incorrect `cssConflict` warnings when using Tailwind CSS v4.3.3+ ([#1601](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1601))
 
 ## 0.14.29
 


### PR DESCRIPTION
This PR fixes an issue where the release of Tailwind CSS v4.3.3 resulted in an invalid `cssConflict` warning:
<img width="1776" height="368" alt="image" src="https://github.com/user-attachments/assets/393ba0e7-d299-43f9-9ef3-49f83e8c0c9a" />

In Tailwind CSS v4, we heavily use CSS nesting, so a `bg-white` and `backdrop:bg-black` look like this:
```css
.bg-white {
  background-color: var(--color-white, #fff);
}
.backdrop\:bg-black {
  &::backdrop {
    background-color: var(--color-black, #000);
  }
}
```

However, since Tailwind CSS v4.3.3 we started handling the nesting (instead of only relying on Lightning CSS). This means that the CSS now looks like this:
```css
.bg-white {
  background-color: var(--color-white, #fff);
}
.backdrop\:bg-black::backdrop {
  background-color: var(--color-black, #000);
}
```

If we convert these to ASTs, there is only a single `node` with a `selector`. We assumed that the very first node we see is the className and then compare the body. Up until Tailwind CSS v4.3.3 that was correct because it contains a `&::backdrop` node, but now not anymore.

This PR fixes that by not assuming that there is a top-level node with _only_ the className, but instead we replace the className with `&` and keep that node. Now we are properly comparing `&` and `&::backdrop`.

Fixes: #1600

## Test plan

1. Added a regression test to make sure that doesn't happen anymore
2. All other tests still pass
3. Tested manually


**A real conflict still occurs when needed:**
<img width="903" height="198" alt="image" src="https://github.com/user-attachments/assets/c01854bc-2728-4fba-a5df-5fb756278cc4" />

**The false-positive warning is gone:**
<img width="495" height="122" alt="image" src="https://github.com/user-attachments/assets/06e249d5-1d70-4fdd-9746-ea21c011c109" />

